### PR TITLE
RFC: monorepo jellyfish development

### DIFF
--- a/packages/jellyfish-core/src/api.ts
+++ b/packages/jellyfish-core/src/api.ts
@@ -1,0 +1,17 @@
+/**
+ * Payload to send to DeFiChain node
+ */
+/* eslint @typescript-eslint/no-explicit-any: off */
+export type Payload = any
+
+export type Call<T> = (method: string, payload: Payload) => Promise<T>
+export type Client = {call: Call<any>}
+
+export class JellyfishError extends Error {
+  readonly status?: number
+
+  constructor(message: string, status?: number) {
+    super(message)
+    this.status = status
+  }
+}

--- a/packages/jellyfish-core/src/core.ts
+++ b/packages/jellyfish-core/src/core.ts
@@ -1,0 +1,20 @@
+import * as methods from './methods'
+import {Client, Payload, JellyfishError} from './api'
+export {methods, Client, Payload, JellyfishError}
+
+/**
+ * Protocol agnostic DeFiChain node client, APIs separated into their category.
+ */
+export abstract class JellyfishClient implements Client {
+  readonly blockchain = new methods.Blockchain(this)
+  readonly mining = new methods.Mining(this)
+  readonly network = new methods.Network(this)
+  readonly wallet = new methods.Wallet(this)
+
+  // TODO(fuxingloh): all rpc categories to be implemented after RFC
+
+  /**
+   * Abstracted isomorphic promise based procedure call handling
+   */
+  abstract call<T>(method: string, payload: Payload): Promise<T>
+}

--- a/packages/jellyfish-core/src/methods/blockchain.ts
+++ b/packages/jellyfish-core/src/methods/blockchain.ts
@@ -1,0 +1,13 @@
+import {Client} from '../api'
+
+export class Blockchain {
+  private readonly client: Client
+
+  constructor(client: Client) {
+    this.client = client
+  }
+
+  async getBestBlockHash(): Promise<any> {
+    return await this.client.call('getbestblockhash', [])
+  }
+}

--- a/packages/jellyfish-core/src/methods/index.ts
+++ b/packages/jellyfish-core/src/methods/index.ts
@@ -1,0 +1,6 @@
+import {Blockchain} from './blockchain'
+import {Mining} from './mining'
+import {Network} from './network'
+import {Wallet} from './wallet'
+
+export {Blockchain, Mining, Network, Wallet}

--- a/packages/jellyfish-core/src/methods/mining.ts
+++ b/packages/jellyfish-core/src/methods/mining.ts
@@ -1,0 +1,23 @@
+import {Client} from '../api'
+
+export interface MintingInfo {
+  blocks: number
+  difficulty: number
+  isoperator: boolean
+  networkhashps: number
+  pooledtx: number
+  chain: 'main' | 'test' | 'regtest'
+  warnings: string
+}
+
+export class Mining {
+  private readonly client: Client
+
+  constructor(client: Client) {
+    this.client = client
+  }
+
+  async getMintingInfo(): Promise<MintingInfo> {
+    return this.client.call('getmintinginfo', [])
+  }
+}

--- a/packages/jellyfish-core/src/methods/network.ts
+++ b/packages/jellyfish-core/src/methods/network.ts
@@ -1,0 +1,18 @@
+import {Client} from '../api'
+
+export class Network {
+  private readonly client: Client
+
+  constructor(client: Client) {
+    this.client = client
+  }
+
+  /**
+   * Requests that a ping be sent to all other nodes, to measure ping time.
+   * Results provided in getpeerinfo, pingtime and pingwait fields are decimal seconds.
+   * Ping command is handled in queue with all other commands, so it measures processing backlog, not just network ping.
+   */
+  async ping(): Promise<any> {
+    return this.client.call('ping', [])
+  }
+}

--- a/packages/jellyfish-core/src/methods/wallet.ts
+++ b/packages/jellyfish-core/src/methods/wallet.ts
@@ -1,0 +1,18 @@
+import {Client} from '../api'
+
+interface AddressInfo {
+  address: string
+  hex?: string
+}
+
+export class Wallet {
+  private readonly client: Client
+
+  constructor(client: Client) {
+    this.client = client
+  }
+
+  async getAddressInfo(address: string): Promise<AddressInfo> {
+    return this.client.call('getaddressinfo', [address])
+  }
+}

--- a/packages/jellyfish-jsonrpc/__tests__/json.test.ts
+++ b/packages/jellyfish-jsonrpc/__tests__/json.test.ts
@@ -1,0 +1,10 @@
+import {JellyfishJsonRpc} from '../src/jsonrpc'
+
+describe('JSON-RPC 1.0', () => {
+  it('should have different ids', () => {
+    // TODO(fuxingloh): AOP; intercept instead of direct testing
+    const first = JellyfishJsonRpc.stringify('diffid', [])
+    const second = JellyfishJsonRpc.stringify('diffid', [])
+    expect(first).not.toBe(second)
+  })
+})

--- a/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
+++ b/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
@@ -1,0 +1,48 @@
+import {JellyfishJsonRpc} from '../src/jsonrpc'
+import {RegTestDocker} from '@defichain/testcontainers'
+
+describe('error handling', () => {
+  const node = new RegTestDocker()
+
+  beforeAll(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterAll(async () => {
+    await node.stop()
+  })
+
+  it('should 401 unauthorized', async () => {
+    const port = await node.getRpcPort()
+    const rpc = new JellyfishJsonRpc(`http://foo:foo@127.0.0.1:${port}`)
+    const call = rpc.call('getmintinginfo', [])
+    return expect(call).rejects.toThrow(/Unauthorized/)
+  })
+})
+
+describe('as expected', () => {
+  const node = new RegTestDocker()
+
+  beforeAll(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterAll(async () => {
+    await node.stop()
+  })
+
+  it('should getmintinginfo', async () => {
+    const rpc = new JellyfishJsonRpc(await node.getRpcUrl())
+    const result: any = await rpc.call('getmintinginfo', [])
+    expect(result.blocks).toBe(0)
+    expect(result.chain).toBe('regtest')
+  })
+})

--- a/packages/jellyfish-jsonrpc/src/jsonrpc.ts
+++ b/packages/jellyfish-jsonrpc/src/jsonrpc.ts
@@ -1,0 +1,50 @@
+import {JellyfishClient, JellyfishError, Payload} from '@defichain/jellyfish-core'
+import fetch from 'cross-fetch'
+import JSONBig from 'json-bigint'
+
+/**
+ * A JSON-RPC client implementation for connecting to a DeFiChain node.
+ */
+export class JellyfishJsonRpc extends JellyfishClient {
+  private readonly url: string
+
+  /**
+   * Construct a Jellyfish client to connect to a DeFiChain node via JSON-RPC.
+   *
+   * @param url
+   */
+  constructor(url: string) {
+    super()
+    this.url = url
+  }
+
+  async call<T>(method: string, payload: Payload): Promise<T> {
+    const body = JellyfishJsonRpc.stringify(method, payload)
+    const response = await fetch(this.url, {
+      method: 'POST',
+      body: body,
+    })
+
+    return await JellyfishJsonRpc.parse<T>(response)
+  }
+
+  static async parse<T>(response: Response): Promise<T> {
+    if (response.status !== 200) {
+      throw new JellyfishError(response.statusText, response.status)
+    }
+
+    // TODO(fuxingloh): validation?
+    const text = await response.text()
+    const data = JSONBig.parse(text)
+    return data.result
+  }
+
+  static stringify(method: string, payload: Payload): string {
+    return JSONBig.stringify({
+      jsonrpc: '1.0',
+      id: Math.floor(Math.random() * 10000000000000000),
+      method: method,
+      params: payload,
+    })
+  }
+}

--- a/packages/jellyfish/__tests__/jsonrpc/blockchain.test.ts
+++ b/packages/jellyfish/__tests__/jsonrpc/blockchain.test.ts
@@ -1,0 +1,24 @@
+import Jellyfish from '../../src/jellyfish'
+import {RegTestDocker} from "@defichain/testcontainers";
+
+describe('Blockchain', () => {
+  const node = new RegTestDocker()
+
+  beforeAll(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterAll(async () => {
+    await node.stop()
+  })
+
+  it('getBestBlockHash', async () => {
+    const client = Jellyfish.jsonrpc(await node.getRpcUrl())
+    const result = await client.blockchain.getBestBlockHash()
+    console.log(result)
+  })
+})

--- a/packages/jellyfish/__tests__/jsonrpc/mining.test.ts
+++ b/packages/jellyfish/__tests__/jsonrpc/mining.test.ts
@@ -1,0 +1,24 @@
+import Jellyfish from '../../src/jellyfish'
+import {RegTestDocker} from "@defichain/testcontainers";
+
+describe('Mining', () => {
+  const node = new RegTestDocker()
+
+  beforeAll(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterAll(async () => {
+    await node.stop()
+  })
+
+  it('getMintingInfo', async () => {
+    const client = Jellyfish.jsonrpc(await node.getRpcUrl())
+    const result = await client.mining.getMintingInfo()
+    expect(result.chain).toBe('regtest')
+  })
+})

--- a/packages/jellyfish/src/jellyfish.ts
+++ b/packages/jellyfish/src/jellyfish.ts
@@ -1,0 +1,14 @@
+import {JellyfishJsonRpc} from '@defichain/jellyfish-jsonrpc'
+
+export const Jellyfish = {
+  /**
+   * Initialize a DeFiChain client and use jsonrpc for interfacing
+   *
+   * @param url
+   */
+  jsonrpc(url: string): JellyfishJsonRpc {
+    return new JellyfishJsonRpc(url)
+  },
+}
+
+export default Jellyfish

--- a/packages/testcontainers/__tests__/index.test.ts
+++ b/packages/testcontainers/__tests__/index.test.ts
@@ -1,0 +1,64 @@
+import {MainNetDocker, RegTestDocker, TestNetDocker} from '../src'
+
+describe('reg test', () => {
+  const node = new RegTestDocker()
+
+  beforeEach(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterEach(async () => {
+    await node.stop()
+  })
+
+  it('should getmintinginfo and chain should be regtest', async () => {
+    const result = await node.call('getmintinginfo', [])
+    expect(result.result.chain).toBe('regtest')
+  })
+})
+
+describe('test net', () => {
+  const node = new TestNetDocker()
+
+  beforeEach(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterEach(async () => {
+    await node.stop()
+  })
+
+  it('should getmintinginfo and chain should be regtest', async () => {
+    const result = await node.call('getmintinginfo', [])
+    expect(result.result.chain).toBe('test')
+  })
+})
+
+describe('main net', () => {
+  const node = new MainNetDocker()
+
+  beforeEach(async () => {
+    await node.start({
+      user: 'foo',
+      password: 'bar',
+    })
+    await node.ready()
+  })
+
+  afterEach(async () => {
+    await node.stop()
+  })
+
+  it('should getmintinginfo and chain should be regtest', async () => {
+    const result = await node.call('getmintinginfo', [])
+    expect(result.result.chain).toBe('main')
+  })
+})

--- a/packages/testcontainers/src/docker.ts
+++ b/packages/testcontainers/src/docker.ts
@@ -1,0 +1,192 @@
+import Dockerode, {DockerOptions, Container} from 'dockerode'
+import fetch from 'node-fetch'
+import JSONBig from 'json-bigint'
+
+export type Network = 'mainnet' | 'testnet' | 'regtest'
+
+export interface StartOptions {
+  // TODO(fuxingloh): change to cookie based auth soon
+  user: string
+  password: string
+}
+
+/**
+ * DeFiChain defid node managed in docker
+ */
+export abstract class DeFiChainDocker {
+  protected static readonly PREFIX = 'defichain-testcontainers-'
+  protected readonly docker: Dockerode
+  protected readonly image = 'defi/defichain:1.5.0'
+  protected readonly network: Network
+
+  protected container?: Container
+  protected startOptions?: StartOptions
+
+  protected constructor(network: Network, options?: DockerOptions) {
+    this.docker = new Dockerode(options)
+    this.network = network
+  }
+
+  /**
+   * Generate a name for a new docker container with network type and random number
+   */
+  protected generateName(): string {
+    const rand = Math.floor(Math.random() * 10000000)
+    return `${DeFiChainDocker.PREFIX}-${this.network}-${rand}`
+  }
+
+  protected getCmd(opts: StartOptions): string[] {
+    return [
+      'defid',
+      '-printtoconsole',
+      '-rpcallowip=172.17.0.0/16',
+      '-rpcbind=0.0.0.0',
+      `-rpcuser=${opts.user}`,
+      `-rpcpassword=${opts.password}`,
+    ]
+  }
+
+  /**
+   * Start defid node on docker
+   *
+   * @param startOptions
+   */
+  async start(startOptions: StartOptions): Promise<void> {
+    this.startOptions = startOptions
+    this.container = await this.docker.createContainer({
+      name: this.generateName(),
+      Image: this.image,
+      Tty: true,
+      Cmd: this.getCmd(startOptions),
+      HostConfig: {
+        PublishAllPorts: true,
+      },
+    })
+    await this.container.start()
+  }
+
+  /**
+   * Get host machine port
+   *
+   * @param name of ExposedPorts e.g. '80/tcp'
+   */
+  async getPort(name: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+      this.container!.inspect(function (err, data) {
+        if (err) {
+          reject(err)
+        } else {
+          resolve(data!.NetworkSettings.Ports[name][0].HostPort)
+        }
+      })
+    })
+  }
+
+  /**
+   * Get host machine port used for defid rpc
+   */
+  public abstract getRpcPort(): Promise<string>
+
+  /**
+   * Get host machine url used for defid rpc calls with auth
+   */
+  async getRpcUrl() {
+    const port = await this.getRpcPort()
+    const user = this.startOptions?.user
+    const password = this.startOptions?.password
+    return `http://${user}:${password}@127.0.0.1:${port}/`
+  }
+
+  /**
+   * Utility rpc function for the current node.
+   * This is not error checked, it will just return the raw result.
+   *
+   * @param method
+   * @param params
+   */
+  async call(method: string, params: any): Promise<any> {
+    const url = await this.getRpcUrl()
+    const response = await fetch(url, {
+      method: 'POST',
+      body: JSONBig.stringify({
+        jsonrpc: '1.0',
+        id: Math.floor(Math.random() * 10000000000000000),
+        method: method,
+        params: params,
+      }),
+    })
+    const text = await response.text()
+    return JSONBig.parse(text)
+  }
+
+  /**
+   * @param timeout millis, default to 15000 ms
+   * @param interval millis, default to 200ms
+   */
+  async ready(timeout = 15000, interval = 200): Promise<void> {
+    const expiredAt = Date.now() + timeout
+
+    return new Promise((resolve, reject) => {
+      const checkReady = async () => {
+        try {
+          const result = await this.call('getmintinginfo', [])
+          if (result?.result) {
+            return resolve()
+          }
+        } catch (err) {}
+
+        if (expiredAt < Date.now()) {
+          return reject(new Error(`DeFiChain docker not ready within given timeout of ${timeout}ms`))
+        }
+
+        setTimeout(() => {
+          checkReady()
+        }, interval)
+      }
+
+      checkReady()
+    })
+  }
+
+  /**
+   * Stop the current node and also automatically stop nodes that are stale.
+   * Stale nodes are nodes that are running for 2 hours
+   */
+  async stop(): Promise<void> {
+    await this.container?.stop()
+    await this.container?.remove()
+
+    return new Promise((resolve, reject) => {
+      this.docker.listContainers({all: 1}, (error, result) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        if (!result) {
+          return
+        }
+
+        const promises = result
+          .filter((containerInfo) => {
+            // filter docker container with the same prefix
+            return containerInfo.Names.filter((value) => value.startsWith(DeFiChainDocker.PREFIX))
+          })
+          .filter((containerInfo) => {
+            // filter docker container that are created 2 hours ago
+            return containerInfo.Created + 60 * 60 * 2 < Date.now() / 1000
+          })
+          .map(
+            async (containerInfo): Promise<void> => {
+              const container = this.docker.getContainer(containerInfo.Id)
+              if (containerInfo.State === 'running') {
+                await container.stop()
+              }
+              await container.remove()
+            }
+          )
+
+        Promise.all(promises).finally(resolve)
+      })
+    })
+  }
+}

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -1,0 +1,4 @@
+export {StartOptions, DeFiChainDocker} from './docker'
+export {RegTestDocker} from './reg_test'
+export {TestNetDocker} from './test_net'
+export {MainNetDocker} from './main_net'

--- a/packages/testcontainers/src/main_net.ts
+++ b/packages/testcontainers/src/main_net.ts
@@ -1,0 +1,12 @@
+import {DockerOptions} from 'dockerode'
+import {DeFiChainDocker} from './docker'
+
+export class MainNetDocker extends DeFiChainDocker {
+  constructor(options?: DockerOptions) {
+    super('mainnet', options)
+  }
+
+  async getRpcPort(): Promise<string> {
+    return this.getPort('8554/tcp')
+  }
+}

--- a/packages/testcontainers/src/reg_test.ts
+++ b/packages/testcontainers/src/reg_test.ts
@@ -1,0 +1,18 @@
+import {DockerOptions} from 'dockerode'
+import {DeFiChainDocker, StartOptions} from './docker'
+
+export class RegTestDocker extends DeFiChainDocker {
+  constructor(options?: DockerOptions) {
+    super('regtest', options)
+  }
+
+  protected getCmd(opts: StartOptions): string[] {
+    return [...super.getCmd(opts), '-regtest=1']
+  }
+
+  // TODO(fuxingloh): add ability to mint token for reg test
+
+  async getRpcPort(): Promise<string> {
+    return this.getPort('19554/tcp')
+  }
+}

--- a/packages/testcontainers/src/test_net.ts
+++ b/packages/testcontainers/src/test_net.ts
@@ -1,0 +1,16 @@
+import {DockerOptions} from 'dockerode'
+import {DeFiChainDocker, StartOptions} from './docker'
+
+export class TestNetDocker extends DeFiChainDocker {
+  constructor(options?: DockerOptions) {
+    super('testnet', options)
+  }
+
+  protected getCmd(opts: StartOptions): string[] {
+    return [...super.getCmd(opts), '-testnet=1']
+  }
+
+  async getRpcPort(): Promise<string> {
+    return this.getPort('18554/tcp')
+  }
+}


### PR DESCRIPTION
> A collection of JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin.

This is an early [1st milestone](https://github.com/DeFiCh/jellyfish/milestone/1) RFC to tackle **DeFiChain JS Library Protocol Implementation/Interfacing** technical design. There will be 4 milestones in total (protocols, wallet, remote & documentation) and this being the biggest unit of work due to the mono repo and utility and toolchain setup.

The purpose of this RFC is to provide a feedback loop before new features or significant change/implementation get introduced to the DeFiChain ecosystem. Extra attention is required for this as this repo is meant to be used by the masses. **As this is an RFC, NOT A CODE REVIEW, some codes are missing and this is not to be merged.** 

For the reviewer, the question is '**does this make sense for the JS ecosystem**' & '**is this easy to use**'?

# Jellyfish Monorepo

> All to be npm published. As jellyfish is all JavaScript related, this mono repo represent a collection of JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin. We can expect more to be added in the future.

- @defichain/jellyfish
- @defichain/jellyfish-core
- @defichain/jellyfish-jsonrpc
- @defichain/jellyfish-wallet (next milestone, by Q1 🤞)
- @defichain/testcontainers

## `@defichain/testcontainers`

Similar to testcontainers in the Java ecosystem, this library provide a lightweight, throwaway instances of `regtest`, `testnet` or `mainnet` provisioned automatically in Docker container. `@defichain/testcontainers` encapsulate on top of `defi/defichain:latest` and directly interface with the Docker REST API. see #20 

With `@defichain/testcontainers`, it allows the JS ecosystem to:

1. E2E application integration test without hassle
2. Parallel unit test runner as port number and container are dynamically generated on demand
3. Supercharge CI/CD workflow, run locally, run anyway, run on CI
4. Supercharge `jellyfish-core` development with integration test guarantees
5. Easy for any developer to test dApp on the DeFiChain JS ecosystem

### Usage Example

```ts
import {MainNetDocker, RegTestDocker, TestNetDocker} from '@defichain/testcontainers'

describe('reg test', () => {
  const node = new RegTestDocker()

  beforeEach(async () => {
    await node.start({
      user: 'foo',
      password: 'bar',
    })
    await node.ready()
  })

  afterEach(async () => {
    await node.stop()
  })

  it('should getmintinginfo and chain should be regtest', async () => {
    const client = Jellyfish.jsonrpc(await node.getRpcUrl())
    const result = await client.call('getmintinginfo', [])
    expect(result.result.chain).toBe('regtest')
  })
})

```

## `@defichain/jellyfish-core`

`@defichain/jellyfish-core` the protocol agnostic DeFiChain client implementation with APIs separated into their category.

### Implementation Details

- Strongly typed `*.d.ts` file will be exported for developer QOL
- Categorically separated concerns, for rapid develop of new features when we upgrade the nodes.
- Protocol agonistic implementation, we can easily swap out and add new REST/WS/MQ providers. see #19 
- Promise based implementation, see #16 

### `client.'category'.'method'()` example
> Client APIs are implemented categorically as follows:

|category|method|JS|CCP|
|---|---|---|---|
|mining|getmintinginfo|`client.mining.getMintingInfo()`|`rpc/mining.cpp#getmintinginfo`|
|rawtransaction|sendrawtransaction|`client.transaction.sendRawTransaction(tx)`|`rpc/sendrawtransaction.cpp#sendrawtransaction`|

#### The client:

https://github.com/DeFiCh/jellyfish/blob/36d11134b74e9285ae36229fdaa3f33876bf3cee/packages/jellyfish-core/src/core.ts#L8-L12

#### The protocol interfacing, with strongly typed interfaces:

https://github.com/DeFiCh/jellyfish/blob/36d11134b74e9285ae36229fdaa3f33876bf3cee/packages/jellyfish-core/src/methods/mining.ts#L3-L23

#### This allow library consumer to use it as follow:

```js
const result = await client.blockchain.getBestBlockHash()
// or
client.blockchain.getBestBlockHash()
  .then((result) => {
    console.log(result)
  }).catch((err)=> {
    console.log('panic!')
  }).finally(() => {
    console.log('cleanup')  
  })
```

## `@defichain/jellyfish-jsonrpc`

Nothing really special about this package, it just imlements `@defichain/jellyfish-core` in the JSON-RPC 1.0 specification. 2 dependencies with 4 deeply are selected, `jsonbig` as JS number is implemented with IEEE-754, defi must not use floating point arithmetic for obvious reason (need to write TDD to guarantee this behavior) see #18. `cross-fetch` a isomorphic `fetch` client that is RN, Node.JS and browser compatible. See #17 

https://github.com/DeFiCh/jellyfish/blob/36d11134b74e9285ae36229fdaa3f33876bf3cee/packages/jellyfish-jsonrpc/src/jsonrpc.ts#L1-L3

https://github.com/DeFiCh/jellyfish/blob/36d11134b74e9285ae36229fdaa3f33876bf3cee/packages/jellyfish-jsonrpc/src/jsonrpc.ts#L21-L29

## `@defichain/jellyfish`

This is the entrypoint for most dApp developer. Distributed as `@defichain/jellyfish`, it is a bundler that creates 4 types of JavaScript packages for public use. This package provides conventional defaults and bundle all code required for dApps building. For library consumer, it is plug and play, they don't need to care how it works underneath.

### 1. `dist/jellyfish.cjs.js` for node.js

Common JS for Node.JS users, plug and play no transpiler required.

```js
const express = require('express')
const Jellyfish = require('@defichain/jellyfish')

const app = express()
const client = Jellyfish.jsonrpc('http://?.defichain.com')

app.get('/', (req, res) => {
  client.mining.getMintingInfo().then((info) => {
    res.send(JSON.stringify(info))
  })
})

app.listen(3000)
```

### 2. `dist/jellyfish.umd.js` for browser

For the global CDN users, this allows developer to just declare jellyfish.js script and use it on any webpage.

1. ReactJS Global Mode
2. VueJS Global Mode
3. WordPress websites
4. The plain old HTML & JavaScript

All library code that are required for jellyfish to work on their browser are automatically bundled into the fat javascript file. (20 KB+) This included `bignumber`, `JSONBig`, `jellyfish-jsonrpc` and in the future all other jellyfish tools e.g. `jellyfish-wallet`. The bundler is set to polyfill on >0.25% of all browser and target node 12 and above implementation.

```html

<script src="https://unpkg.com/@defichain/jellyfish@latest/dist/jellyfish.umd.js"/>
<script lang="js">
  var client = Jellyfish.jsonrpc('http://?.defichain.com')
  client.mining.getMintingInfo().then(info => {
    console.log(info)
  })
</script>
```

### 3. `dist/jellyfish.esm.js` for ES module

For webpack, parcel, and variety of users that want to use their own bundler (tree shaking), ES modules packages are also provided.

```js
import * as jf from '@defichain/jellyfish'

const client = jf.jsonrpc('http://?.defichain.com')
```

### 4. `dist/jellyfish.d.ts` for TS types

TypeScript's types are also exported for convenience’s sake, removes the need for `@types/jellyfish`.

```ts
import {Jellyfish, JellyfishClient} from '@defichain/jellyfish'

const client: JellyfishClient = Jellyfish.jsonrpc('http://?.defichain.com')
```

# Next?

If all is approved this implementation style will be internally frozen and slowly patched into main.