### PR TITLE
setup collective code owner for this mono repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,18 +2,22 @@
 # More details are here: https://help.github.com/articles/about-codeowners/
 
 /.github/                                       @fuxingloh
+/.husky/                                        @fuxingloh
 /.idea/                                         @fuxingloh
-CONTRIBUTING.md                                 @fuxingloh
-README.md                                       @fuxingloh
 
 /docs/                                          @fuxingloh
 
-/packages/jellyfish/                            @fuxingloh
-/packages/jellyfish-core/                       @fuxingloh
-/packages/jellyfish-jsonrpc/                    @fuxingloh
-/packages/testcontainers/                       @fuxingloh
+/packages/jellyfish/                            @fuxingloh @thedoublejay
+/packages/jellyfish-core/                       @fuxingloh @thedoublejay @fullstackninja864 @saurabh391
+/packages/jellyfish-jsonrpc/                    @fuxingloh @thedoublejay
+/packages/testcontainers/                       @fuxingloh @thedoublejay @fullstackninja864 @saurabh391
 
+lerna.json                                      @fuxingloh
+tsconfig.json                                   @fuxingloh
+jest.config.js                                  @fuxingloh
 package.json                                    @fuxingloh
 package-lock.json                               @fuxingloh
 
+CONTRIBUTING.md                                 @fuxingloh
+README.md                                       @fuxingloh
 LICENSE                                         @uzyn @fuxingloh @monstrobishi


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
-->

/kind chore

#### What this PR does / why we need it:

Collective code owner for parts of jellyfish mono repo packages. This bring in better long term maintainability of the project, and for contingency reasons too.