### PR TITLE
jellyfish-core with lossless, bignumber and number precision implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13571,6 +13571,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "node_modules/@types/lossless-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.0.tgz",
+      "integrity": "sha512-knKgXT5I1x87nKLuwCKWi7nfwwYrmyi51ss7O8kAnbj8c116wBm86Laj9yguoN+Ju1S8jkjasam/OdearnQKRw==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -22251,6 +22257,12 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-zEkWwELMSQQISdtOF44vk0bRJhN/PJ93qcgJLcodizQjxrJKdFrq2H1+Xv5QDe7v3dTYYbBI5hOsh4a9l0B2Ow==",
+      "peer": true
+    },
     "node_modules/loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -30401,10 +30413,12 @@
       "license": "MIT",
       "devDependencies": {
         "@defichain/testcontainers": "0.0.0",
+        "@types/lossless-json": "^1.0.0",
         "typescript": "^4.2.2"
       },
       "peerDependencies": {
-        "bignumber.js": "^9.0.1"
+        "bignumber.js": "^9.0.1",
+        "lossless-json": "^1.0.4"
       }
     },
     "packages/jellyfish-jsonrpc": {
@@ -31735,6 +31749,7 @@
       "version": "file:packages/jellyfish-core",
       "requires": {
         "@defichain/testcontainers": "0.0.0",
+        "@types/lossless-json": "^1.0.0",
         "typescript": "^4.2.2"
       }
     },
@@ -41426,6 +41441,12 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/lossless-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/lossless-json/-/lossless-json-1.0.0.tgz",
+      "integrity": "sha512-knKgXT5I1x87nKLuwCKWi7nfwwYrmyi51ss7O8kAnbj8c116wBm86Laj9yguoN+Ju1S8jkjasam/OdearnQKRw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -48196,6 +48217,12 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.4.tgz",
+      "integrity": "sha512-zEkWwELMSQQISdtOF44vk0bRJhN/PJ93qcgJLcodizQjxrJKdFrq2H1+Xv5QDe7v3dTYYbBI5hOsh4a9l0B2Ow==",
+      "peer": true
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/packages/jellyfish-core/README.md
+++ b/packages/jellyfish-core/README.md
@@ -1,8 +1,55 @@
 # @defichain/jellyfish-core
 
-- [ ] TODO(fuxingloh): core interfaces 
-- [ ] Force JSON string for floating number to prevent precision problem?
+`@defichain/jellyfish-core` is a protocol agnostic DeFiChain client implementation with APIs separated into their
+category.
 
-### Testing
+## Features
 
-1. mock testing
+* `Promise<T>` first implementation to prevent callback hell.
+* Numeric precision aware JSON parsing with options of `lossless`, `bignumber` or `number`.
+* Implementation in TypeScript with strongly typed interfaces and exported as `*.d.ts` too.
+* Raw RPC call is available with `client.call('getbalance', [], 'bignumber')`
+
+### Usage Example
+
+```js
+const result = await client.mining.getMintingInfo()
+// or
+client.mining.getMintingInfo().then((result) => {
+  console.log(result)
+}).catch((err) => {
+  console.log('panic!')
+}).finally(() => {
+  console.log('cleanup')
+})
+```
+
+## Development
+
+`JellyfishClient` being an abstract class allows the ability to adapt to any protocol when introduced (e.g. ws, https)
+while being simple to use. This implementation structure can be observed in ContainerAdapterClient where it is used to
+test jellyfish-core implementations.
+
+RPC categories are grouped into `jellyfish-core/src/category/*.ts` (e.g. `category/mining.ts`) this allows a protocol
+agnostic implementation of the RPC. All concerns are grouped within one `ts` file for better developer experience of
+browsing and maintaining the code.
+
+`JellyfishError` encapsulate RPC errors from DeFiChain within a structure. This allows for `instanceof` or type of error
+handling with rich structure.
+
+`JellyfishJSON` allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
+
+* **'lossless'** uses LosslessJSON that parses numeric values as LosslessNumber. With LosslessNumber, one can perform
+  regular numeric operations, and it will throw an error when this would result in losing information.
+* **'bignumber'** parse all numeric values as 'BigNumber' using bignumber.js library.
+* **'number'** parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
+
+## Testing
+
+```shell
+jest
+```
+
+As the RPC is implemented on `jellyfish-core`, all testing of RPC implementation should be done on `jellyfish-core`.
+`ContainerAdapterClient` is created to facilitate testing via an adapter implementation with all RPCs proxied into a
+`@defichain/testcontainers`.

--- a/packages/jellyfish-core/__tests__/category/wallet.test.ts
+++ b/packages/jellyfish-core/__tests__/category/wallet.test.ts
@@ -1,0 +1,46 @@
+import { ContainerAdapterClient } from '../container_adapter_client'
+import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { BigNumber } from '../../src/core'
+import waitForExpect from 'wait-for-expect'
+
+describe('non masternode', () => {
+  const container = new RegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+    await container.waitForReady()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should getBalance = 0', async () => {
+    const balance: BigNumber = await client.wallet.getBalance()
+
+    expect(balance.toString()).toBe('0')
+  })
+})
+
+describe('masternode', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+    await container.waitForReady()
+    await container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should getBalance >= 100', async () => {
+    return await waitForExpect(async () => {
+      const balance: BigNumber = await client.wallet.getBalance()
+      expect(balance.isGreaterThan(new BigNumber('100'))).toBe(true)
+    })
+  })
+})

--- a/packages/jellyfish-core/__tests__/container_adapter_client.ts
+++ b/packages/jellyfish-core/__tests__/container_adapter_client.ts
@@ -1,4 +1,4 @@
-import { JellyfishClient, JellyfishError } from '../src/core'
+import { JellyfishJSON, JellyfishClient, JellyfishError, Precision } from '../src/core'
 import { DeFiDContainer } from '@defichain/testcontainers'
 
 /**
@@ -16,8 +16,8 @@ export class ContainerAdapterClient extends JellyfishClient {
   /**
    * Wrap the call from client to testcontainers.
    */
-  async call<T> (method: string, params: any[]): Promise<T> {
-    const body = JSON.stringify({
+  async call<T> (method: string, params: any[], precision: Precision): Promise<T> {
+    const body = JellyfishJSON.stringify({
       jsonrpc: '1.0',
       id: Math.floor(Math.random() * 100000000000000),
       method: method,
@@ -25,7 +25,7 @@ export class ContainerAdapterClient extends JellyfishClient {
     })
 
     const text = await this.container.post(body)
-    const response = JSON.parse(text)
+    const response = JellyfishJSON.parse(text, precision)
 
     const { result, error } = response
 

--- a/packages/jellyfish-core/__tests__/core.test.ts
+++ b/packages/jellyfish-core/__tests__/core.test.ts
@@ -38,12 +38,12 @@ describe('JellyfishError handling', () => {
   })
 
   it('invalid method should throw -32601 with message as structured', async () => {
-    return await expect(client.call('invalid', []))
+    return await expect(client.call('invalid', [], 'lossless'))
       .rejects.toThrowError(/JellyfishError from RPC: 'Method not found', code: -32601/)
   })
 
   it('importprivkey should throw -5 with message as structured', async () => {
-    return await expect(client.call('importprivkey', ['invalid-key']))
+    return await expect(client.call('importprivkey', ['invalid-key'], 'lossless'))
       .rejects.toThrowError(/JellyfishError from RPC: 'Invalid private key encoding', code: -5/)
   })
 })

--- a/packages/jellyfish-core/__tests__/json.test.ts
+++ b/packages/jellyfish-core/__tests__/json.test.ts
@@ -1,0 +1,66 @@
+import { BigNumber, JellyfishJSON, LosslessNumber } from '../src/json'
+
+describe('parse', () => {
+  describe('lossless', () => {
+    /* eslint-disable @typescript-eslint/restrict-plus-operands */
+    it('18 digit significant should parse as lossless without precision lost', () => {
+      const obj = JellyfishJSON.parse('{"lossless":1200000000.00000001}', 'lossless')
+      expect(obj.lossless.toString()).toBe('1200000000.00000001')
+    })
+
+    it('10 digit significant should parse as lossless with math operators should not have an error', () => {
+      const obj = JellyfishJSON.parse('{"lossless":1200000000}', 'lossless')
+      expect((obj.lossless + 1).toString()).toBe('1200000001')
+    })
+
+    it('18 digit significant should parse as lossless with math operators should throw an error', () => {
+      const obj = JellyfishJSON.parse('{"lossless":1200000000.00000001}', 'lossless')
+      expect(() => {
+        console.log(obj.lossless + 1)
+      }).toThrow(/Cannot convert to number: number would be truncated \(value: 1200000000\.00000001\)/)
+    })
+    /* eslint-enable @typescript-eslint/restrict-plus-operands */
+  })
+
+  describe('bignumber', () => {
+    it('18 digit significant should parse as bignumber without precision lost', () => {
+      const obj = JellyfishJSON.parse('{"bignumber":1200000000.00000001}', 'bignumber')
+      expect(obj.bignumber.toString()).toBe('1200000000.00000001')
+    })
+  })
+
+  describe('number', () => {
+    it('18 digit significant should parse as number with precision lost', () => {
+      const obj = JellyfishJSON.parse('{"number":1200000000.00000001}', 'number')
+      expect(obj.number.toString()).not.toBe('1200000000.00000001')
+    })
+
+    it('10 digit significant should parse as number without precision lost', () => {
+      const obj = JellyfishJSON.parse('{"number":1200000000}', 'number')
+      expect(obj.number.toString()).toBe('1200000000')
+    })
+  })
+})
+
+describe('stringify', () => {
+  it('should stringify number as json numeric', () => {
+    const string = JellyfishJSON.stringify({
+      number: Number('1200000000')
+    })
+    expect(string).toBe('{"number":1200000000}')
+  })
+
+  it('should stringify lossless as json numeric', () => {
+    const string = JellyfishJSON.stringify({
+      lossless: new LosslessNumber('1200000000.00000001')
+    })
+    expect(string).toBe('{"lossless":1200000000.00000001}')
+  })
+
+  it('should stringify bignumber as json number', () => {
+    const string = JellyfishJSON.stringify({
+      bignumber: new BigNumber('1200000000.00000001')
+    })
+    expect(string).toBe('{"bignumber":1200000000.00000001}')
+  })
+})

--- a/packages/jellyfish-core/package.json
+++ b/packages/jellyfish-core/package.json
@@ -35,10 +35,12 @@
     "publish:latest": "npm publish --tag latest"
   },
   "peerDependencies": {
-    "bignumber.js": "^9.0.1"
+    "bignumber.js": "^9.0.1",
+    "lossless-json": "^1.0.4"
   },
   "devDependencies": {
     "@defichain/testcontainers": "0.0.0",
+    "@types/lossless-json": "^1.0.0",
     "typescript": "^4.2.2"
   }
 }

--- a/packages/jellyfish-core/src/category/mining.ts
+++ b/packages/jellyfish-core/src/category/mining.ts
@@ -35,7 +35,7 @@ export class Mining {
    * @return Promise<number>
    */
   async getNetworkHashPerSecond (nblocks: number = 120, height: number = -1): Promise<number> {
-    return await this.client.call('getnetworkhashps', [nblocks, height])
+    return await this.client.call('getnetworkhashps', [nblocks, height], 'number')
   }
 
   /**
@@ -43,6 +43,6 @@ export class Mining {
    * @return Promise<MintingInfo>
    */
   async getMintingInfo (): Promise<MintingInfo> {
-    return await this.client.call('getmintinginfo', [])
+    return await this.client.call('getmintinginfo', [], 'number')
   }
 }

--- a/packages/jellyfish-core/src/category/wallet.ts
+++ b/packages/jellyfish-core/src/category/wallet.ts
@@ -1,0 +1,23 @@
+import { BigNumber, JellyfishClient } from '../core'
+
+/**
+ * Minting related RPC calls for DeFiChain
+ */
+export class Wallet {
+  private readonly client: JellyfishClient
+
+  constructor (client: JellyfishClient) {
+    this.client = client
+  }
+
+  /**
+   * Returns the total available balance.
+   *
+   * @param minimumConfirmation
+   * @param includeWatchOnly
+   * @return Promise<number>
+   */
+  async getBalance (minimumConfirmation: number = 0, includeWatchOnly: boolean = false): Promise<BigNumber> {
+    return await this.client.call('getbalance', ['*', minimumConfirmation, includeWatchOnly], 'bignumber')
+  }
+}

--- a/packages/jellyfish-core/src/category/wallet.ts
+++ b/packages/jellyfish-core/src/category/wallet.ts
@@ -1,7 +1,7 @@
 import { BigNumber, JellyfishClient } from '../core'
 
 /**
- * Minting related RPC calls for DeFiChain
+ * Wallet related RPC calls for DeFiChain
  */
 export class Wallet {
   private readonly client: JellyfishClient

--- a/packages/jellyfish-core/src/core.ts
+++ b/packages/jellyfish-core/src/core.ts
@@ -1,24 +1,36 @@
-import BigNumber from 'bignumber.js'
 import { Mining } from './category/mining'
+import { Wallet } from './category/wallet'
+import { Precision } from './json'
 
-// TODO(fuxingloh): might need to restructure how it's exported as this grows, will look into this soon
 export * from './category/mining'
-export { BigNumber }
+export * from './category/wallet'
+export * from './json'
 
 /**
  * JellyfishClient; a protocol agnostic DeFiChain node client, RPC calls are separated into their category.
  */
 export abstract class JellyfishClient {
   public readonly mining = new Mining(this)
+  public readonly wallet = new Wallet(this)
 
   /**
    * A promise based procedure call handling
    *
-   * @param method name
-   * @param params payload
+   * @param method Name of the RPC method
+   * @param params Array of params as RPC payload
+   * @param precision
+   * Numeric precision to parse RPC payload as 'lossless', 'bignumber' or 'number'.
+   *
+   * 'lossless' uses LosslessJSON that parses numeric values as LosslessNumber. With LosslessNumber, one can perform
+   * regular numeric operations, and it will throw an error when this would result in losing information.
+   *
+   * 'bignumber' parse all numeric values as 'BigNumber' using bignumber.js library.
+   *
+   * 'number' parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
+   *
    * @throws JellyfishError
    */
-  abstract call<T> (method: string, params: any[]): Promise<T>
+  abstract call<T> (method: string, params: any[], precision: Precision): Promise<T>
 }
 
 /**

--- a/packages/jellyfish-core/src/json.ts
+++ b/packages/jellyfish-core/src/json.ts
@@ -1,0 +1,67 @@
+import BigNumber from 'bignumber.js'
+import { parse, stringify, LosslessNumber } from 'lossless-json'
+
+export { BigNumber }
+
+/**
+ * Numeric precision to parse RPC payload as.
+ *
+ * 'lossless' uses LosslessJSON that parses numeric values as LosslessNumber. With LosslessNumber, one can perform
+ * regular numeric operations, and it will throw an error when this would result in losing information.
+ *
+ * 'bignumber' parse all numeric values as 'BigNumber' using bignumber.js library.
+ *
+ * 'number' parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
+ */
+export type Precision = 'lossless' | 'bignumber' | 'number'
+
+/**
+ * JellyfishJSON allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
+ */
+export const JellyfishJSON = {
+  /**
+   * @param text JSON string to parse into object.
+   * @param precision Numeric precision to parse RPC payload as.
+   */
+  parse (text: string, precision: Precision): any {
+    switch (precision) {
+      case 'lossless':
+        return parse(text)
+
+      case 'bignumber':
+        return parse(text, (key: string, value: any) => {
+          if (value instanceof LosslessNumber) {
+            return new BigNumber(value.toString())
+          }
+
+          return value
+        })
+
+      case 'number':
+        return parse(text, (key: string, value: any) => {
+          if (value instanceof LosslessNumber) {
+            return Number(value.toString())
+          }
+
+          return value
+        })
+
+      default:
+        throw new Error(`JellyfishJson.parse ${precision as string} precision is not supported`)
+    }
+  },
+
+  /**
+   * @param value Object to stringify, with no risk of losing precision.
+   */
+  stringify (value: any): string {
+    const replacer = (key: string, value: any): any => {
+      if (value instanceof BigNumber) {
+        return new LosslessNumber(value.toString())
+      }
+      return value
+    }
+
+    return stringify(value, replacer)
+  }
+}

--- a/packages/testcontainers/__tests__/chains/reg_test_container.test.ts
+++ b/packages/testcontainers/__tests__/chains/reg_test_container.test.ts
@@ -67,8 +67,8 @@ describe('master node pos minting', () => {
 
   it('should wait until coinbase maturity with spendable balance', async () => {
     const key = GenesisKeys[2].operator
+    await container.waitForWalletCoinbaseMaturity()
     await container.generate(10, key.address)
-    await container.generate(100)
 
     await waitForExpect(async () => {
       const info = await container.getMintingInfo()

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -102,4 +102,11 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
     await this.container?.start()
     await super.waitForReady(timeout)
   }
+
+  /**
+   * Wait for master node wallet coin to be mature for spending.
+   */
+  async waitForWalletCoinbaseMaturity (): Promise<void> {
+    await this.generate(100)
+  }
 }


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

> This is a JS library design balancing act, beginner friendly yet accurate.

This implements a JSON parser for `jellyfish-core` with no risk of losing precision with parse and stringify. As not all number parsed are significant in all context, (e.g. `mining.getMintingInfo()`) this allow jellyfish library users to use the `number` for non precision sensitive operation (e.g. `networkhashps`) and BigNumber for precision sensitive operations.

`JellyfishJSON` allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.

* **'lossless'** uses LosslessJSON that parses numeric values as LosslessNumber. With LosslessNumber, one can perform
  regular numeric operations, and it will throw an error when this would result in losing information.
* **'bignumber'** parse all numeric values as 'BigNumber' using bignumber.js library.
* **'number'** parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.


#### Which issue(s) does this PR fixes?:

Fixes #18 

#### Additional comments:

> JellyfishJSON Examples

https://github.com/DeFiCh/jellyfish/blob/d6dd0c2192aa02dc189482de1c3c745fcfc3bca8/packages/jellyfish-core/__tests__/json.test.ts#L3-L66