### PR TITLE
implements JSON-RPC 1.0 specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13553,12 +13553,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "node_modules/@types/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-WW+0cfH3ovFN6ROV+p/Xfw36dT6s16hbXBYIG49PYw6+j6e+AkpqYccctgxwyicBmC8CZDBnPhOH94shFhXgHQ==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -13960,6 +13954,17 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/abortcontroller-polyfill": {
       "version": "1.7.1",
@@ -14717,6 +14722,7 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -18217,6 +18223,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -21781,14 +21795,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "dependencies": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -22151,6 +22157,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "node_modules/lodash.sortby": {
@@ -22844,6 +22856,21 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "node_modules/nock": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "3.1.0",
@@ -25848,6 +25875,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proto-list": {
       "version": "1.2.4",
@@ -30427,12 +30463,12 @@
       "license": "MIT",
       "dependencies": {
         "@defichain/jellyfish-core": "0.0.0",
-        "cross-fetch": "^3.0.6",
-        "json-bigint": "^1.0.0"
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.0.6"
       },
       "devDependencies": {
         "@defichain/testcontainers": "0.0.0",
-        "@types/json-bigint": "^1.0.0",
+        "nock": "^13.0.11",
         "typescript": "^4.2.2"
       }
     },
@@ -31758,9 +31794,9 @@
       "requires": {
         "@defichain/jellyfish-core": "0.0.0",
         "@defichain/testcontainers": "0.0.0",
-        "@types/json-bigint": "^1.0.0",
+        "abort-controller": "^3.0.0",
         "cross-fetch": "^3.0.6",
-        "json-bigint": "^1.0.0",
+        "nock": "^13.0.11",
         "typescript": "^4.2.2"
       }
     },
@@ -41423,12 +41459,6 @@
         "pretty-format": "^26.0.0"
       }
     },
-    "@types/json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-WW+0cfH3ovFN6ROV+p/Xfw36dT6s16hbXBYIG49PYw6+j6e+AkpqYccctgxwyicBmC8CZDBnPhOH94shFhXgHQ==",
-      "dev": true
-    },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -41707,6 +41737,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "abortcontroller-polyfill": {
       "version": "1.7.1",
@@ -42294,7 +42332,8 @@
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
+      "peer": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -45058,6 +45097,11 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.7",
@@ -47830,14 +47874,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-bigint": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-      "requires": {
-        "bignumber.js": "^9.0.0"
-      }
-    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -48131,6 +48167,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
     "lodash.sortby": {
@@ -48678,6 +48720,18 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.11.tgz",
+      "integrity": "sha512-sKZltNkkWblkqqPAsjYW0bm3s9DcHRPiMOyKO/PkfJ+ANHZ2+LA2PLe22r4lLrKgXaiSaDQwW3qGsJFtIpQIeQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      }
     },
     "node-addon-api": {
       "version": "3.1.0",
@@ -51070,6 +51124,12 @@
           "dev": true
         }
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",

--- a/packages/jellyfish-core/__tests__/container_adapter_client.ts
+++ b/packages/jellyfish-core/__tests__/container_adapter_client.ts
@@ -1,4 +1,4 @@
-import { JellyfishJSON, JellyfishClient, JellyfishError, Precision } from '../src/core'
+import { JellyfishJSON, JellyfishClient, Precision, JellyfishRPCError } from '../src/core'
 import { DeFiDContainer } from '@defichain/testcontainers'
 
 /**
@@ -29,8 +29,8 @@ export class ContainerAdapterClient extends JellyfishClient {
 
     const { result, error } = response
 
-    if (error !== null) {
-      throw new JellyfishError(error)
+    if (error !== undefined && error !== null) {
+      throw new JellyfishRPCError(error)
     }
 
     return result

--- a/packages/jellyfish-core/__tests__/core.test.ts
+++ b/packages/jellyfish-core/__tests__/core.test.ts
@@ -37,11 +37,11 @@ describe('JellyfishError handling', () => {
 
   it('invalid method should throw -32601 with message as structured', async () => {
     return await expect(client.call('invalid', [], 'lossless'))
-      .rejects.toThrowError(/JellyfishError from RPC: 'Method not found', code: -32601/)
+      .rejects.toThrowError(/JellyfishRPCError: 'Method not found', code: -32601/)
   })
 
   it('importprivkey should throw -5 with message as structured', async () => {
     return await expect(client.call('importprivkey', ['invalid-key'], 'lossless'))
-      .rejects.toThrowError(/JellyfishError from RPC: 'Invalid private key encoding', code: -5/)
+      .rejects.toThrowError(/JellyfishRPCError: 'Invalid private key encoding', code: -5/)
   })
 })

--- a/packages/jellyfish-core/__tests__/core.test.ts
+++ b/packages/jellyfish-core/__tests__/core.test.ts
@@ -1,19 +1,17 @@
-import { MintingInfo, JellyfishError, JellyfishClient } from '../src/core'
+import { MintingInfo, JellyfishClient, JellyfishClientError } from '../src/core'
 import { ContainerAdapterClient } from './container_adapter_client'
 import { RegTestContainer } from '@defichain/testcontainers'
 
 class TestClient extends JellyfishClient {
   async call<T> (method: string, payload: any[]): Promise<T> {
-    throw new JellyfishError({
-      code: 1, message: 'error message from node'
-    })
+    throw new JellyfishClientError('error from client')
   }
 }
 
 it('should export client', async () => {
   const client = new TestClient()
   return await expect(client.call('fail', []))
-    .rejects.toThrowError(JellyfishError)
+    .rejects.toThrowError(JellyfishClientError)
 })
 
 it('should export categories', async () => {
@@ -21,7 +19,7 @@ it('should export categories', async () => {
   return await expect(async () => {
     const info: MintingInfo = await client.mining.getMintingInfo()
     console.log(info)
-  }).rejects.toThrowError(JellyfishError)
+  }).rejects.toThrowError(JellyfishClientError)
 })
 
 describe('JellyfishError handling', () => {

--- a/packages/jellyfish-core/src/core.ts
+++ b/packages/jellyfish-core/src/core.ts
@@ -29,6 +29,8 @@ export abstract class JellyfishClient {
    * 'number' parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
    *
    * @throws JellyfishError
+   * @throws JellyfishRPCError
+   * @throws JellyfishClientError
    */
   abstract call<T> (method: string, params: any[], precision: Precision): Promise<T>
 }
@@ -37,12 +39,25 @@ export abstract class JellyfishClient {
  * JellyfishError; where jellyfish/defichain errors are encapsulated into.
  */
 export class JellyfishError extends Error {
-  public readonly code: number
-  public readonly rawMessage: string
+}
+
+/**
+ * Jellyfish client side error, from user.
+ */
+export class JellyfishClientError extends JellyfishError {
+  constructor (message: string) {
+    super(`JellyfishClientError: ${message}`)
+  }
+}
+
+/**
+ * Jellyfish RPC error, from upstream.
+ */
+export class JellyfishRPCError extends JellyfishError {
+  public readonly payload: { code: number, message: string }
 
   constructor (error: { code: number, message: string }) {
-    super(`JellyfishError from RPC: '${error.message}', code: ${error.code}`)
-    this.code = error.code
-    this.rawMessage = error.message
+    super(`JellyfishRPCError: '${error.message}', code: ${error.code}`)
+    this.payload = error
   }
 }

--- a/packages/jellyfish-jsonrpc/README.md
+++ b/packages/jellyfish-jsonrpc/README.md
@@ -1,3 +1,16 @@
 # @defichain/jellyfish-jsonrpc
 
-- [ ] TODO(fuxingloh): specific rpc protocol implementation only 
+`@defichain/jellyfish-jsonrpc` implements `@defichain/jellyfish-core`
+with [`JSON-RPC 1.0`](https://www.jsonrpc.org/specification_v1) specification.
+
+Other than `jellyfish-core`, 2 other external dependencies are used with 4 deeply.
+
+1. `cross-fetch` for an isomorphic fetch client compatible with RN, Node & browser.
+    1. `node-fetch`
+2. `abort-controller` for fetch abort signal implementation for request timeout.
+    1. `event-target-shim`
+
+## Development & Testing
+
+As all RPC interfacing is implemented in `jellyfish-core`, this package development & testing only focus on the
+[JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification implementation.

--- a/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
+++ b/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
@@ -31,10 +31,22 @@ describe('JSON-RPC 1.0 specification', () => {
 
     await expect(result).toBe('intercepted')
 
-    await expect(intercept.mock.calls[0][0].id).toBeGreaterThan(-1)
     await expect(intercept.mock.calls[0][0].jsonrpc).toBe('1.0')
+    await expect(intercept.mock.calls[0][0].id).toBeGreaterThan(-1)
     await expect(intercept.mock.calls[0][0].method).toBe('intercept')
     await expect(intercept.mock.calls[0][0].params).toEqual(['p1', 'p2'])
+  })
+
+  it('generated id must be positive as per the spec', async () => {
+    const client = new JsonRpcClient('http://intercepted.defichain.node')
+
+    for (const i of [...Array(100).keys()]) {
+      await client.call(`generate${i}`, [], 'number')
+      await expect(intercept.mock.calls[i][0].id).toBeGreaterThan(-1)
+      await expect(intercept.mock.calls[i][0].id.toString()).not.toEqual(
+        expect.not.stringMatching('.')
+      )
+    }
   })
 
   it('should generate a different id for each RPC', async () => {

--- a/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
+++ b/packages/jellyfish-jsonrpc/__tests__/jsonrpc.test.ts
@@ -1,5 +1,137 @@
-import { getName } from '../src/jsonrpc'
+import { JsonRpcClient } from '../src/jsonrpc'
+import { RegTestContainer } from '@defichain/testcontainers'
+import { JellyfishClientError, JellyfishError, JellyfishRPCError } from '@defichain/jellyfish-core'
+import nock from 'nock'
 
-it('should getName jsonrpc', () => {
-  expect(getName()).toBe('jellyfish-jsonrpc')
+describe('JSON-RPC 1.0 specification', () => {
+  const intercept = jest.fn()
+
+  beforeEach(() => {
+    nock('http://intercepted.defichain.node')
+      .post('/')
+      .reply(200, function (_, body: string) {
+        const req = JSON.parse(body)
+        intercept(req)
+        return {
+          result: 'intercepted',
+          id: req.id
+        }
+      })
+      .persist()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    nock.cleanAll()
+  })
+
+  it('should conform to JSON-RPC 1.0 specification', async () => {
+    const client = new JsonRpcClient('http://intercepted.defichain.node')
+    const result = await client.call('intercept', ['p1', 'p2'], 'number')
+
+    await expect(result).toBe('intercepted')
+
+    await expect(intercept.mock.calls[0][0].id).toBeGreaterThan(-1)
+    await expect(intercept.mock.calls[0][0].jsonrpc).toBe('1.0')
+    await expect(intercept.mock.calls[0][0].method).toBe('intercept')
+    await expect(intercept.mock.calls[0][0].params).toEqual(['p1', 'p2'])
+  })
+
+  it('should generate a different id for each RPC', async () => {
+    const client = new JsonRpcClient('http://intercepted.defichain.node')
+    await client.call('generate0', [], 'number')
+    await client.call('generate1', [], 'number')
+    await client.call('generate2', [], 'number')
+
+    await expect(intercept.mock.calls[0][0].id).not.toBe(intercept.mock.calls[1][0].id)
+    await expect(intercept.mock.calls[1][0].id).not.toBe(intercept.mock.calls[2][0].id)
+  })
+})
+
+describe('JellyfishError', () => {
+  const container = new RegTestContainer()
+
+  beforeAll(async () => {
+    await container.start({
+      user: 'foo',
+      password: 'bar'
+    })
+    await container.waitForReady()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should throw JellyfishRPCError', async () => {
+    const url = await container.getCachedRpcUrl()
+    const client = new JsonRpcClient(url)
+
+    const promise = client.call('importprivkey', ['invalid-key'], 'lossless')
+
+    await expect(promise).rejects.toThrow(JellyfishError)
+    await expect(promise).rejects.toThrow(JellyfishRPCError)
+    await expect(promise).rejects.toThrow('JellyfishRPCError: \'Invalid private key encoding\', code: -5')
+  })
+
+  it('should throw JellyfishClientError: 404 - Not Found', async () => {
+    const url = await container.getCachedRpcUrl()
+    const client = new JsonRpcClient(url)
+
+    const promise = client.call('invalid', [], 'number')
+
+    await expect(promise).rejects.toThrow(JellyfishError)
+    await expect(promise).rejects.toThrow(JellyfishClientError)
+    await expect(promise).rejects.toThrow('JellyfishClientError: 404 - Not Found')
+  })
+
+  it('should throw JellyfishClientError: 401 - Unauthorized', async () => {
+    const port = await container.getRpcPort()
+    const client = new JsonRpcClient(`http://foo:not-bar@localhost:${port}`)
+
+    const promise = client.mining.getMintingInfo()
+
+    await expect(promise).rejects.toThrow(JellyfishError)
+    await expect(promise).rejects.toThrow(JellyfishClientError)
+    await expect(promise).rejects.toThrow('JellyfishClientError: 401 - Unauthorized')
+  })
+})
+
+describe('ClientOptions', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    nock.cleanAll()
+  })
+
+  it('should send with custom headers', async () => {
+    nock('http://options.defid.node')
+      .matchHeader('Authorization', 'Bearer OCEAN')
+      .post('/')
+      .reply(200, { result: 'authorized' })
+
+    const client = new JsonRpcClient('http://options.defid.node', {
+      headers: {
+        Authorization: 'Bearer OCEAN'
+      }
+    })
+
+    const result = await client.call('authorize', [], 'number')
+    await expect(result).toBe('authorized')
+  })
+
+  it('should timeout in 2 second', async () => {
+    nock('http://options.defid.node')
+      .post('/')
+      .delayConnection(5000)
+      .reply(200, { result: 'timeout' })
+
+    const client = new JsonRpcClient('http://options.defid.node', {
+      timeout: 2000
+    })
+
+    const promise = client.mining.getMintingInfo()
+    await expect(promise).rejects.toThrow(JellyfishError)
+    await expect(promise).rejects.toThrow(JellyfishClientError)
+    await expect(promise).rejects.toThrow('JellyfishClientError: request aborted due to set timeout of 2000ms')
+  })
 })

--- a/packages/jellyfish-jsonrpc/jest.config.js
+++ b/packages/jellyfish-jsonrpc/jest.config.js
@@ -7,5 +7,6 @@ module.exports = {
     '^.+\\.ts$': 'ts-jest'
   },
   verbose: true,
-  clearMocks: true
+  clearMocks: true,
+  testTimeout: 120000
 }

--- a/packages/jellyfish-jsonrpc/package.json
+++ b/packages/jellyfish-jsonrpc/package.json
@@ -37,11 +37,11 @@
   "dependencies": {
     "@defichain/jellyfish-core": "0.0.0",
     "cross-fetch": "^3.0.6",
-    "json-bigint": "^1.0.0"
+    "abort-controller": "^3.0.0"
   },
   "devDependencies": {
     "@defichain/testcontainers": "0.0.0",
-    "@types/json-bigint": "^1.0.0",
+    "nock": "^13.0.11",
     "typescript": "^4.2.2"
   }
 }

--- a/packages/jellyfish-jsonrpc/src/jsonrpc.ts
+++ b/packages/jellyfish-jsonrpc/src/jsonrpc.ts
@@ -1,3 +1,114 @@
-export function getName (): string {
-  return 'jellyfish-jsonrpc'
+import {
+  JellyfishClient,
+  JellyfishClientError,
+  JellyfishJSON,
+  JellyfishRPCError,
+  Precision
+} from '@defichain/jellyfish-core'
+import fetch from 'cross-fetch'
+import AbortController from 'abort-controller'
+
+/**
+ * ClientOptions for JsonRpc
+ */
+export interface ClientOptions {
+  timeout?: number
+  headers?: Headers | string[][] | Record<string, string>
+}
+
+/**
+ * JsonRpcClient default client options
+ */
+export const defaultOptions: ClientOptions = {
+  timeout: 60000,
+  headers: undefined
+}
+
+/**
+ * A JSON-RPC client implementation for connecting to a DeFiChain node.
+ */
+export class JsonRpcClient extends JellyfishClient {
+  private readonly url: string
+  private readonly options: ClientOptions
+
+  /**
+   * Construct a Jellyfish client to connect to a DeFiChain node via JSON-RPC.
+   *
+   * @param url endpoint
+   * @param options Optional JellyfishJsonRpcOptions
+   * timeout: default to 60000ms
+   * headers: none
+   */
+  constructor (url: string, options?: ClientOptions) {
+    super()
+    this.url = url
+    this.options = Object.assign(defaultOptions, options ?? {})
+  }
+
+  /**
+   * Implements JSON-RPC 1.0 specification for JellyfishClient
+   */
+  async call<T> (method: string, params: any[], precision: Precision): Promise<T> {
+    const body = JsonRpcClient.stringify(method, params)
+    const response = await this.fetchTimeout(body)
+    const text = await response.text()
+
+    switch (response.status) {
+      case 200:
+      default:
+        return JsonRpcClient.parse(text, precision)
+
+      case 401:
+      case 404:
+        throw new JellyfishClientError(`${response.status} - ${response.statusText}`)
+    }
+  }
+
+  private static stringify (method: string, params: any[]): string {
+    return JellyfishJSON.stringify({
+      jsonrpc: '1.0',
+      id: Math.floor(Math.random() * 100000000000000),
+      method: method,
+      params: params
+    })
+  }
+
+  private static parse (text: string, precision: Precision): any {
+    const { result, error } = JellyfishJSON.parse(text, precision)
+
+    if (error !== undefined && error !== null) {
+      throw new JellyfishRPCError(error)
+    }
+
+    return result
+  }
+
+  /**
+   * Fetch with timeout defined in 'this.options.timeout'
+   */
+  private async fetchTimeout (body: string): Promise<Response> {
+    const timeout: number = this.options.timeout ?? 60000
+    const controller = new AbortController()
+    const id = setTimeout(() => controller.abort(), timeout)
+
+    const request = fetch(this.url, {
+      method: 'POST',
+      body: body,
+      cache: 'no-cache',
+      headers: this.options.headers,
+      signal: controller.signal
+    })
+
+    try {
+      const response = await request
+      clearTimeout(id)
+      return response
+    } catch (err) {
+      if (err.type === 'aborted') {
+        throw new JellyfishClientError(`request aborted due to set timeout of ${timeout}ms`)
+      }
+
+      throw err
+    }
+  }
 }

--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -316,6 +316,6 @@ export abstract class DeFiDContainer {
  */
 export class DeFiDRpcError extends Error {
   constructor (error: { code: number, message: string }) {
-    super(`DeFiDRpcError from RPC: '${error.message}', code: ${error.code}`)
+    super(`DeFiDRpcError: '${error.message}', code: ${error.code}`)
   }
 }

--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -207,7 +207,7 @@ export abstract class DeFiDContainer {
     const text = await this.post(body)
     const { result, error } = JSON.parse(text)
 
-    if (error !== null) {
+    if (error !== undefined && error !== null) {
       throw new DeFiDRpcError(error)
     }
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

This PR implements the [`JSON-RPC 1.0`](https://www.jsonrpc.org/specification_v1) specification in `jellyfish-jsonrpc` for `jellyfish-core` abstraction of `JellyfishClient` & `JellyfishError`.

#### Which issue(s) does this PR fixes?:

Implements parts of #17

#### Additional comments?:

Expanded on `JellyfishError` in core with `JellyfishRPCError` and `JellyfishClientError`. 

This error raising design follows many popular implementations such as the AmazonSDK, where user config problem & issues are surfaced as ClientError, while server/validation issues are categorized as another type, RPCError in this context.