### PR TITLE
upgraded oss-governance-bot to v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,8 @@
 /.github/                                       @fuxingloh
 /.husky/                                        @fuxingloh
 /.idea/                                         @fuxingloh
+/.github/workflows/oss-governance-bot.yml       @fuxingloh
+/.github/governance.yml                         @fuxingloh
 
 /docs/                                          @fuxingloh
 

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -111,7 +111,7 @@ pull_request:
           * `/kind refactor`
           * `/kind dependencies`
         status:
-          context: "Governance / Kind"
+          context: "Governance / Kind Label"
           description:
             success: Ready for review & merge.
             failure: Missing 'kind' label for release generation.

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -2,6 +2,7 @@ name: OSS
 
 on:
   pull_request_target:
+    branches: [ master, main ]
     types: [ synchronize, opened, labeled, unlabeled ]
   issues:
     types: [ opened, labeled, unlabeled ]
@@ -13,7 +14,7 @@ jobs:
     name: Governance
     runs-on: ubuntu-latest
     steps:
-      - uses: DeFiCh/oss-governance-bot@v1
+      - uses: DeFiCh/oss-governance-bot@v2
         with:
-          bot-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.DEFICHAIN_BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Upgraded oss-governance-bot to v2 due to workflow automation chaining permission complications. Using a unified bot token now.

https://github.com/DeFiCh/oss-governance-bot/pull/64

