### PR TITLE
moved @types to dev for testcontainers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13071,6 +13071,7 @@
     },
     "node_modules/@types/dockerode": {
       "version": "3.2.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -13142,11 +13143,14 @@
     },
     "node_modules/@types/node": {
       "version": "14.14.33",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -13154,7 +13158,9 @@
     },
     "node_modules/@types/node-fetch/node_modules/form-data": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13815,6 +13821,7 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/at-least-node": {
@@ -15006,6 +15013,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -16063,6 +16071,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -21455,6 +21464,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.46.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -21462,6 +21472,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.29",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.46.0"
@@ -29002,12 +29013,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/dockerode": "^3.2.2",
-        "@types/node-fetch": "^2.5.8",
         "dockerode": "^3.2.1",
         "node-fetch": "^2.6.1"
       },
       "devDependencies": {
+        "@types/dockerode": "^3.2.2",
+        "@types/node-fetch": "^2.5.8",
         "typescript": ">=4.2.0"
       }
     }
@@ -39408,6 +39419,7 @@
     },
     "@types/dockerode": {
       "version": "3.2.2",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -39468,10 +39480,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.33"
+      "version": "14.14.33",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -39479,6 +39495,9 @@
       "dependencies": {
         "form-data": {
           "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -39904,7 +39923,8 @@
       "dev": true
     },
     "asynckit": {
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "dev": true
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -40763,6 +40783,7 @@
     },
     "combined-stream": {
       "version": "1.0.8",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -41560,7 +41581,8 @@
       }
     },
     "delayed-stream": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -45254,10 +45276,12 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.46.0"
+      "version": "1.46.0",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.29",
+      "dev": true,
       "requires": {
         "mime-db": "1.46.0"
       }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -32,12 +32,12 @@
     "publish:latest": "npm publish --tag latest"
   },
   "dependencies": {
-    "@types/dockerode": "^3.2.2",
-    "@types/node-fetch": "^2.5.8",
     "dockerode": "^3.2.1",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {
+    "@types/dockerode": "^3.2.2",
+    "@types/node-fetch": "^2.5.8",
     "typescript": ">=4.2.0"
   }
 }


### PR DESCRIPTION
#### What kind of PR is this?:
/kind chore

#### What this PR does / why we need it:

By moving `@types` to dev deps for `testcontainers`, this will prevent optional licenses clause from showing up for library users.