### PR TITLE
added explicit publish flags for package-json

### DIFF
--- a/packages/jellyfish-core/package.json
+++ b/packages/jellyfish-core/package.json
@@ -2,11 +2,12 @@
   "private": false,
   "name": "@defichain/jellyfish-core",
   "version": "0.0.0",
-  "description": "A collection of TypeScript/JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFiChain developers to build decentralized finance on Bitcoin",
   "keywords": [
     "DeFiChain",
     "JavaScript",
-    "API"
+    "API",
+    "Bitcoin"
   ],
   "repository": "DeFiCh/jellyfish",
   "bugs": "https://github.com/DeFiCh/jellyfish/issues",
@@ -31,8 +32,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "publish:next": "npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "peerDependencies": {
     "bignumber.js": "^9.0.1",

--- a/packages/jellyfish-jsonrpc/package.json
+++ b/packages/jellyfish-jsonrpc/package.json
@@ -2,11 +2,12 @@
   "private": false,
   "name": "@defichain/jellyfish-jsonrpc",
   "version": "0.0.0",
-  "description": "A collection of TypeScript/JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFiChain developers to build decentralized finance on Bitcoin",
   "keywords": [
     "DeFiChain",
     "JavaScript",
-    "API"
+    "API",
+    "Bitcoin"
   ],
   "repository": "DeFiCh/jellyfish",
   "bugs": "https://github.com/DeFiCh/jellyfish/issues",
@@ -31,8 +32,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "publish:next": "npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "@defichain/jellyfish-core": "0.0.0",

--- a/packages/jellyfish/package.json
+++ b/packages/jellyfish/package.json
@@ -2,11 +2,12 @@
   "private": false,
   "name": "@defichain/jellyfish",
   "version": "0.0.0",
-  "description": "A collection of TypeScript/JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFiChain developers to build decentralized finance on Bitcoin",
   "keywords": [
     "DeFiChain",
     "JavaScript",
-    "API"
+    "API",
+    "Bitcoin"
   ],
   "repository": "DeFiCh/jellyfish",
   "bugs": "https://github.com/DeFiCh/jellyfish/issues",
@@ -48,8 +49,8 @@
   },
   "scripts": {
     "build": "parcel build src/jellyfish.ts",
-    "publish:next": "npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "@defichain/jellyfish-core": "0.0.0",

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -2,11 +2,12 @@
   "private": false,
   "name": "@defichain/testcontainers",
   "version": "0.0.0",
-  "description": "A collection of TypeScript/JavaScript tools and libraries for DeFiChain to build decentralized finance on Bitcoin",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFiChain developers to build decentralized finance on Bitcoin",
   "keywords": [
     "DeFiChain",
     "JavaScript",
-    "API"
+    "API",
+    "Bitcoin"
   ],
   "repository": "DeFiCh/jellyfish",
   "bugs": "https://github.com/DeFiCh/jellyfish/issues",
@@ -28,8 +29,8 @@
   ],
   "scripts": {
     "build": "tsc",
-    "publish:next": "npm publish --tag next",
-    "publish:latest": "npm publish --tag latest"
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
     "dockerode": "^3.2.1",


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

So that publish flags are always included for new sub repo for consistency.