### PR TITLE
renamed docs to website for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,7 @@
 /.github/workflows/oss-governance-bot.yml       @fuxingloh
 /.github/governance.yml                         @fuxingloh
 
-/docs/                                          @fuxingloh
+/website/                                       @fuxingloh
 
 /packages/jellyfish/                            @fuxingloh @thedoublejay
 /packages/jellyfish-core/                       @fuxingloh @thedoublejay @fullstackninja864 @saurabh391


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

In https://github.com/DeFiCh/jellyfish/pull/64 `website` is used instead of `docs` for jellyfish documentation website
