### PR TITLE
renamed JellyfishError to ApiError

### DIFF
--- a/packages/api-core/README.md
+++ b/packages/api-core/README.md
@@ -34,7 +34,7 @@ RPC categories are grouped into `api-core/src/category/*.ts` (e.g. `category/min
 agnostic implementation of the RPC. All concerns are grouped within one `ts` file for better developer experience of
 browsing and maintaining the code.
 
-`JellyfishError` encapsulate RPC errors from DeFiChain within a structure. This allows for `instanceof` or type of error
+`ApiError` encapsulate RPC errors from DeFiChain within a structure. This allows for `instanceof` or type of error
 handling with rich structure.
 
 `JellyfishJSON` allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.

--- a/packages/api-core/__tests__/container_adapter_client.ts
+++ b/packages/api-core/__tests__/container_adapter_client.ts
@@ -1,4 +1,4 @@
-import { JellyfishJSON, ApiClient, Precision, JellyfishRPCError } from '../src'
+import { JellyfishJSON, ApiClient, Precision, RpcApiError } from '../src'
 import { DeFiDContainer } from '@defichain/testcontainers'
 
 /**
@@ -30,7 +30,7 @@ export class ContainerAdapterClient extends ApiClient {
     const { result, error } = response
 
     if (error !== undefined && error !== null) {
-      throw new JellyfishRPCError(error)
+      throw new RpcApiError(error)
     }
 
     return result

--- a/packages/api-core/__tests__/index.test.ts
+++ b/packages/api-core/__tests__/index.test.ts
@@ -1,17 +1,17 @@
-import { MintingInfo, ApiClient, JellyfishClientError } from '../src'
+import { MintingInfo, ApiClient, ClientApiError } from '../src'
 import { ContainerAdapterClient } from './container_adapter_client'
 import { RegTestContainer } from '@defichain/testcontainers'
 
 class TestClient extends ApiClient {
   async call<T> (method: string, payload: any[]): Promise<T> {
-    throw new JellyfishClientError('error from client')
+    throw new ClientApiError('error from client')
   }
 }
 
 it('should export client', async () => {
   const client = new TestClient()
   await expect(client.call('fail', []))
-    .rejects.toThrowError(JellyfishClientError)
+    .rejects.toThrowError(ClientApiError)
 })
 
 it('should export categories', async () => {
@@ -19,10 +19,10 @@ it('should export categories', async () => {
   await expect(async () => {
     const info: MintingInfo = await client.mining.getMintingInfo()
     console.log(info)
-  }).rejects.toThrowError(JellyfishClientError)
+  }).rejects.toThrowError(ClientApiError)
 })
 
-describe('JellyfishError handling', () => {
+describe('ApiError handling', () => {
   const container = new RegTestContainer()
   const client = new ContainerAdapterClient(container)
 
@@ -37,11 +37,11 @@ describe('JellyfishError handling', () => {
 
   it('invalid method should throw -32601 with message as structured', async () => {
     await expect(client.call('invalid', [], 'lossless'))
-      .rejects.toThrowError(/JellyfishRPCError: 'Method not found', code: -32601/)
+      .rejects.toThrowError(/RpcApiError: 'Method not found', code: -32601/)
   })
 
   it('importprivkey should throw -5 with message as structured', async () => {
     await expect(client.call('importprivkey', ['invalid-key'], 'lossless'))
-      .rejects.toThrowError(/JellyfishRPCError: 'Invalid private key encoding', code: -5/)
+      .rejects.toThrowError(/RpcApiError: 'Invalid private key encoding', code: -5/)
   })
 })

--- a/packages/api-core/src/index.ts
+++ b/packages/api-core/src/index.ts
@@ -28,37 +28,36 @@ export abstract class ApiClient {
    *
    * 'number' parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
    *
-   * @throws JellyfishError
-   * @throws JellyfishRPCError
-   * @throws JellyfishClientError
+   * @throws ApiError
+   * @throws RpcApiError
+   * @throws ClientApiError
    */
   abstract call<T> (method: string, params: any[], precision: Precision): Promise<T>
 }
 
 /**
- * JellyfishError; where jellyfish/defichain errors are encapsulated into.
- * TODO(fuxingloh): wait for wallet-core integration to refactor this out rename this
+ * ApiError; where defichain errors are encapsulated into.
  */
-export class JellyfishError extends Error {
+export class ApiError extends Error {
 }
 
 /**
- * Jellyfish client side error, from user.
+ * Api client side error, from user.
  */
-export class JellyfishClientError extends JellyfishError {
+export class ClientApiError extends ApiError {
   constructor (message: string) {
-    super(`JellyfishClientError: ${message}`)
+    super(`ClientApiError: ${message}`)
   }
 }
 
 /**
- * Jellyfish RPC error, from upstream.
+ * API RPC error, from upstream.
  */
-export class JellyfishRPCError extends JellyfishError {
+export class RpcApiError extends ApiError {
   public readonly payload: { code: number, message: string }
 
   constructor (error: { code: number, message: string }) {
-    super(`JellyfishRPCError: '${error.message}', code: ${error.code}`)
+    super(`RpcApiError: '${error.message}', code: ${error.code}`)
     this.payload = error
   }
 }

--- a/packages/api-jsonrpc/__tests__/index.test.ts
+++ b/packages/api-jsonrpc/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { JsonRpcClient } from '../src'
 import { RegTestContainer } from '@defichain/testcontainers'
-import { JellyfishClientError, JellyfishError, JellyfishRPCError } from '@defichain/api-core'
+import { ClientApiError, ApiError, RpcApiError } from '@defichain/api-core'
 import nock from 'nock'
 
 describe('JSON-RPC 1.0 specification', () => {
@@ -60,7 +60,7 @@ describe('JSON-RPC 1.0 specification', () => {
   })
 })
 
-describe('JellyfishError', () => {
+describe('ApiError', () => {
   const container = new RegTestContainer()
 
   beforeAll(async () => {
@@ -75,37 +75,37 @@ describe('JellyfishError', () => {
     await container.stop()
   })
 
-  it('should throw JellyfishRPCError', async () => {
+  it('should throw RpcApiError', async () => {
     const url = await container.getCachedRpcUrl()
     const client = new JsonRpcClient(url)
 
     const promise = client.call('importprivkey', ['invalid-key'], 'lossless')
 
-    await expect(promise).rejects.toThrow(JellyfishError)
-    await expect(promise).rejects.toThrow(JellyfishRPCError)
-    await expect(promise).rejects.toThrow('JellyfishRPCError: \'Invalid private key encoding\', code: -5')
+    await expect(promise).rejects.toThrow(ApiError)
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid private key encoding\', code: -5')
   })
 
-  it('should throw JellyfishClientError: 404 - Not Found', async () => {
+  it('should throw ClientApiError: 404 - Not Found', async () => {
     const url = await container.getCachedRpcUrl()
     const client = new JsonRpcClient(url)
 
     const promise = client.call('invalid', [], 'number')
 
-    await expect(promise).rejects.toThrow(JellyfishError)
-    await expect(promise).rejects.toThrow(JellyfishClientError)
-    await expect(promise).rejects.toThrow('JellyfishClientError: 404 - Not Found')
+    await expect(promise).rejects.toThrow(ApiError)
+    await expect(promise).rejects.toThrow(ClientApiError)
+    await expect(promise).rejects.toThrow('ClientApiError: 404 - Not Found')
   })
 
-  it('should throw JellyfishClientError: 401 - Unauthorized', async () => {
+  it('should throw ClientApiError: 401 - Unauthorized', async () => {
     const port = await container.getRpcPort()
     const client = new JsonRpcClient(`http://foo:not-bar@localhost:${port}`)
 
     const promise = client.mining.getMintingInfo()
 
-    await expect(promise).rejects.toThrow(JellyfishError)
-    await expect(promise).rejects.toThrow(JellyfishClientError)
-    await expect(promise).rejects.toThrow('JellyfishClientError: 401 - Unauthorized')
+    await expect(promise).rejects.toThrow(ApiError)
+    await expect(promise).rejects.toThrow(ClientApiError)
+    await expect(promise).rejects.toThrow('ClientApiError: 401 - Unauthorized')
   })
 })
 
@@ -142,8 +142,8 @@ describe('ClientOptions', () => {
     })
 
     const promise = client.mining.getMintingInfo()
-    await expect(promise).rejects.toThrow(JellyfishError)
-    await expect(promise).rejects.toThrow(JellyfishClientError)
-    await expect(promise).rejects.toThrow('JellyfishClientError: request aborted due to set timeout of 2000ms')
+    await expect(promise).rejects.toThrow(ApiError)
+    await expect(promise).rejects.toThrow(ClientApiError)
+    await expect(promise).rejects.toThrow('ClientApiError: request aborted due to set timeout of 2000ms')
   })
 })

--- a/packages/api-jsonrpc/src/index.ts
+++ b/packages/api-jsonrpc/src/index.ts
@@ -1,8 +1,8 @@
 import {
   ApiClient,
-  JellyfishClientError,
+  ClientApiError,
   JellyfishJSON,
-  JellyfishRPCError,
+  RpcApiError,
   Precision
 } from '@defichain/api-core'
 import fetch from 'cross-fetch'
@@ -69,7 +69,7 @@ export class JsonRpcClient extends ApiClient {
 
       case 401:
       case 404:
-        throw new JellyfishClientError(`${response.status} - ${response.statusText}`)
+        throw new ClientApiError(`${response.status} - ${response.statusText}`)
     }
   }
 
@@ -86,7 +86,7 @@ export class JsonRpcClient extends ApiClient {
     const { result, error } = JellyfishJSON.parse(text, precision)
 
     if (error !== undefined && error !== null) {
-      throw new JellyfishRPCError(error)
+      throw new RpcApiError(error)
     }
 
     return result
@@ -114,7 +114,7 @@ export class JsonRpcClient extends ApiClient {
       return response
     } catch (err) {
       if (err.type === 'aborted') {
-        throw new JellyfishClientError(`request aborted due to set timeout of ${timeout}ms`)
+        throw new ClientApiError(`request aborted due to set timeout of ${timeout}ms`)
       }
 
       throw err

--- a/website/docs/jellyfish/design.md
+++ b/website/docs/jellyfish/design.md
@@ -117,9 +117,9 @@ export abstract class ApiClient {
    *
    * 'number' parse all numeric values as 'Number' and precision will be loss if it exceeds IEEE-754 standard.
    *
-   * @throws JellyfishError
-   * @throws JellyfishRPCError
-   * @throws JellyfishClientError
+   * @throws ApiError
+   * @throws RpcApiError
+   * @throws ClientApiError
    */
   abstract call<T> (method: string, params: any[], precision: Precision): Promise<T>
 }

--- a/website/docs/jellyfish/usage.md
+++ b/website/docs/jellyfish/usage.md
@@ -69,7 +69,7 @@ import { ApiClient } from '@defichain/api-core'
 
 class SpecClient extends ApiClient {
   async call<T> (method: string, payload: any[]): Promise<T> {
-    throw new JellyfishClientError('error from client')
+    throw new ClientApiError('error from client')
   }
 }
 


### PR DESCRIPTION
#### What kind of PR is this?:

/kind refactor

#### What this PR does / why we need it:

Removing all jellyfish keyword from `api-core`, renamed `JellyfishError` to `ApiError`.