### PR TITLE
renamed packages/network exports to be more concise

### DIFF
--- a/packages/network/__tests__/index.test.ts
+++ b/packages/network/__tests__/index.test.ts
@@ -1,23 +1,29 @@
-import { Main, RegTest, Test } from "../src";
+import { Network, MainNet, RegTest, TestNet } from '../src'
 
-it('should match Main network', () => {
-  expect(Main.messagePrefix).toBe('\x15Defi Signed Message:\n')
-  expect(Main.bech32).toBe('df')
-  expect(Main.bip32.public).toBe(0x0488b21e)
-  expect(Main.bip32.private).toBe(0x0488ade4)
-  expect(Main.pubKeyHash).toBe(0x12)
-  expect(Main.scriptHash).toBe(0x5a)
-  expect(Main.wif).toBe(0x80)
+it('should be exported', () => {
+  const network: Network = MainNet
+  expect(network.bech32).toBe('df')
+  expect(network.wif).toBe(0x80)
 })
 
-it('should match Test network', () => {
-  expect(Test.messagePrefix).toBe('\x15Defi Signed Message:\n')
-  expect(Test.bech32).toBe('tf')
-  expect(Test.bip32.public).toBe(0x043587cf)
-  expect(Test.bip32.private).toBe(0x04358394)
-  expect(Test.pubKeyHash).toBe(0xf)
-  expect(Test.scriptHash).toBe(0x80)
-  expect(Test.wif).toBe(0xef)
+it('should match MainNet network', () => {
+  expect(MainNet.messagePrefix).toBe('\x15Defi Signed Message:\n')
+  expect(MainNet.bech32).toBe('df')
+  expect(MainNet.bip32.public).toBe(0x0488b21e)
+  expect(MainNet.bip32.private).toBe(0x0488ade4)
+  expect(MainNet.pubKeyHash).toBe(0x12)
+  expect(MainNet.scriptHash).toBe(0x5a)
+  expect(MainNet.wif).toBe(0x80)
+})
+
+it('should match TestNet network', () => {
+  expect(TestNet.messagePrefix).toBe('\x15Defi Signed Message:\n')
+  expect(TestNet.bech32).toBe('tf')
+  expect(TestNet.bip32.public).toBe(0x043587cf)
+  expect(TestNet.bip32.private).toBe(0x04358394)
+  expect(TestNet.pubKeyHash).toBe(0xf)
+  expect(TestNet.scriptHash).toBe(0x80)
+  expect(TestNet.wif).toBe(0xef)
 })
 
 it('should match RegTest network', () => {

--- a/packages/network/src/index.ts
+++ b/packages/network/src/index.ts
@@ -1,15 +1,15 @@
-interface Network {
+export interface Network {
   /**
    * For signing message with RPC
    * - 'signmessage'
    * - 'verifymessage'
    */
-  messagePrefix: string;
+  messagePrefix: string
   /**
    * Wallet import format
    * base58Prefixes.SECRET_KEY
    */
-  wif: number;
+  wif: number
   /**
    * Hierarchical Deterministic Wallet
    */
@@ -17,48 +17,48 @@ interface Network {
     /**
      * base58Prefixes.EXT_PUBLIC_KEY
      */
-    public: number;
+    public: number
     /**
      * base58Prefixes.EXT_SECRET_KEY
      */
-    private: number;
-  };
+    private: number
+  }
   /**
    * Version prefix used for bech32
    */
-  bech32: string;
+  bech32: string
   /**
    * base58Prefixes.PUBKEY_ADDRESS
    */
-  pubKeyHash: number;
+  pubKeyHash: number
   /**
    * base58Prefixes.SCRIPT_ADDRESS
    */
-  scriptHash: number;
+  scriptHash: number
 }
 
-export const Main: Network = {
+export const MainNet: Network = {
   messagePrefix: '\x15Defi Signed Message:\n',
   bech32: 'df',
   bip32: {
     public: 0x0488b21e,
-    private: 0x0488ade4,
+    private: 0x0488ade4
   },
   pubKeyHash: 0x12,
   scriptHash: 0x5a,
-  wif: 0x80,
-};
+  wif: 0x80
+}
 
-export const Test: Network = {
+export const TestNet: Network = {
   messagePrefix: '\x15Defi Signed Message:\n',
   bech32: 'tf',
   bip32: {
     public: 0x043587cf,
-    private: 0x04358394,
+    private: 0x04358394
   },
   pubKeyHash: 0xf,
   scriptHash: 0x80,
-  wif: 0xef,
+  wif: 0xef
 }
 
 export const RegTest: Network = {
@@ -66,9 +66,9 @@ export const RegTest: Network = {
   bech32: 'bcrt',
   bip32: {
     public: 0x043587cf,
-    private: 0x04358394,
+    private: 0x04358394
   },
   pubKeyHash: 0x6f,
   scriptHash: 0xc4,
-  wif: 0xef,
+  wif: 0xef
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

To make it more explicit and concise, also fixed a missing `export` keyword.
