### PR TITLE
update testcontainers to use 1.6.0

### DIFF
--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -92,7 +92,7 @@ async function pullImage (docker: Dockerode): Promise<void> {
 export abstract class DeFiDContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
-  public static readonly image = 'defi/defichain:1.5.0'
+  public static readonly image = 'defi/defichain:1.6.0'
 
   protected readonly docker: Dockerode
   protected readonly network: Network

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -16,7 +16,8 @@ export class RegTestContainer extends DeFiDContainer {
       '-bayfrontheight=1',
       '-bayfrontgardensheight=2',
       '-clarkequayheight=3',
-      '-dakotaheight=4'
+      '-dakotaheight=4',
+      '-dakotacrescentheight=5'
     ]
   }
 


### PR DESCRIPTION
#### What kind of PR is this?:
/kind dependencies

#### What this PR does / why we need it:

Following the latest release of https://github.com/DeFiCh/ain/releases/tag/v1.6.0
