### PR TITLE
update cross-fetch to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15467,9 +15467,9 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.2.tgz",
+      "integrity": "sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==",
       "dependencies": {
         "node-fetch": "2.6.1"
       }
@@ -29007,7 +29007,7 @@
       "dependencies": {
         "@defichain/jellyfish-api-core": "0.0.0",
         "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6"
+        "cross-fetch": "^3.1.2"
       },
       "devDependencies": {
         "@defichain/testcontainers": "0.0.0",
@@ -30222,7 +30222,7 @@
         "@defichain/jellyfish-api-core": "0.0.0",
         "@defichain/testcontainers": "0.0.0",
         "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.0.6",
+        "cross-fetch": "^3.1.2",
         "nock": "^13.0.11",
         "typescript": ">=4.2.0"
       }
@@ -41166,9 +41166,9 @@
       }
     },
     "cross-fetch": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
-      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.2.tgz",
+      "integrity": "sha512-+JhD65rDNqLbGmB3Gzs3HrEKC0aQnD+XA3SY6RjgkF88jV2q5cTc5+CwxlS3sdmLk98gpPt5CF9XRnPdlxZe6w==",
       "requires": {
         "node-fetch": "2.6.1"
       }

--- a/packages/jellyfish-api-jsonrpc/package.json
+++ b/packages/jellyfish-api-jsonrpc/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@defichain/jellyfish-api-core": "0.0.0",
-    "cross-fetch": "^3.0.6",
+    "cross-fetch": "^3.1.2",
     "abort-controller": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jellyfish-api-jsonrpc/src/index.ts
+++ b/packages/jellyfish-api-jsonrpc/src/index.ts
@@ -6,6 +6,7 @@ import {
   Precision
 } from '@defichain/jellyfish-api-core'
 import fetch from 'cross-fetch'
+import { Response } from 'cross-fetch/lib.fetch'
 import AbortController from 'abort-controller'
 
 /**


### PR DESCRIPTION
#### What kind of PR is this?:
/kind dependencies

#### What this PR does / why we need it:

Updated `cross-fetch` to `3.1.2`, this introduces better typescript support but causes breaking change to the exported types. Requiring a manual patch.
