### PR TITLE
added canonbrother to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,9 +9,9 @@
 
 /website/                                       @fuxingloh
 
-/packages/jellyfish/                            @fuxingloh @thedoublejay @fullstackninja864
-/packages/jellyfish-api-core/                   @fuxingloh @thedoublejay @fullstackninja864
-/packages/jellyfish-api-jsonrpc/                @fuxingloh @thedoublejay @fullstackninja864
+/packages/jellyfish/                            @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
+/packages/jellyfish-api-core/                   @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
+/packages/jellyfish-api-jsonrpc/                @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
 /packages/jellyfish-json/                       @fuxingloh
 /packages/jellyfish-network/                    @fuxingloh
 /packages/testcontainers/                       @fuxingloh


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Added @canonbrother to be part of the jellyfish core code owners.