### PR TITLE
fuxingloh/rpc blockchain getblock

### DIFF
--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -37,15 +37,36 @@ export class Blockchain {
 
   /**
    * Get block data with particular header hash.
-   * @param blockHash
-   * @param verbosity optional, default is 1, 0 for hex encoded
-   * @return Promise<string | Block>
+   * Returns a string that is serialized, hex-encoded data for block 'hash'
+   *
+   * @param hash of the block
+   * @param verbosity 0
+   * @return Promise<string>
    */
-  async getBlock (hash: string, verbosity?: 0): Promise<string>
-  async getBlock (hash: string, verbosity?: 1): Promise<Block<string>>
-  async getBlock (hash: string, verbosity?: 2): Promise<Block<RawTx>>
-  async getBlock<T> (blockHash: string, verbosity?: 0 | 1 | 2): Promise<string | Block<T>> {
-    return await this.client.call('getblock', [blockHash, verbosity], 'number')
+  getBlock (hash: string, verbosity: 0): Promise<string>
+
+  /**
+   * Get block data with particular header hash.
+   * Returns an Object with information about the block 'hash'.
+   *
+   * @param hash of the block
+   * @param verbosity 1
+   * @return Promise<Block<string>>
+   */
+  getBlock (hash: string, verbosity: 1): Promise<Block<string>>
+
+  /**
+   * Get block data with particular header hash.
+   * Returns an Object with information about block 'hash' and information about each transaction.
+   *
+   * @param hash of the block
+   * @param verbosity 2
+   * @return Promise<Block<Transaction>>
+   */
+  getBlock (hash: string, verbosity: 2): Promise<Block<Transaction>>
+
+  async getBlock<T> (hash: string, verbosity: 0 | 1 | 2): Promise<string | Block<T>> {
+    return await this.client.call('getblock', [hash, verbosity], 'number')
   }
 }
 
@@ -99,7 +120,7 @@ export interface Block<T> {
   nextblockhash: string
 }
 
-export interface RawTx {
+export interface Transaction {
   txid: string
   hash: string
   version: number

--- a/website/docs/jellyfish/api/blockchain.md
+++ b/website/docs/jellyfish/api/blockchain.md
@@ -51,10 +51,10 @@ Get block data with particular header hash.
 
 ```ts title="client.blockchain.getBlock()"
 interface blockchain {
-  async getBlock (hash: string, verbosity?: 0): Promise<string>
-  async getBlock (hash: string, verbosity?: 1): Promise<Block<string>>
-  async getBlock (hash: string, verbosity?: 2): Promise<Block<RawTx>>
-  async getBlock<T> (blockHash: string, verbosity?: 0 | 1 | 2): Promise<string | Block<T>>
+  getBlock (hash: string, verbosity: 0): Promise<string>
+  getBlock (hash: string, verbosity: 1): Promise<Block<string>>
+  getBlock (hash: string, verbosity: 2): Promise<Block<Transaction>>
+  getBlock<T> (hash: string, verbosity: 0 | 1 | 2): Promise<string | Block<T>>
 }
 
 export interface Block<T> {
@@ -80,6 +80,44 @@ export interface Block<T> {
   nTx: number
   previousblockhash: string
   nextblockhash: string
+}
+
+export interface Transaction {
+  txid: string
+  hash: string
+  version: number
+  size: number
+  vsize: number
+  weight: number
+  locktime: number
+  vin: Vin[]
+  vout: Vout[]
+  hex: string
+}
+
+export interface Vin {
+  coinbase: string
+  txid: string
+  vout: number
+  scriptSig: {
+    asm: string
+    hex: string
+  }
+  txinwitness: string[]
+  sequence: string
+}
+
+export interface Vout {
+  value: number
+  n: number
+  scriptPubKey: {
+    asm: string
+    hex: string
+    type: string
+    reqSigs: number
+    addresses: string[]
+    tokenId: string
+  }
 }
 ```
 


### PR DESCRIPTION
- isolated and removed all possible race conditions from test so that you can run them separately without relying on each other
- renamed RawTx to Transaction since its actually Transaction in this case, raw is hex coded data. 
- documented each verbosity and make it non-optional, you have to specific verbosity for better typing support.
- moved all test notes/comments into the test name for better test clarity. `it('')`
- updated website with the latest changes