### PR TITLE
jellyfish transaction buffer composer

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -8,6 +8,7 @@
       <w>bayfrontmarinaheight</w>
       <w>bcrt</w>
       <w>bech</w>
+      <w>chainparams</w>
       <w>clarkequayheight</w>
       <w>createmasternode</w>
       <w>currentblocktx</w>

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -3,13 +3,23 @@
     <words>
       <w>accounttoutxos</w>
       <w>amkheight</w>
+      <w>anyonecanpay</w>
       <w>bayfrontgardensheight</w>
       <w>bayfrontheight</w>
       <w>bayfrontmarinaheight</w>
       <w>bcrt</w>
       <w>bech</w>
+      <w>booland</w>
+      <w>boolor</w>
       <w>chainparams</w>
+      <w>checklocktimeverify</w>
+      <w>checkmultisig</w>
+      <w>checkmultisigverify</w>
+      <w>checksequenceverify</w>
+      <w>checksig</w>
+      <w>checksigverify</w>
       <w>clarkequayheight</w>
+      <w>codeseparator</w>
       <w>createmasternode</w>
       <w>currentblocktx</w>
       <w>currentblockweight</w>
@@ -21,6 +31,8 @@
       <w>devnet</w>
       <w>dockerode</w>
       <w>dummypos</w>
+      <w>equalverify</w>
+      <w>fromaltstack</w>
       <w>fullstackninja</w>
       <w>fuxingloh</w>
       <w>generatetoaddress</w>
@@ -34,13 +46,20 @@
       <w>getreceivedbyaddress</w>
       <w>gettransaction</w>
       <w>getunconfirmedbalance</w>
+      <w>greaterthan</w>
+      <w>greaterthanorequal</w>
+      <w>ifdup</w>
       <w>importprivkey</w>
       <w>infima</w>
+      <w>invalidopcode</w>
       <w>isoperator</w>
       <w>jsonrpc</w>
+      <w>lessthan</w>
+      <w>lessthanorequal</w>
       <w>libevent</w>
       <w>listaccounts</w>
       <w>logtimemicros</w>
+      <w>lshift</w>
       <w>mainnet</w>
       <w>masternode</w>
       <w>masternodeid</w>
@@ -51,25 +70,40 @@
       <w>networkhashps</w>
       <w>nmasternode</w>
       <w>nospv</w>
+      <w>notif</w>
+      <w>numequal</w>
+      <w>numequalverify</w>
+      <w>numnotequal</w>
       <w>pooledtx</w>
       <w>printtoconsole</w>
       <w>priv</w>
+      <w>pubkey</w>
+      <w>pushdata</w>
       <w>regtest</w>
       <w>rewardaddress</w>
+      <w>ripemd</w>
       <w>rpcallowip</w>
       <w>rpcbind</w>
       <w>rpcpassword</w>
       <w>rpcuser</w>
+      <w>rshift</w>
       <w>segwit</w>
       <w>sendtoaddress</w>
       <w>signmessage</w>
       <w>testcontainers</w>
       <w>thedoublejay</w>
+      <w>toaltstack</w>
+      <w>txid</w>
       <w>txnotokens</w>
       <w>uacomment</w>
       <w>unpkg</w>
       <w>utxostoaccount</w>
+      <w>varint</w>
+      <w>verif</w>
       <w>verifymessage</w>
+      <w>vernotif</w>
+      <w>vout</w>
+      <w>wpkh</w>
     </words>
   </dictionary>
 </component>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 A collection of TypeScript + JavaScript tools and libraries for DeFi Blockchain developers to build decentralized
 finance on Bitcoin.
 
-> 🚧 Work in progress, `3/193` rpc completed.
+> 🚧 Work in progress, `10/193` rpc completed.
 
 ## Installation
 
@@ -86,9 +86,10 @@ Package                                            | Description
 ---------------------------------------------------|-------------
 `@defichain/jellyfish`                             | Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts
 `@defichain/jellyfish-api-core`                    | A protocol agnostic DeFi Blockchain client interfaces, with a "foreign function interface" design.
-`@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification.
+`@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification for api-core.
 `@defichain/jellyfish-json`                        | Allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
-`@defichain/jellyfish-network`                     | Contains DeFi blockchain various network configuration for main, net and regtest.
+`@defichain/jellyfish-network`                     | Contains DeFi blockchain various network configuration for mainnet, testnet and regtest.
+`@defichain/jellyfish-transaction`                 | Dead simple modern stateless raw transaction builder for DeFi.
 `@defichain/testcontainers`                        | Provides a lightweight, throw away instances for DeFiD node provisioned automatically in a Docker container.
 
 ## Developing & Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1496,6 +1496,10 @@
       "resolved": "packages/jellyfish-network",
       "link": true
     },
+    "node_modules/@defichain/jellyfish-transaction": {
+      "resolved": "packages/jellyfish-transaction",
+      "link": true
+    },
     "node_modules/@defichain/testcontainers": {
       "resolved": "packages/testcontainers",
       "link": true
@@ -26314,7 +26318,6 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -29028,6 +29031,17 @@
         "typescript": ">=4.2.0"
       }
     },
+    "packages/jellyfish-transaction": {
+      "name": "@defichain/jellyfish-transaction",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "smart-buffer": "^4.1.0"
+      },
+      "devDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
     "packages/testcontainers": {
       "name": "@defichain/testcontainers",
       "version": "0.0.0",
@@ -30228,6 +30242,13 @@
     "@defichain/jellyfish-network": {
       "version": "file:packages/jellyfish-network",
       "requires": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "@defichain/jellyfish-transaction": {
+      "version": "file:packages/jellyfish-transaction",
+      "requires": {
+        "smart-buffer": "^4.1.0",
         "typescript": ">=4.2.0"
       }
     },
@@ -48838,8 +48859,7 @@
       "dev": true
     },
     "smart-buffer": {
-      "version": "4.1.0",
-      "dev": true
+      "version": "4.1.0"
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/packages/jellyfish-network/src/index.ts
+++ b/packages/jellyfish-network/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * Network specific DeFi Wallet configuration.
+ * Network specific DeFi configuration.
  * They can be found in DeFiCh/ain project in file chainparams.cpp, under base58Prefixes
  */
 export interface Network {
@@ -25,7 +25,7 @@ export interface Network {
 
 /**
  * @param network name
- * @return Network specific DeFi Wallet configuration
+ * @return Network specific DeFi configuration
  */
 export function getNetwork (network: 'mainnet' | 'testnet' | 'regtest'): Network {
   switch (network) {
@@ -41,7 +41,7 @@ export function getNetwork (network: 'mainnet' | 'testnet' | 'regtest'): Network
 }
 
 /**
- * MainNet specific DeFi Wallet configuration.
+ * MainNet specific DeFi configuration.
  */
 export const MainNet: Network = {
   bech32: {
@@ -58,7 +58,7 @@ export const MainNet: Network = {
 }
 
 /**
- * TestNet specific DeFi Wallet configuration.
+ * TestNet specific DeFi configuration.
  */
 export const TestNet: Network = {
   bech32: {
@@ -75,7 +75,7 @@ export const TestNet: Network = {
 }
 
 /**
- * RegTest specific DeFi Wallet configuration.
+ * RegTest specific DeFi configuration.
  */
 export const RegTest: Network = {
   bech32: {

--- a/packages/jellyfish-transaction/README.md
+++ b/packages/jellyfish-transaction/README.md
@@ -1,0 +1,12 @@
+[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction)](https://www.npmjs.com/package/@defichain/jellyfish-transaction/v/latest)
+[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-transaction/next)](https://www.npmjs.com/package/@defichain/jellyfish-transaction/v/next)
+
+# @defichain/jellyfish-transaction
+
+Stateless transaction builder for DeFi. 
+
+## Prior-art
+
+- https://github.com/ilyavf/tx-builder
+- https://github.com/bitpay/bitcore
+- https://github.com/bitcoinjs/bitcoinjs-lib

--- a/packages/jellyfish-transaction/README.md
+++ b/packages/jellyfish-transaction/README.md
@@ -3,7 +3,11 @@
 
 # @defichain/jellyfish-transaction
 
-Stateless transaction builder for DeFi. 
+Dead simple modern stateless raw transaction builder for DeFi.
+
+```
+Used in DeFi Fiber, but not yet included in @defichain/jellyfish bundle. 
+```
 
 ## Prior-art
 

--- a/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
+++ b/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
@@ -1,0 +1,752 @@
+import { SmartBuffer } from 'smart-buffer'
+import { BufferComposer, ComposableBuffer } from '../../src/buffer/buffer_composer'
+import { readVarUInt, writeVarUInt } from '../../src/buffer/buffer_varuint'
+
+function hexAsBufferLE (hex: string | string[]): SmartBuffer {
+  if (typeof hex === 'string') {
+    const buffer = Buffer.from(hex, 'hex').reverse()
+    return SmartBuffer.fromBuffer(buffer)
+  }
+
+  const buffer = new SmartBuffer()
+  for (const hex1 of hex) {
+    buffer.writeBuffer(Buffer.from(hex1, 'hex').reverse())
+  }
+  return buffer
+}
+
+/* eslint-disable no-return-assign */
+
+it('should format (4 bytes, 32 bytes, 8 bytes) hex with hexAsBufferLE', () => {
+  // assert hexAsBufferLE conditions is as expected.
+
+  const buffer = hexAsBufferLE([
+    '00080008',
+    'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f',
+    '01aa535d3d0c0000'
+  ])
+  expect(buffer.toString('hex'))
+    .toBe('080008009f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff00000c3d5d53aa01')
+})
+
+function shouldFromBuffer<T> (composer: BufferComposer, hex: string | string[], val: T, getter: () => T): void {
+  composer.fromBuffer(hexAsBufferLE(hex))
+  expect(getter()).toEqual(val)
+}
+
+function shouldToBuffer<T> (composer: BufferComposer, hex: string | string[], val: T, setter: (v: T) => void): void {
+  setter(val)
+  const buffer: SmartBuffer = new SmartBuffer()
+  composer.toBuffer(buffer)
+  const expected: SmartBuffer = hexAsBufferLE(hex)
+  expect(buffer.toString('hex')).toBe(expected.toString('hex'))
+}
+
+describe('ComposableBuffer deep implementation', () => {
+  interface Root {
+    ver: number // 1 byte
+    items: Item[] // c = VarUInt{1-9 bytes}, + c x Item
+    text: string // n = VarUInt{1-9 bytes}, + n bytes
+  }
+
+  interface Item {
+    ver: number // 2 bytes
+    val: number // 4 bytes
+    hex: string // 8 bytes
+  }
+
+  class CRoot extends ComposableBuffer<Root> implements Root {
+    composers (root: Root): BufferComposer[] {
+      return [
+        ComposableBuffer.uInt8(() => root.ver, v => root.ver = v),
+        ComposableBuffer.varUIntArray(() => root.items, v => root.items = v, item => {
+          return new CItem(item)
+        }),
+        {
+          fromBuffer (buffer: SmartBuffer) {
+            const length = readVarUInt(buffer)
+            const buff = Buffer.from(buffer.readBuffer(length))
+            root.text = buff.reverse().toString('utf-8')
+          },
+          toBuffer (buffer: SmartBuffer) {
+            const text = root.text
+            const buff = Buffer.from(text, 'utf-8').reverse()
+            writeVarUInt(buff.length, buffer)
+            buffer.writeBuffer(buff)
+          }
+        }
+      ]
+    }
+
+    get ver (): number {
+      return this.data.ver
+    }
+
+    get items (): Item[] {
+      return this.data.items
+    }
+
+    get text (): string {
+      return this.data.text
+    }
+  }
+
+  class CItem extends ComposableBuffer<Item> implements Item {
+    composers (data: Item): BufferComposer[] {
+      return [
+        ComposableBuffer.uInt16(() => data.ver, v => data.ver = v),
+        ComposableBuffer.uInt32(() => data.val, v => data.val = v),
+        ComposableBuffer.hex(8, () => data.hex, v => data.hex = v)
+      ]
+    }
+
+    get ver (): number {
+      return this.data.ver
+    }
+
+    get val (): number {
+      return this.data.val
+    }
+
+    get hex (): string {
+      return this.data.hex
+    }
+  }
+
+  const data: Root = {
+    ver: 0x01,
+    items: [
+      {
+        ver: 0x0001,
+        val: 0x00004000,
+        hex: 'ef51e1b804cc89d1'
+      }, {
+        ver: 0x0001,
+        val: 0x00008000,
+        hex: 'df5a4bdc045c1dd1'
+      }
+    ],
+    text: 'hello world'
+  }
+
+  const hex = '0102010000400000d189cc04b8e151ef010000800000d11d5c04dc4b5adf0b646c726f77206f6c6c6568'
+
+  it('CRoot to buffer', () => {
+    const root = new CRoot(data)
+    const buffer = new SmartBuffer()
+    root.toBuffer(buffer)
+
+    expect(buffer.toBuffer().toString('hex')).toBe(hex)
+  })
+
+  it('buffer to CRoot', () => {
+    const buffer = SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
+    const root = new CRoot(buffer)
+
+    expect(JSON.stringify(root.data)).toBe(JSON.stringify(data))
+  })
+})
+
+describe('ComposableBuffer.varUIntArray', () => {
+  interface VarItem {
+    val: number // 2 bytes
+    hex: string // 12 bytes
+  }
+
+  let items: VarItem[] = []
+
+  class CVarItem extends ComposableBuffer<VarItem> {
+    composers (data: VarItem): BufferComposer[] {
+      return [
+        ComposableBuffer.uInt16(() => data.val, v => data.val = v),
+        ComposableBuffer.hex(12, () => data.hex, v => data.hex = v)
+      ]
+    }
+  }
+
+  const composer = ComposableBuffer.varUIntArray(() => items, (v) => items = v, (v) => {
+    return new CVarItem(v)
+  })
+
+  describe('[1 byte, (2 bytes, 12 bytes), (2 bytes, 12 bytes)]', () => {
+    const hex = [
+      '02',
+      'a000',
+      'fff7f7881a8099afa6940d42',
+      '0080',
+      'ef51e1b804cc89d182d27965'
+    ]
+
+    const val = [
+      {
+        val: 0xa000,
+        hex: 'fff7f7881a8099afa6940d42'
+      },
+      {
+        val: 0x0080,
+        hex: 'ef51e1b804cc89d182d27965'
+      }
+    ]
+
+    it('should fromBuffer', () => {
+      items = val
+      shouldFromBuffer(composer, hex, val, () => items)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, hex, val, v => items = v)
+    })
+  })
+
+  describe('validate', () => {
+    it('should fail toBuffer deeply due to hex invalid length', () => {
+      items = [
+        {
+          val: 0xa000,
+          hex: 'fff7f7881a8099afa6940d421'
+        }
+      ]
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
+    })
+
+    it('should fail toBuffer deeply due to value out of range', () => {
+      items = [
+        {
+          val: 0xFFFFF000,
+          hex: 'fff7f7881a8099afa6940d42'
+        }
+      ]
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('It must be >= 0 and <= 65535. Received 4294963200')
+    })
+  })
+})
+
+describe('ComposableBuffer.array', () => {
+  interface Item {
+    value: BigInt // 8 bytes
+    txid: string // 32 bytes
+  }
+
+  let items: Item[] = []
+
+  class CItem extends ComposableBuffer<Item> {
+    composers (data: Item): BufferComposer[] {
+      return [
+        ComposableBuffer.bigUInt64(() => data.value, v => data.value = v),
+        ComposableBuffer.hex(32, () => data.txid, v => data.txid = v)
+      ]
+    }
+  }
+
+  const composer = ComposableBuffer.array(() => items, (v) => items = v, (v) => {
+    return new CItem(v)
+  }, () => items.length)
+
+  describe('[(8 bytes, 32 bytes),(8 bytes, 32 bytes)]', () => {
+    const hex = [
+      '0008000800080008',
+      'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f',
+      '01aa535d3d0c0000',
+      'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+    ]
+
+    const val = [
+      {
+        value: BigInt('0x0008000800080008'),
+        txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+      },
+      {
+        value: BigInt('0x01aa535d3d0c0000'),
+        txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+      }
+    ]
+
+    it('should fromBuffer', () => {
+      items = val
+      shouldFromBuffer(composer, hex, val, () => items)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, hex, val, v => items = v)
+    })
+  })
+
+  describe('validate', () => {
+    it('should fail toBuffer deeply due to hex invalid length', () => {
+      items = [
+        {
+          value: BigInt('0x0008000800080008'),
+          txid: 'fff7f7881a8099afa6940d42d1e7f636'
+        }
+      ]
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
+    })
+
+    it('should fail toBuffer deeply due to value out of range', () => {
+      items = [
+        {
+          value: BigInt('0x100008000800080008'),
+          txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+        }
+      ]
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('It must be >= 0n and < 2n ** 64n. Received 295_150_157_013_526_773_768n')
+    })
+  })
+})
+
+describe('ComposableBuffer.single', () => {
+  interface Single {
+    id: string // 16 bytes
+    value: number // 2 bytes
+  }
+
+  let object: Single = {
+    id: 'ef51e1b804cc89d182d279655c3aa89e',
+    value: 0
+  }
+
+  class CSingle extends ComposableBuffer<Single> {
+    composers (data: Single): BufferComposer[] {
+      return [
+        ComposableBuffer.hex(16, () => data.id, v => data.id = v),
+        ComposableBuffer.uInt16(() => data.value, v => data.value = v)
+      ]
+    }
+  }
+
+  const composer = ComposableBuffer.single(() => object, (v) => object = v, (v) => {
+    return new CSingle(v)
+  })
+
+  describe('16 bytes + 2 bytes', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, [
+        'ef51e1b804cc89d182d2796a5c3af89e',
+        '0008'
+      ], {
+        id: 'ef51e1b804cc89d182d2796a5c3af89e',
+        value: 0x0008
+      }, () => object)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, [
+        'ef51e1b804cc89d182d2796a5c3af89e',
+        '0001'
+      ], {
+        id: 'ef51e1b804cc89d182d2796a5c3af89e',
+        value: 0x0001
+      }, v => object = v)
+    })
+  })
+
+  describe('validate', () => {
+    it('should fail toBuffer deeply due to hex invalid length', () => {
+      object = {
+        id: '',
+        value: 0x0000
+      }
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
+    })
+
+    it('should fail toBuffer deeply due to value out of range', () => {
+      object = {
+        id: 'ef51e1b804cc89d182d279655c3aa89e',
+        value: 0xFFFF0000
+      }
+
+      expect(() => {
+        composer.toBuffer(new SmartBuffer())
+      }).toThrow('It must be >= 0 and <= 65535. Received 4294901760')
+    })
+  })
+})
+
+describe('ComposableBuffer.hex', () => {
+  const composer = ComposableBuffer.hex(16, () => value, (v: string) => value = v)
+  const expectedBuffer = Buffer.from('ef51e1b804cc89d182d279655c3aa89e', 'hex').reverse()
+  let value = ''
+
+  it('should fromBuffer', () => {
+    composer.fromBuffer(SmartBuffer.fromBuffer(expectedBuffer))
+
+    expect(value).toBe('ef51e1b804cc89d182d279655c3aa89e')
+  })
+
+  it('should toBuffer', () => {
+    value = 'ef51e1b804cc89d182d279655c3aa89e'
+
+    const buffer = new SmartBuffer()
+    composer.toBuffer(buffer)
+
+    expect(buffer.toBuffer().toString('hex')).toBe(expectedBuffer.toString('hex'))
+  })
+
+  it('should not have side effect when reading and writing', () => {
+    const from = SmartBuffer.fromBuffer(expectedBuffer)
+    composer.fromBuffer(from)
+    const to = new SmartBuffer()
+    composer.toBuffer(to)
+
+    expect(from.toString()).toBe(to.toString())
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = 'ef'
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
+  })
+})
+
+describe('ComposableBuffer.uInt8', () => {
+  let value = 0x00
+  const composer = ComposableBuffer.uInt8(() => value, (v: number) => value = v)
+
+  describe('0x01', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '01', 0x01, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '01', 0x01, v => value = v)
+    })
+  })
+
+  describe('0xb1', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, 'b1', 0xb1, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, 'b1', 0xb1, v => value = v)
+    })
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = 0xfff
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('It must be >= 0 and <= 255. Received 4095')
+  })
+})
+
+describe('ComposableBuffer.uInt16', () => {
+  let value = 0x0000
+  const composer = ComposableBuffer.uInt16(() => value, (v: number) => value = v)
+
+  describe('0x0081', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '0081', 0x0081, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '0081', 0x0081, v => value = v)
+    })
+  })
+
+  describe('0x0801', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '0801', 0x0801, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '0801', 0x0801, v => value = v)
+    })
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = 0x01ffff
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('It must be >= 0 and <= 65535. Received 131071')
+  })
+})
+
+describe('ComposableBuffer.int32', () => {
+  let value = 0x00000000
+  const composer = ComposableBuffer.int32(() => value, (v: number) => value = v)
+
+  describe('0x00000002', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '00000002', 0x00000002, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '00000002', 0x00000002, v => value = v)
+    })
+  })
+
+  describe('0x00aa0002', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '00aa0002', 0x00aa0002, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '00aa0002', 0x00aa0002, v => value = v)
+    })
+  })
+
+  describe('2147483647', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '7FFFFFFF', 2147483647, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '7FFFFFFF', 2147483647, v => value = v)
+    })
+  })
+
+  describe('-1660944385', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '9CFFFFFF', -1660944385, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '9CFFFFFF', -1660944385, v => value = v)
+    })
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = 0x100000000
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('It must be >= -2147483648 and <= 2147483647. Received 4294967296')
+  })
+})
+
+describe('ComposableBuffer.uInt32', () => {
+  let value = 0x00000000
+  const composer = ComposableBuffer.uInt32(() => value, (v: number) => value = v)
+
+  describe('0x00000001', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '00000001', 0x00000001, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '00000001', 0x00000001, v => value = v)
+    })
+  })
+
+  describe('0x0faa0002', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '0faa0002', 0x0faa0002, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '0faa0002', 0x0faa0002, v => value = v)
+    })
+  })
+
+  describe('2147483647', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '7FFFFFFF', 2147483647, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '7FFFFFFF', 2147483647, v => value = v)
+    })
+  })
+
+  describe('4000000000', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, 'ee6b2800', 4000000000, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, 'ee6b2800', 4000000000, v => value = v)
+    })
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = 0x100000000
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('It must be >= 0 and <= 4294967295. Received 4294967296')
+  })
+})
+
+describe('ComposableBuffer.bigUInt64', () => {
+  let value: BigInt = BigInt('0x01')
+  const composer = ComposableBuffer.bigUInt64(() => value, (v: BigInt) => value = v)
+
+  describe('0x0000000000000001', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '0000000000000001', BigInt('0x0000000000000001'), () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '0000000000000001', BigInt('0x0000000000000001'), v => value = v)
+    })
+  })
+
+  describe('0x8000000000000001', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '8000000000000001', BigInt('0x8000000000000001'), () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '8000000000000001', BigInt('0x8000000000000001'), v => value = v)
+    })
+  })
+
+  describe('0xff00000000000001', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, 'ff00000000000001', BigInt('0xff00000000000001'), () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, 'ff00000000000001', BigInt('0xff00000000000001'), v => value = v)
+    })
+  })
+
+  describe('4000000000', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '00000000ee6b2800', BigInt(4000000000), () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '00000000ee6b2800', BigInt(4000000000), v => value = v)
+    })
+  })
+
+  describe('120000000000000000', () => {
+    // 1200000000.00000000 MAX DFI Supply
+
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '01aa535d3d0c0000', BigInt('120000000000000000'), () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '01aa535d3d0c0000', BigInt('120000000000000000'), v => value = v)
+    })
+  })
+
+  it('should fail toBuffer validate', () => {
+    value = BigInt('0x10000000000000001')
+
+    expect(() => {
+      composer.toBuffer(new SmartBuffer())
+    }).toThrow('It must be >= 0n and < 2n ** 64n. Received 18_446_744_073_709_551_617n')
+  })
+})
+
+describe('ComposableBuffer.varUInt', () => {
+  let value: number = 0
+  const composer = ComposableBuffer.varUInt(() => value, (v: number) => value = v)
+
+  describe('1 byte = 0', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '00', 0x00, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '00', 0x00, v => value = v)
+    })
+  })
+
+  describe('1 byte = 100', () => {
+    it('should fromBuffer', () => {
+      shouldFromBuffer(composer, '64', 100, () => value)
+    })
+
+    it('should toBuffer', () => {
+      shouldToBuffer(composer, '64', 100, v => value = v)
+    })
+  })
+
+  describe('3 bytes = 1000', () => {
+    it('should fromBuffer', () => {
+      const buffer = new SmartBuffer()
+      buffer.writeUInt8(0xfd)
+      buffer.writeUInt16LE(0x03e8)
+
+      composer.fromBuffer(buffer)
+      expect(value).toBe(1000)
+    })
+
+    it('should toBuffer', () => {
+      value = 1000
+
+      const buffer = new SmartBuffer()
+      composer.toBuffer(buffer)
+
+      const expected = Buffer.from('fde803', 'hex')
+      expect(buffer.toString()).toBe(expected.toString())
+    })
+  })
+
+  describe('5 bytes = 100000', () => {
+    it('should fromBuffer', () => {
+      const buffer = new SmartBuffer()
+      buffer.writeUInt8(0xfe)
+      buffer.writeUInt32LE(0x000186a0)
+
+      composer.fromBuffer(buffer)
+      expect(value).toBe(100000)
+    })
+
+    it('should toBuffer', () => {
+      value = 100000
+
+      const buffer = new SmartBuffer()
+      composer.toBuffer(buffer)
+
+      const expected = Buffer.from('fea0860100', 'hex')
+      expect(buffer.toString()).toBe(expected.toString())
+    })
+  })
+
+  describe('9 bytes = 10000000000', () => {
+    it('should fromBuffer', () => {
+      const buffer = new SmartBuffer()
+      buffer.writeUInt8(0xff)
+      buffer.writeBigInt64LE(BigInt(10000000000))
+
+      composer.fromBuffer(buffer)
+      expect(value).toBe(10000000000)
+    })
+
+    it('should toBuffer', () => {
+      value = 10000000000
+
+      const buffer = new SmartBuffer()
+      composer.toBuffer(buffer)
+
+      const expected = Buffer.from('ff00e40b5402000000', 'hex')
+      expect(buffer.toString()).toBe(expected.toString())
+    })
+  })
+
+  it('should fail fromBuffer out of MAX_SAFE_INTEGER', () => {
+    const buffer = new SmartBuffer()
+    buffer.writeUInt8(0xff)
+    buffer.writeUInt32LE(0xffffffff)
+    buffer.writeUInt32LE(0xffffffff)
+
+    expect(() => {
+      composer.fromBuffer(buffer)
+    }).toThrow('out of Number.MAX_SAFE_INTEGER range')
+  })
+})

--- a/packages/jellyfish-transaction/__tests__/buffer/buffer_varuint.test.ts
+++ b/packages/jellyfish-transaction/__tests__/buffer/buffer_varuint.test.ts
@@ -1,0 +1,265 @@
+import { SmartBuffer } from 'smart-buffer'
+import { byteLength, readVarUInt, writeVarUInt } from '../../src/buffer/buffer_varuint'
+
+it('readBigInt64LE should be equal (readUInt32LE + readUInt32LE * 0x100000000)', () => {
+  const buffer = Buffer.allocUnsafe(8)
+  buffer.writeUInt32LE(1000)
+  buffer.writeUInt32LE(1000, 4)
+
+  const bigInt = buffer.readBigInt64LE()
+
+  const lo = buffer.readUInt32LE()
+  const hi = buffer.readUInt32LE(4)
+  const num = lo + (hi * 0x100000000)
+
+  expect(bigInt.toString()).toBe(num.toString())
+})
+
+describe('writeVarUInt', () => {
+  function shouldWrite (num: number): SmartBuffer {
+    const buffer = new SmartBuffer()
+    writeVarUInt(num, buffer)
+    return buffer
+  }
+
+  describe('1 byte', () => {
+    it('should read 0', () => {
+      const buffer = shouldWrite(0)
+      expect(buffer.readUInt8()).toBe(0)
+    })
+
+    it('should read 128', () => {
+      const buffer = shouldWrite(128)
+      expect(buffer.readUInt8()).toBe(128)
+    })
+
+    it('should read 252', () => {
+      const buffer = shouldWrite(252)
+      expect(buffer.readUInt8()).toBe(252)
+    })
+  })
+
+  describe('3 bytes', () => {
+    it('should read 253', () => {
+      const buffer = shouldWrite(253)
+      expect(buffer.readUInt8()).toBe(0xfd)
+      expect(buffer.readUInt16LE()).toBe(253)
+    })
+
+    it('should read 25000', () => {
+      const buffer = shouldWrite(25000)
+      expect(buffer.readUInt8()).toBe(0xfd)
+      expect(buffer.readUInt16LE()).toBe(25000)
+    })
+
+    it('should read 65535', () => {
+      const buffer = shouldWrite(65535)
+      expect(buffer.readUInt8()).toBe(0xfd)
+      expect(buffer.readUInt16LE()).toBe(65535)
+    })
+  })
+
+  describe('5 bytes', () => {
+    it('should read 65536', () => {
+      const buffer = shouldWrite(65536)
+      expect(buffer.readUInt8()).toBe(0xfe)
+      expect(buffer.readUInt32LE()).toBe(65536)
+    })
+
+    it('should read 123456789', () => {
+      const buffer = shouldWrite(123456789)
+      expect(buffer.readUInt8()).toBe(0xfe)
+      expect(buffer.readUInt32LE()).toBe(123456789)
+    })
+
+    it('should read 4294967295', () => {
+      const buffer = shouldWrite(4294967295)
+      expect(buffer.readUInt8()).toBe(0xfe)
+      expect(buffer.readUInt32LE()).toBe(4294967295)
+    })
+  })
+
+  describe('9 bytes', () => {
+    it('should read 4294967296', () => {
+      const buffer = shouldWrite(4294967296)
+      expect(buffer.readUInt8()).toBe(0xff)
+      expect(buffer.readUInt32LE()).toBe(4294967296 >>> 0)
+      expect(buffer.readUInt32LE()).toBe((4294967296 / 0x100000000) | 0)
+    })
+
+    it('should read 5234560000000000', () => {
+      const buffer = shouldWrite(5234560000000000)
+      expect(buffer.readUInt8()).toBe(0xff)
+      expect(buffer.readUInt32LE()).toBe(5234560000000000 >>> 0)
+      expect(buffer.readUInt32LE()).toBe((5234560000000000 / 0x100000000) | 0)
+    })
+
+    it('should read 9007199254740991', () => {
+      const buffer = shouldWrite(9007199254740991)
+      expect(buffer.readUInt8()).toBe(0xff)
+      expect(buffer.readUInt32LE()).toBe(9007199254740991 >>> 0)
+      expect(buffer.readUInt32LE()).toBe((9007199254740991 / 0x100000000) | 0)
+    })
+  })
+})
+
+describe('readVarUInt', () => {
+  function shouldRead (num: number, writer: (buffer: SmartBuffer) => void): void {
+    const buffer = new SmartBuffer()
+    writer(buffer)
+    return expect(readVarUInt(buffer)).toBe(num)
+  }
+
+  describe('1 byte', () => {
+    it('should read 0', () => {
+      shouldRead(0, buffer => {
+        buffer.writeUInt8(0)
+        buffer.writeUInt8(64)
+      })
+    })
+
+    it('should read 128', () => {
+      shouldRead(128, buffer => {
+        buffer.writeUInt8(128)
+        buffer.writeUInt8(64)
+      })
+    })
+
+    it('should read 252', () => {
+      shouldRead(252, buffer => {
+        buffer.writeUInt8(252)
+        buffer.writeUInt8(64)
+      })
+    })
+  })
+
+  describe('3 bytes', () => {
+    it('should read 253', () => {
+      shouldRead(253, buffer => {
+        buffer.writeUInt8(0xfd)
+        buffer.writeUInt16LE(253)
+        buffer.writeUInt16LE(512)
+      })
+    })
+
+    it('should read 25000', () => {
+      shouldRead(25000, buffer => {
+        buffer.writeUInt8(0xfd)
+        buffer.writeUInt16LE(25000)
+        buffer.writeUInt16LE(512)
+      })
+    })
+
+    it('should read 65535', () => {
+      shouldRead(65535, buffer => {
+        buffer.writeUInt8(0xfd)
+        buffer.writeUInt16LE(65535)
+        buffer.writeUInt16LE(512)
+      })
+    })
+  })
+
+  describe('5 bytes', () => {
+    it('should read 65536', () => {
+      shouldRead(65536, buffer => {
+        buffer.writeUInt8(0xfe)
+        buffer.writeUInt32LE(65536)
+        buffer.writeUInt32LE(512)
+      })
+    })
+
+    it('should read 123456789', () => {
+      shouldRead(123456789, buffer => {
+        buffer.writeUInt8(0xfe)
+        buffer.writeUInt32LE(123456789)
+        buffer.writeUInt32LE(512)
+      })
+    })
+
+    it('should read 4294967295', () => {
+      shouldRead(4294967295, buffer => {
+        buffer.writeUInt8(0xfe)
+        buffer.writeUInt32LE(4294967295)
+        buffer.writeUInt32LE(512)
+      })
+    })
+  })
+
+  describe('9 bytes', () => {
+    it('should read 4294967296', () => {
+      shouldRead(4294967296, buffer => {
+        buffer.writeUInt8(0xff)
+        buffer.writeUInt32LE(4294967296 >>> 0)
+        buffer.writeUInt32LE((4294967296 / 0x100000000) | 0)
+        buffer.writeUInt32LE(999999)
+      })
+    })
+
+    it('should read 5234560000000000', () => {
+      shouldRead(5234560000000000, buffer => {
+        buffer.writeUInt8(0xff)
+        buffer.writeUInt32LE(5234560000000000 >>> 0)
+        buffer.writeUInt32LE((5234560000000000 / 0x100000000) | 0)
+        buffer.writeUInt32LE(999999)
+      })
+    })
+
+    it('should read 9007199254740991', () => {
+      shouldRead(9007199254740991, buffer => {
+        buffer.writeUInt8(0xff)
+        buffer.writeUInt32LE(9007199254740991 >>> 0)
+        buffer.writeUInt32LE((9007199254740991 / 0x100000000) | 0)
+        buffer.writeUInt32LE(999999)
+      })
+    })
+  })
+})
+
+describe('byteLength', () => {
+  it('should be 1', () => {
+    expect(byteLength(0)).toBe(1)
+    expect(byteLength(1)).toBe(1)
+    expect(byteLength(128)).toBe(1)
+    expect(byteLength(252)).toBe(1)
+    expect(byteLength(0xfc)).toBe(1)
+  })
+
+  it('should be 3', () => {
+    expect(byteLength(253)).toBe(3)
+    expect(byteLength(1000)).toBe(3)
+    expect(byteLength(10000)).toBe(3)
+    expect(byteLength(65535)).toBe(3)
+    expect(byteLength(0xffff)).toBe(3)
+  })
+
+  it('should be 5', () => {
+    expect(byteLength(65536)).toBe(5)
+    expect(byteLength(100000)).toBe(5)
+    expect(byteLength(1200000)).toBe(5)
+    expect(byteLength(12300000)).toBe(5)
+    expect(byteLength(123400000)).toBe(5)
+    expect(byteLength(1234500000)).toBe(5)
+    expect(byteLength(4294967295)).toBe(5)
+    expect(byteLength(0xffffffff)).toBe(5)
+  })
+
+  it('should be 9', () => {
+    expect(byteLength(4294967296)).toBe(9)
+    expect(byteLength(10000000000)).toBe(9)
+    expect(byteLength(120000000000)).toBe(9)
+    expect(byteLength(1230000000000)).toBe(9)
+    expect(byteLength(12340000000000)).toBe(9)
+    expect(byteLength(123450000000000)).toBe(9)
+    expect(byteLength(1234560000000000)).toBe(9)
+    expect(byteLength(5234560000000000)).toBe(9)
+    expect(byteLength(9007199254740991)).toBe(9)
+    expect(byteLength(0x1fffffffffffff)).toBe(9)
+    expect(byteLength(Number.MAX_SAFE_INTEGER)).toBe(9)
+  })
+
+  it('should throw range error if out of Number.MAX_SAFE_INTEGER', () => {
+    expect(() => {
+      return byteLength(Number.MAX_SAFE_INTEGER + 1)
+    }).toThrow('out of Number.MAX_SAFE_INTEGER range')
+  })
+})

--- a/packages/jellyfish-transaction/jest.config.js
+++ b/packages/jellyfish-transaction/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.ts'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  verbose: true,
+  clearMocks: true,
+  testTimeout: 120000
+}

--- a/packages/jellyfish-transaction/package.json
+++ b/packages/jellyfish-transaction/package.json
@@ -1,0 +1,45 @@
+{
+  "private": false,
+  "name": "@defichain/jellyfish-transaction",
+  "version": "0.0.0",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFi Blockchain developers to build decentralized finance on Bitcoin",
+  "keywords": [
+    "DeFiChain",
+    "DeFi",
+    "Blockchain",
+    "API",
+    "Bitcoin"
+  ],
+  "repository": "DeFiCh/jellyfish",
+  "bugs": "https://github.com/DeFiCh/jellyfish/issues",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "DeFiChain Foundation",
+      "email": "engineering@defichain.com",
+      "url": "https://defichain.com/"
+    },
+    {
+      "name": "DeFi Blockchain Contributors"
+    },
+    {
+      "name": "DeFi Jellyfish Contributors"
+    }
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
+  },
+  "dependencies": {
+    "smart-buffer": "^4.1.0"
+  },
+  "devDependencies": {
+    "typescript": ">=4.2.0"
+  }
+}

--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -27,6 +27,11 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
    */
   constructor (buffer: SmartBuffer)
 
+  /**
+   * For typescript type checking
+   */
+  constructor (data: SmartBuffer | T)
+
   constructor (data: SmartBuffer | T) {
     if (data instanceof SmartBuffer) {
       // @ts-expect-error as data will be mapped by fromBuffer()

--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -1,0 +1,181 @@
+import { SmartBuffer } from 'smart-buffer'
+import { writeVarUInt, readVarUInt } from './buffer_varuint'
+
+export interface BufferComposer {
+  fromBuffer: (buffer: SmartBuffer) => void
+  toBuffer: (buffer: SmartBuffer) => void
+}
+
+/**
+ * A highly composable buffer,
+ *
+ * Little Endian by default because BITCOIN!
+ */
+export abstract class ComposableBuffer<T> implements BufferComposer {
+  readonly data: T
+
+  abstract composers (data: T): BufferComposer[]
+
+  constructor (data: SmartBuffer | T) {
+    if (data instanceof SmartBuffer) {
+      // @ts-expect-error as data will be mapped by fromBuffer()
+      this.data = {}
+      this.fromBuffer(data)
+    } else {
+      this.data = data
+    }
+  }
+
+  fromBuffer (buffer: SmartBuffer): void {
+    for (const mapping of this.composers(this.data)) {
+      mapping.fromBuffer(buffer)
+    }
+  }
+
+  toBuffer (buffer: SmartBuffer): void {
+    for (const mapping of this.composers(this.data)) {
+      mapping.toBuffer(buffer)
+    }
+  }
+
+  static varUIntArray<T> (
+    getter: () => T[],
+    setter: (data: T[]) => void,
+    asC: (data: SmartBuffer | T) => ComposableBuffer<T>
+  ): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        const length = readVarUInt(buffer)
+        const array: T[] = []
+        for (let i = 0; i < length; i++) {
+          array.push(asC(buffer).data)
+        }
+        setter(array)
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        const array = getter()
+        writeVarUInt(array.length, buffer)
+        array.forEach(data => asC(data).toBuffer(buffer))
+      }
+    }
+  }
+
+  static array<T> (
+    getter: () => T[],
+    setter: (data: T[]) => void,
+    asC: (data: SmartBuffer | T) => ComposableBuffer<T>,
+    getLength: () => number
+  ): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        const array: T[] = []
+        for (let i = 0; i < getLength(); i++) {
+          array.push(asC(buffer).data)
+        }
+        setter(array)
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        const array = getter()
+        array.forEach(data => asC(data).toBuffer(buffer))
+      }
+    }
+  }
+
+  static single<T> (
+    getter: () => T,
+    setter: (data: T) => void,
+    asC: (data: SmartBuffer | T) => ComposableBuffer<T>
+  ): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(asC(buffer).data)
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        asC(getter()).toBuffer(buffer)
+      }
+    }
+  }
+
+  static hex (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        const buff = Buffer.from(buffer.readBuffer(length))
+        setter(buff.reverse().toString('hex'))
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        const hex = getter()
+        if (hex.length !== length * 2) {
+          throw new Error('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
+        }
+        const buff: Buffer = Buffer.from(hex, 'hex').reverse()
+        buffer.writeBuffer(buff)
+      }
+    }
+  }
+
+  static uInt8 (getter: () => number, setter: (data: number) => any): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(buffer.readUInt8())
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        buffer.writeUInt8(getter())
+      }
+    }
+  }
+
+  static uInt16 (getter: () => number, setter: (data: number) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(buffer.readUInt16LE())
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        buffer.writeUInt16LE(getter())
+      }
+    }
+  }
+
+  static int32 (getter: () => number, setter: (data: number) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(buffer.readInt32LE())
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        buffer.writeInt32LE(getter())
+      }
+    }
+  }
+
+  static uInt32 (getter: () => number, setter: (data: number) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(buffer.readUInt32LE())
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        buffer.writeUInt32LE(getter())
+      }
+    }
+  }
+
+  static bigUInt64 (getter: () => BigInt, setter: (data: BigInt) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(buffer.readBigUInt64LE())
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        buffer.writeBigUInt64LE(getter().valueOf())
+      }
+    }
+  }
+
+  static varUInt (getter: () => number, setter: (data: number) => void): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(readVarUInt(buffer))
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        writeVarUInt(getter(), buffer)
+      }
+    }
+  }
+}

--- a/packages/jellyfish-transaction/src/buffer/buffer_varuint.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_varuint.ts
@@ -1,0 +1,76 @@
+import { SmartBuffer } from 'smart-buffer'
+
+/**
+ * @param num to write as VarUInt (1-9 bytes)
+ * @param buffer to write to
+ */
+export function writeVarUInt (num: number, buffer: SmartBuffer): void {
+  validateUInt53(num)
+
+  // 8 bit (1 byte)
+  if (num < 0xfd) {
+    buffer.writeUInt8(num)
+    return
+  }
+
+  // 16 bit (1 + 2 bytes)
+  if (num <= 0xffff) {
+    buffer.writeUInt8(0xfd)
+    buffer.writeUInt16LE(num)
+    return
+  }
+
+  // 32 bit (1 + 4 bytes)
+  if (num <= 0xffffffff) {
+    buffer.writeUInt8(0xfe)
+    buffer.writeUInt32LE(num)
+    return
+  }
+
+  // 64 bit (1 + 8 bytes)
+  buffer.writeUInt8(0xff)
+  buffer.writeUInt32LE(num >>> 0)
+  buffer.writeUInt32LE((num / 0x100000000) | 0)
+}
+
+/**
+ * Read VarUInt as number
+ * @param buffer to read VarUInt from (1-9 bytes)
+ * @throws RangeError 'out of Number.MAX_SAFE_INTEGER range' when it's out of MAX_SAFE_INTEGER
+ */
+export function readVarUInt (buffer: SmartBuffer): number {
+  const first = buffer.readUInt8()
+  switch (first) {
+    case 0xfd: // 16 bit (1 + 2 bytes)
+      return buffer.readUInt16LE()
+    case 0xfe: // 32 bit (1 + 4 bytes)
+      return buffer.readUInt32LE()
+    case 0xff: { // 64 bit (1 + 8 bytes)
+      const lo = buffer.readUInt32LE()
+      const hi = buffer.readUInt32LE()
+      const num = (hi * 0x0100000000) + lo
+      validateUInt53(num)
+      return num
+    }
+    default: // 8 bit (1 byte)
+      return first
+  }
+}
+
+/**
+ * @param num to get total number bytes (1-9 bytes)
+ */
+export function byteLength (num: number): number {
+  validateUInt53(num)
+  return num < 0xfd ? 1 : num <= 0xffff ? 3 : num <= 0xffffffff ? 5 : 9
+}
+
+/**
+ * @param num to validate
+ * @throws RangeError 'out of Number.MAX_SAFE_INTEGER range' when it's out of MAX_SAFE_INTEGER
+ */
+function validateUInt53 (num: number): void {
+  if (num < 0 || num > Number.MAX_SAFE_INTEGER || num % 1 !== 0) {
+    throw new RangeError('out of Number.MAX_SAFE_INTEGER range')
+  }
+}

--- a/packages/jellyfish-transaction/tsconfig.json
+++ b/packages/jellyfish-transaction/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "target": "es6",
     "lib": [
-      "es2019"
+      "es2020"
     ],
     "module": "commonjs",
     "strict": true,

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -29,7 +29,8 @@ Package                                            | Description
 ---------------------------------------------------|-------------
 `@defichain/jellyfish`                             | Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts
 `@defichain/jellyfish-api-core`                    | A protocol agnostic DeFi Blockchain client interfaces, with a "foreign function interface" design.
-`@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification.
+`@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification for api-core.
 `@defichain/jellyfish-json`                        | Allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
-`@defichain/jellyfish-network`                     | Contains DeFi blockchain various network configuration for main, net and regtest.
+`@defichain/jellyfish-network`                     | Contains DeFi blockchain various network configuration for mainnet, testnet and regtest.
+`@defichain/jellyfish-transaction`                 | Dead simple modern stateless raw transaction builder for DeFi.
 `@defichain/testcontainers`                        | Provides a lightweight, throw away instances for DeFiD node provisioned automatically in a Docker container.


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

A dead simple modern stateless raw transaction builder for DeFi.

This is the first in a series of PRs to DeFi raw transaction builder in JavaScript.

This composer design is bi-directional, allows you to `fromBuffer()` or `toBuffer()` composing. In short you compose from a byte buffer to JavaScript Object or JavaScript Object to a byte buffer. This is little endian by design as DeFi uses LE.


```ts
export class CTransaction extends ComposableBuffer<Transaction> implements Transaction {
  public get version (): Version {
    return this.data.version
  }

  public get vin (): Vin[] {
    return this.data.vin
  }

  public get vout (): Vout[] {
    return this.data.vout
  }

  public get lockTime (): LockTime {
    return this.data.lockTime
  }

  composers (tx: Transaction): BufferComposer[] {
    return [
      ComposableBuffer.uInt32(() => tx.version, v => tx.version = v),
      ComposableBuffer.varUIntArray<Vin>(() => tx.vin, v => tx.vin = v, v => new CVin(v)),
      ComposableBuffer.varUIntArray<Vout>(() => tx.vout, v => tx.vout = v, v => new CVout(v)),
      ComposableBuffer.uInt32(() => tx.lockTime, v => tx.lockTime = v)
    ]
  }
}
```

Allowing you to toBuffer and fromBuffer, before as an example.

```ts
new CTransaction({}).toBuffer()

new CTransaction(Buffer.from())
```