### PR TITLE
updated CODEOWNERS to include latest ownership priority and preference

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,15 @@
 /website/                                       @fuxingloh
 
 /packages/jellyfish/                            @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
-/packages/jellyfish-api-core/                   @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
+/packages/jellyfish-api-core/                   @fuxingloh @canonbrother @thedoublejay @fullstackninja864
 /packages/jellyfish-api-jsonrpc/                @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
-/packages/jellyfish-json/                       @fuxingloh
+/packages/jellyfish-json/                       @fuxingloh @canonbrother
 /packages/jellyfish-network/                    @fuxingloh
+/packages/jellyfish-transaction/                @fuxingloh
+/packages/jellyfish-wallet/                     @fuxingloh
+/packages/jellyfish-wallet-dfi/                 @fuxingloh
+/packages/jellyfish-wallet-mnemonic/            @fuxingloh
+/packages/jellyfish-wallet-ledger-dfi/          @fuxingloh
 /packages/testcontainers/                       @fuxingloh
 
 lerna.json                                      @fuxingloh


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Change in ownership priority and inclusion of @canonbrother into `jellyfish-json` due to recent work on it.