### PR TITLE
jellyfish-transaction constants and module export

### DIFF
--- a/packages/jellyfish-transaction/__tests__/index.test.ts
+++ b/packages/jellyfish-transaction/__tests__/index.test.ts
@@ -1,0 +1,48 @@
+import { BigNumber } from 'bignumber.js'
+import { SmartBuffer } from 'smart-buffer'
+import { CTransactionSegWit, TransactionSegWit, DeFiTransaction } from '../src'
+import { OP_CODES, OP_PUSHDATA } from '../src/script'
+
+it('should be able to use DeFiTransaction constants to craft Transaction', () => {
+  const hex = '04000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0000000000ffffffff0100e1f505000000001600143bde42dbee7e4dbe6a21b2d50ce2f0167faa8159010000000000'
+  const data: TransactionSegWit = {
+    version: DeFiTransaction.Version,
+    marker: DeFiTransaction.WitnessMarker,
+    flag: DeFiTransaction.WitnessFlag,
+    vin: [
+      {
+        index: 0,
+        script: {
+          stack: []
+        },
+        sequence: 0xffffffff,
+        txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+      }
+    ],
+    vout: [
+      {
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            new OP_PUSHDATA(Buffer.from('3bde42dbee7e4dbe6a21b2d50ce2f0167faa8159', 'hex'), 'little')
+          ]
+        },
+        value: new BigNumber('1')
+      }
+    ],
+    witness: [
+      {
+        scripts: [
+          {
+            hex: ''
+          }
+        ]
+      }
+    ],
+    lockTime: 0x00000000
+  }
+
+  const buffer = new SmartBuffer()
+  new CTransactionSegWit(data).toBuffer(buffer)
+  expect(buffer.toBuffer().toString('hex')).toBe(hex)
+})

--- a/packages/jellyfish-transaction/__tests__/tx_composer.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer.test.ts
@@ -1,8 +1,8 @@
-import { Script, Vout, Vin, Transaction, WitnessScript, Witness, TransactionSegWit } from '../src/tx'
+import { BigNumber } from 'bignumber.js'
+import { Script, Vout, Vin, Transaction, WitnessScript, Witness, TransactionSegWit, CScript, CTransaction, CTransactionSegWit, CVin, CVout, CWitness, CWitnessScript } from '../src'
+
 import { OP_CODES, OP_PUSHDATA } from '../src/script'
-import { CScript, CTransaction, CTransactionSegWit, CVin, CVout, CWitness, CWitnessScript } from '../src/tx_composer'
 import { SmartBuffer } from 'smart-buffer'
-import { BigNumber } from '@defichain/jellyfish-json'
 import { ComposableBuffer } from '../src/buffer/buffer_composer'
 
 // Test vector mostly taken from: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
@@ -805,6 +805,12 @@ describe('CTransactionSegWit', () => {
 
     it('should compose from Object to Composable to Buffer', () => {
       expectObjectToHexBuffer(data, hex, data => new CTransactionSegWit(data))
+    })
+
+    it('should be consistent for 10000 to Buffer generation', () => {
+      for (let i = 0; i < 10000; i++) {
+        expectObjectToHexBuffer(data, hex, data => new CTransactionSegWit(data))
+      }
     })
   })
 

--- a/packages/jellyfish-transaction/src/index.ts
+++ b/packages/jellyfish-transaction/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * DeFi Blockchain Transaction Constants
+ * https://github.com/DeFiCh/ain/blob/master/src/primitives/transaction.h
+ */
+export const DeFiTransaction = {
+  Version: 0x00000004, // 4 bytes
+  WitnessMarker: 0x00, // 1 byte
+  WitnessFlag: 0x01 // 1 byte
+}
+
+export * from './tx'
+export * from './tx_composer'


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

Added constants and `export * tx/tx_composer` to jellyfish-transaction `/index.ts`