### PR TITLE
jellyfish-crypto

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,13 @@
 /packages/jellyfish/                            @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
 /packages/jellyfish-api-core/                   @fuxingloh @canonbrother @thedoublejay @fullstackninja864
 /packages/jellyfish-api-jsonrpc/                @fuxingloh @thedoublejay @fullstackninja864 @canonbrother
+/packages/jellyfish-crypto/                     @fuxingloh
 /packages/jellyfish-json/                       @fuxingloh @canonbrother
 /packages/jellyfish-network/                    @fuxingloh
 /packages/jellyfish-transaction/                @fuxingloh
 /packages/jellyfish-wallet/                     @fuxingloh
 /packages/jellyfish-wallet-dfi/                 @fuxingloh
 /packages/jellyfish-wallet-mnemonic/            @fuxingloh
-/packages/jellyfish-wallet-ledger-dfi/          @fuxingloh
 /packages/testcontainers/                       @fuxingloh
 
 lerna.json                                      @fuxingloh

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -35,13 +35,13 @@ issue:
         - jellyfish
         - jellyfish-api-core
         - jellyfish-api-jsonrpc
+        - jellyfish-crypto
         - jellyfish-json
         - jellyfish-network
         - jellyfish-transaction
         - jellyfish-wallet
         - jellyfish-wallet-dfi
         - jellyfish-wallet-mnemonic
-        - jellyfish-wallet-ledger-dfi
         - testcontainers
       multiple: true
       needs:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -61,6 +61,8 @@
 - color: fbca04
   name: area/jellyfish-api-jsonrpc
 - color: fbca04
+  name: area/jellyfish-crypto
+- color: fbca04
   name: area/jellyfish-json
 - color: fbca04
   name: area/jellyfish-network
@@ -72,8 +74,6 @@
   name: area/jellyfish-wallet-dfi
 - color: fbca04
   name: area/jellyfish-wallet-mnemonic
-- color: fbca04
-  name: area/jellyfish-wallet-ledger-dfi
 - color: fbca04
   name: area/testcontainers
 

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -11,6 +11,7 @@
       <w>bech</w>
       <w>booland</w>
       <w>boolor</w>
+      <w>canonbrother</w>
       <w>chainparams</w>
       <w>checklocktimeverify</w>
       <w>checkmultisig</w>
@@ -87,6 +88,7 @@
       <w>rpcpassword</w>
       <w>rpcuser</w>
       <w>rshift</w>
+      <w>secp</w>
       <w>segwit</w>
       <w>sendtoaddress</w>
       <w>signmessage</w>

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -91,6 +91,7 @@
       <w>secp</w>
       <w>segwit</w>
       <w>sendtoaddress</w>
+      <w>sighashtype</w>
       <w>signmessage</w>
       <w>testcontainers</w>
       <w>thedoublejay</w>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "jellyfish",
+  "name": "@defich/jellyfish",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -1486,6 +1486,10 @@
     },
     "node_modules/@defichain/jellyfish-api-jsonrpc": {
       "resolved": "packages/jellyfish-api-jsonrpc",
+      "link": true
+    },
+    "node_modules/@defichain/jellyfish-crypto": {
+      "resolved": "packages/jellyfish-crypto",
       "link": true
     },
     "node_modules/@defichain/jellyfish-json": {
@@ -13081,12 +13085,39 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/create-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
+      "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/dockerode": {
       "version": "3.2.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "dev": true,
+      "dependencies": {
+        "@types/bn.js": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -14159,8 +14190,7 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -14608,7 +14638,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -15447,7 +15476,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -16401,7 +16429,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -16415,8 +16442,7 @@
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-      "dev": true
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -18827,7 +18853,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -18841,7 +18866,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -18861,7 +18885,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -18887,7 +18910,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -21362,7 +21384,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -21504,14 +21525,12 @@
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
@@ -25712,7 +25731,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -25769,7 +25787,6 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex": {
@@ -26159,7 +26176,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -29008,6 +29024,20 @@
         "typescript": ">=4.2.0"
       }
     },
+    "packages/jellyfish-crypto": {
+      "name": "@defichain/jellyfish-crypto",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "elliptic": "^6.5.4"
+      },
+      "devDependencies": {
+        "@types/create-hash": "^1.2.2",
+        "@types/elliptic": "^6.4.12",
+        "typescript": ">=4.2.0"
+      }
+    },
     "packages/jellyfish-json": {
       "name": "@defichain/jellyfish-json",
       "version": "0.0.0",
@@ -30231,6 +30261,16 @@
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "nock": "^13.0.11",
+        "typescript": ">=4.2.0"
+      }
+    },
+    "@defichain/jellyfish-crypto": {
+      "version": "file:packages/jellyfish-crypto",
+      "requires": {
+        "@types/create-hash": "^1.2.2",
+        "@types/elliptic": "^6.4.12",
+        "create-hash": "^1.2.0",
+        "elliptic": "^6.5.4",
         "typescript": ">=4.2.0"
       }
     },
@@ -39474,11 +39514,38 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bn.js": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
+      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/create-hash": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
+      "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/dockerode": {
       "version": "3.2.2",
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/elliptic": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+      "dev": true,
+      "requires": {
+        "@types/bn.js": "*"
       }
     },
     "@types/graceful-fs": {
@@ -40210,8 +40277,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -40535,7 +40601,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -41156,7 +41221,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -41878,7 +41942,6 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dev": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -41892,8 +41955,7 @@
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
-          "dev": true
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         }
       }
     },
@@ -43485,7 +43547,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -43495,8 +43556,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -43504,7 +43564,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -43527,7 +43586,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -45260,7 +45318,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -45358,14 +45415,12 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -48445,7 +48500,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -48474,8 +48528,7 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "dev": true
+      "version": "5.1.2"
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -48752,7 +48805,6 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13085,15 +13085,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -13109,15 +13100,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/elliptic": {
-      "version": "6.4.12",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
-      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
-      "dev": true,
-      "dependencies": {
-        "@types/bn.js": "*"
       }
     },
     "node_modules/@types/graceful-fs": {
@@ -13238,6 +13220,15 @@
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tiny-secp256k1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tiny-secp256k1/-/tiny-secp256k1-1.0.0.tgz",
+      "integrity": "sha512-IW3dFGNyVkVLC1MCMogVWQaKH/ZtjPQdOW9c3X128o5lVpFYNsq/l3Qo1pV7sfTmvDzWEXR3QTxg1TMy1pyaAQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
@@ -14144,6 +14135,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/bl": {
@@ -15488,7 +15495,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -17874,6 +17880,11 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filesize": {
       "version": "3.6.1",
@@ -21735,6 +21746,11 @@
       "version": "0.0.8",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "node_modules/nanoid": {
       "version": "3.1.20",
@@ -27524,6 +27540,27 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "dev": true,
@@ -29029,12 +29066,13 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
-        "elliptic": "^6.5.4"
+        "tiny-secp256k1": "^1.1.6"
       },
       "devDependencies": {
         "@types/create-hash": "^1.2.2",
-        "@types/elliptic": "^6.4.12",
+        "@types/tiny-secp256k1": "^1.0.0",
         "typescript": ">=4.2.0"
       }
     },
@@ -30268,9 +30306,10 @@
       "version": "file:packages/jellyfish-crypto",
       "requires": {
         "@types/create-hash": "^1.2.2",
-        "@types/elliptic": "^6.4.12",
+        "@types/tiny-secp256k1": "^1.0.0",
+        "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
-        "elliptic": "^6.5.4",
+        "tiny-secp256k1": "^1.1.6",
         "typescript": ">=4.2.0"
       }
     },
@@ -39514,15 +39553,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bn.js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.0.tgz",
-      "integrity": "sha512-QSSVYj7pYFN49kW77o2s9xTCwZ8F2xLbjLLSEVh8D2F4JUhZtPAGOFLTD+ffqksBx/u4cE/KImFjyhqCjn/LIA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -39537,15 +39567,6 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/elliptic": {
-      "version": "6.4.12",
-      "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
-      "integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
-      "dev": true,
-      "requires": {
-        "@types/bn.js": "*"
       }
     },
     "@types/graceful-fs": {
@@ -39651,6 +39672,15 @@
     "@types/stack-utils": {
       "version": "2.0.0",
       "dev": true
+    },
+    "@types/tiny-secp256k1": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tiny-secp256k1/-/tiny-secp256k1-1.0.0.tgz",
+      "integrity": "sha512-IW3dFGNyVkVLC1MCMogVWQaKH/ZtjPQdOW9c3X128o5lVpFYNsq/l3Qo1pV7sfTmvDzWEXR3QTxg1TMy1pyaAQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "15.0.13",
@@ -40238,6 +40268,22 @@
     "binary-extensions": {
       "version": "2.2.0",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bip66": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+      "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "bl": {
       "version": "4.1.0",
@@ -41233,7 +41279,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -42895,6 +42940,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
       "version": "3.6.1",
@@ -45554,6 +45604,11 @@
     "mute-stream": {
       "version": "0.0.8",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
       "version": "3.1.20",
@@ -49741,6 +49796,25 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
+    },
+    "tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        }
+      }
     },
     "tmp": {
       "version": "0.0.33",

--- a/packages/jellyfish-crypto/README.md
+++ b/packages/jellyfish-crypto/README.md
@@ -1,0 +1,6 @@
+[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-crypto)](https://www.npmjs.com/package/@defichain/jellyfish-crypto/v/latest)
+[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-crypto/next)](https://www.npmjs.com/package/@defichain/jellyfish-crypto/v/next)
+
+# @defichain/jellyfish-crypto
+
+Cryptography operations for jellyfish, includes a simple `secp256k1` `EllipticPair`.

--- a/packages/jellyfish-crypto/__tests__/elliptic.test.ts
+++ b/packages/jellyfish-crypto/__tests__/elliptic.test.ts
@@ -1,0 +1,139 @@
+import { getEllipticPairFromPrivateKey } from '../src'
+
+// Test vector taken from https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
+
+it('should return privateKey from getEllipticPairFromPrivateKey ', async () => {
+  const privateKeyHex = 'bbc27228ddcb9209d7fd6f36b02f7dfa6252af40bb2f1cbc7a557da8027ff866'
+  const privateKey = Buffer.from(privateKeyHex, 'hex')
+  const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+  const getPrivKey: Buffer = await curvePair.privateKey()
+  expect(getPrivKey.toString('hex')).toBe(privateKeyHex)
+})
+
+describe('keypair', () => {
+  const privateKeyHex = '619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9'
+  const publicKeyHex = '025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357'
+
+  it('should return publicKey from getEllipticPairFromPrivateKey', async () => {
+    const privateKey = Buffer.from(privateKeyHex, 'hex')
+    const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+    const getPubKey: Buffer = await curvePair.publicKey()
+    expect(getPubKey.toString('hex')).toBe(publicKeyHex)
+  })
+
+  it('should return privateKey from getEllipticPairFromPrivateKey ', async () => {
+    const privateKey = Buffer.from(privateKeyHex, 'hex')
+    const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+    const getPrivKey: Buffer = await curvePair.privateKey()
+    expect(getPrivKey.toString('hex')).toBe(privateKeyHex)
+  })
+})
+
+describe('DER Signature: sign and verify', () => {
+  async function shouldReturnPubKeyFromPubKey (privateKeyHex: string, publicKeyHex: string): Promise<void> {
+    const privateKey = Buffer.from(privateKeyHex, 'hex')
+    const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+    const getPubKey: Buffer = await curvePair.publicKey()
+    expect(getPubKey.toString('hex')).toBe(publicKeyHex)
+  }
+
+  async function shouldSignHashBufferGetSignature (privateKeyHex: string, hashHex: string, signatureHex: string): Promise<void> {
+    const privateKey = Buffer.from(privateKeyHex, 'hex')
+    const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+    const hash = Buffer.from(hashHex, 'hex')
+    const signature = await curvePair.sign(hash)
+    expect(signature.toString('hex')).toBe(signatureHex)
+  }
+
+  async function shouldVerifyHashWithSignature (privateKeyHex: string, hashHex: string, signatureHex: string): Promise<void> {
+    const privateKey = Buffer.from(privateKeyHex, 'hex')
+    const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+    const hash = Buffer.from(hashHex, 'hex')
+    const signature = Buffer.from(signatureHex, 'hex')
+
+    const isValid = await curvePair.verify(hash, signature)
+    expect(isValid).toBe(true)
+  }
+
+  describe('30 44<0220<>0220<>> 1', () => {
+    const privateKeyHex = '619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9'
+    const publicKeyHex = '025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357'
+    const hashHex = 'c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670'
+    const signatureHex = '304402203609e17b84f6a7d30c80bfa610b5b4542f32a8a0d5447a12fb1366d7f01cc44a0220573a954c4518331561406f90300e8f3358f51928d43c212a8caed02de67eebee'
+
+    it('should return publicKey from privateKey', async () => {
+      return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
+    })
+
+    it('should sign hash Buffer and get signature', async () => {
+      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    })
+
+    it('should verify hash with signature', async () => {
+      return await shouldVerifyHashWithSignature(privateKeyHex, hashHex, signatureHex)
+    })
+  })
+
+  describe('30 44<0220<>0220<>> 2', () => {
+    const privateKeyHex = 'f52b3484edd96598e02a9c89c4492e9c1e2031f471c49fd721fe68b3ce37780d'
+    const publicKeyHex = '0392972e2eb617b2388771abe27235fd5ac44af8e61693261550447a4c3e39da98'
+    const hashHex = 'cd72f1f1a433ee9df816857fad88d8ebd97e09a75cd481583eb841c330275e54'
+    const signatureHex = '30440220032521802a76ad7bf74d0e2c218b72cf0cbc867066e2e53db905ba37f130397e02207709e2188ed7f08f4c952d9d13986da504502b8c3be59617e043552f506c46ff'
+
+    it('should return publicKey from privateKey', async () => {
+      return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
+    })
+
+    it('should sign hash Buffer and get signature', async () => {
+      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    })
+
+    it('should verify hash with signature', async () => {
+      return await shouldVerifyHashWithSignature(privateKeyHex, hashHex, signatureHex)
+    })
+  })
+
+  describe('30 45<0221<>0220<>> 1', () => {
+    const privateKeyHex = 'f52b3484edd96598e02a9c89c4492e9c1e2031f471c49fd721fe68b3ce37780d'
+    const publicKeyHex = '0392972e2eb617b2388771abe27235fd5ac44af8e61693261550447a4c3e39da98'
+    const hashHex = 'e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a'
+    const signatureHex = '3045022100f6a10b8604e6dc910194b79ccfc93e1bc0ec7c03453caaa8987f7d6c3413566002206216229ede9b4d6ec2d325be245c5b508ff0339bf1794078e20bfe0babc7ffe6'
+
+    it('should return publicKey from privateKey', async () => {
+      return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
+    })
+
+    it('should sign hash Buffer and get signature', async () => {
+      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    })
+
+    it('should verify hash with signature', async () => {
+      return await shouldVerifyHashWithSignature(privateKeyHex, hashHex, signatureHex)
+    })
+  })
+
+  describe('30 45<0221<>0220<>> 2', () => {
+    const privateKeyHex = 'f52b3484edd96598e02a9c89c4492e9c1e2031f471c49fd721fe68b3ce37780d'
+    const publicKeyHex = '0392972e2eb617b2388771abe27235fd5ac44af8e61693261550447a4c3e39da98'
+    const hashHex = 'e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a'
+    const signatureHex = '3045022100f6a10b8604e6dc910194b79ccfc93e1bc0ec7c03453caaa8987f7d6c3413566002206216229ede9b4d6ec2d325be245c5b508ff0339bf1794078e20bfe0babc7ffe6'
+
+    it('should return publicKey from privateKey', async () => {
+      return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
+    })
+
+    it('should sign hash Buffer and get signature', async () => {
+      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    })
+
+    it('should verify hash with signature', async () => {
+      return await shouldVerifyHashWithSignature(privateKeyHex, hashHex, signatureHex)
+    })
+  })
+})

--- a/packages/jellyfish-crypto/__tests__/hash.test.ts
+++ b/packages/jellyfish-crypto/__tests__/hash.test.ts
@@ -1,0 +1,19 @@
+import { dSHA256, HASH160, SHA256 } from '../src'
+
+it('should sha256 with SHA256', () => {
+  const buffer = Buffer.from('56210307b8ae49ac90a048e9b53357a2354b3334e9c8bee813ecb98e99a7e07e8c3ba32103b28f0c28bfab54554ae8c658ac5c3e0ce6e79ad336331f78c428dd43eea8449b21034b8113d703413d57761b8b9781957b8c0ac1dfe69f492580ca4195f50376ba4a21033400f6afecb833092a9a21cfdf1ed1376e58c5d1f47de74683123987e967a8f42103a6d48b1131e94ba04d9737d61acdaa1322008af9602b3b14862c07a1789aac162102d8b661b0b3302ee2f162b09e07a55ad5dfbe673a9f01d9f0c19617681024306b56ae', 'hex')
+  const hashed = SHA256(buffer)
+  expect(hashed.toString('hex')).toBe('a16b5755f7f6f96dbd65f5f0d6ab9418b89af4b1f14a1bb8a09062c35f0dcb54')
+})
+
+it('should sha256(rmd160) with HASH160', () => {
+  const buffer = Buffer.from('025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357', 'hex')
+  const hashed = HASH160(buffer)
+  expect(hashed.toString('hex')).toBe('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1')
+})
+
+it('should double sha256 with dSHA256', () => {
+  const buffer = Buffer.from('eeffffffffffffff', 'hex')
+  const hashed = dSHA256(buffer)
+  expect(hashed.toString('hex')).toBe('52b0a642eea2fb7ae638c36f6252b6750293dbe574a806984b8e4d8548339a3b')
+})

--- a/packages/jellyfish-crypto/jest.config.js
+++ b/packages/jellyfish-crypto/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: [
+    '**/__tests__/**/*.test.ts'
+  ],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  verbose: true,
+  clearMocks: true,
+  testTimeout: 120000
+}

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -37,12 +37,13 @@
     "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
+    "bip66": "^1.1.5",
     "create-hash": "^1.2.0",
-    "elliptic": "^6.5.4"
+    "tiny-secp256k1": "^1.1.6"
   },
   "devDependencies": {
     "@types/create-hash": "^1.2.2",
-    "@types/elliptic": "^6.4.12",
+    "@types/tiny-secp256k1": "^1.0.0",
     "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -1,0 +1,48 @@
+{
+  "private": false,
+  "name": "@defichain/jellyfish-crypto",
+  "version": "0.0.0",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFi Blockchain developers to build decentralized finance on Bitcoin",
+  "keywords": [
+    "DeFiChain",
+    "DeFi",
+    "Blockchain",
+    "API",
+    "Bitcoin"
+  ],
+  "repository": "DeFiCh/jellyfish",
+  "bugs": "https://github.com/DeFiCh/jellyfish/issues",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "DeFiChain Foundation",
+      "email": "engineering@defichain.com",
+      "url": "https://defichain.com/"
+    },
+    {
+      "name": "DeFi Blockchain Contributors"
+    },
+    {
+      "name": "DeFi Jellyfish Contributors"
+    }
+  ],
+  "main": "dist",
+  "types": "dist",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "publish:next": "npm publish --tag next --access public",
+    "publish:latest": "npm publish --tag latest --access public"
+  },
+  "dependencies": {
+    "create-hash": "^1.2.0",
+    "elliptic": "^6.5.4"
+  },
+  "devDependencies": {
+    "@types/create-hash": "^1.2.2",
+    "@types/elliptic": "^6.4.12",
+    "typescript": ">=4.2.0"
+  }
+}

--- a/packages/jellyfish-crypto/src/bip66.d.ts
+++ b/packages/jellyfish-crypto/src/bip66.d.ts
@@ -1,0 +1,7 @@
+declare module 'bip66' {
+  export function check (buffer: Buffer): boolean
+
+  export function decode (buffer: Buffer): { r: Buffer, s: Buffer }
+
+  export function encode (r: Buffer, s: Buffer): Buffer
+}

--- a/packages/jellyfish-crypto/src/bip66.d.ts
+++ b/packages/jellyfish-crypto/src/bip66.d.ts
@@ -1,3 +1,6 @@
+/**
+ * No DefinitelyTyped declarations found, declaring our own here.
+ */
 declare module 'bip66' {
   export function check (buffer: Buffer): boolean
 

--- a/packages/jellyfish-crypto/src/der.ts
+++ b/packages/jellyfish-crypto/src/der.ts
@@ -1,0 +1,62 @@
+import bip66 from 'bip66'
+
+/**
+ * Distinguished Encoding Rules (DER) Signatures
+ *
+ * The MIT License (MIT)
+ * Copyright (c) 2011-2020 bitcoinjs-lib contributors
+ *
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
+ * @see https://github.com/bitcoinjs/bitcoinjs-lib/blob/master/ts_src/script_signature.ts
+ */
+export const DERSignature = {
+  /**
+   * @param signature to encode into DER Signature
+   */
+  encode (signature: Buffer): Buffer {
+    const r = DER.to(signature.slice(0, 32))
+    const s = DER.to(signature.slice(32, 64))
+    return bip66.encode(r, s)
+  },
+  /**
+   * @param derSignature to decode
+   */
+  decode (derSignature: Buffer): Buffer {
+    const { r, s } = bip66.decode(derSignature)
+    return Buffer.concat([
+      DER.from(r),
+      DER.from(s)
+    ], 64)
+  }
+}
+
+const DER = {
+  to (buffer: Buffer): Buffer {
+    let i = 0
+    while (buffer[i] === 0) ++i
+
+    if (i === buffer.length) {
+      return Buffer.alloc(1, 0)
+    }
+
+    buffer = buffer.slice(i)
+    if ((buffer[0] & 0x80) !== 0) {
+      return Buffer.concat([
+        Buffer.alloc(1, 0),
+        buffer
+      ], 1 + buffer.length)
+    }
+    return buffer
+  },
+
+  from (der: Buffer): Buffer {
+    if (der[0] === 0x00) {
+      der = der.slice(1)
+    }
+
+    const buffer = Buffer.alloc(32, 0)
+    const copyStart = Math.max(0, 32 - der.length)
+    der.copy(buffer, copyStart)
+    return buffer
+  }
+}

--- a/packages/jellyfish-crypto/src/elliptic.ts
+++ b/packages/jellyfish-crypto/src/elliptic.ts
@@ -1,0 +1,71 @@
+import ecc from 'tiny-secp256k1'
+import { DERSignature } from './der'
+
+/**
+ * Provides the interface for an elliptic curve pair to sign and verify hash.
+ * This interface is Promise based to allow async operations, this is required for hardware or network based elliptic
+ * curve operation. Everything must be implemented in little endian because DeFi Blockchain uses LE.
+ *
+ * Signature must be encoded with Distinguished Encoding Rules.
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0066.mediawiki
+ */
+export interface EllipticPair {
+  publicKey: () => Promise<Buffer>
+  privateKey: () => Promise<Buffer>
+
+  /**
+   * @param hash to sign
+   * @return signature of signed hash in DER
+   */
+  sign: (hash: Buffer) => Promise<Buffer>
+
+  /**
+   * @param hash to verify with signature
+   * @param derSignature of the hash in encoded with Distinguished Encoding Rules, SIGHASHTYPE must not be included
+   * @return validity of signature of the hash
+   */
+  verify: (hash: Buffer, derSignature: Buffer) => Promise<boolean>
+}
+
+/**
+ * Wraps secp256k1 from 'tiny-secp256k1' & 'bip66'
+ */
+class SECP256K1 implements EllipticPair {
+  private readonly privKey: Buffer
+  private readonly pubKey: Buffer
+
+  constructor (privKey: Buffer) {
+    this.privKey = privKey
+    const pubKey = ecc.pointFromScalar(privKey, true)
+    if (pubKey === null) {
+      throw new Error('point at infinity')
+    }
+    this.pubKey = pubKey
+  }
+
+  async privateKey (): Promise<Buffer> {
+    return this.privKey
+  }
+
+  async publicKey (): Promise<Buffer> {
+    return this.pubKey
+  }
+
+  async sign (hash: Buffer): Promise<Buffer> {
+    const signature = ecc.sign(hash, this.privKey)
+    return DERSignature.encode(signature)
+  }
+
+  async verify (hash: Buffer, derSignature: Buffer): Promise<boolean> {
+    const signature = DERSignature.decode(derSignature)
+    return ecc.verify(hash, this.pubKey, signature)
+  }
+}
+
+/**
+ * @param buffer in little endian
+ * @return SECP256K1 EllipticPair
+ */
+export function getEllipticPairFromPrivateKey (buffer: Buffer): EllipticPair {
+  return new SECP256K1(buffer)
+}

--- a/packages/jellyfish-crypto/src/hash.ts
+++ b/packages/jellyfish-crypto/src/hash.ts
@@ -1,0 +1,29 @@
+import createHash from 'create-hash'
+
+/**
+ * @param buffer to RIPEMD160(buffer)
+ */
+export function RIPEMD160 (buffer: Buffer): Buffer {
+  return createHash('rmd160').update(buffer).digest()
+}
+
+/**
+ * @param buffer to SHA256(buffer)
+ */
+export function SHA256 (buffer: Buffer): Buffer {
+  return createHash('sha256').update(buffer).digest()
+}
+
+/**
+ * @param buffer to RIPEMD160(SHA256(buffer))
+ */
+export function HASH160 (buffer: Buffer): Buffer {
+  return RIPEMD160(SHA256(buffer))
+}
+
+/**
+ * @param buffer to SHA256(SHA256(buffer))
+ */
+export function dSHA256 (buffer: Buffer): Buffer {
+  return SHA256(SHA256(buffer))
+}

--- a/packages/jellyfish-crypto/src/index.ts
+++ b/packages/jellyfish-crypto/src/index.ts
@@ -1,0 +1,1 @@
+export * from './hash'

--- a/packages/jellyfish-crypto/src/index.ts
+++ b/packages/jellyfish-crypto/src/index.ts
@@ -1,1 +1,3 @@
+export * from './der'
+export * from './elliptic'
 export * from './hash'

--- a/packages/jellyfish-crypto/tsconfig.json
+++ b/packages/jellyfish-crypto/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  }
+}


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

Created a new package `jellyfish-crypto`. 
- `hash.ts`
  - RIPEMD160
  - SHA256
  - HASH160
  - dSHA256
- DERSignature
   - encode
   - decode
- EllipticPair
   - SECP256K1

#### Additional comments:

1. SECP256K1 is non hd, mainly for testing or non hd node design. SECP256K1 interface will not be exported, internal only.
2. EllipticPair will be used for `wallet-core` package for HDNode
3. EllipticPair must generate DER Signature and SIGHASHTYPE must not be included