### PR TITLE
added acindex=1 and txindex=1 to reg_test_containers

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -2,6 +2,7 @@
   <dictionary name="fuxing">
     <words>
       <w>accounttoutxos</w>
+      <w>acindex</w>
       <w>amkheight</w>
       <w>anyonecanpay</w>
       <w>bayfrontgardensheight</w>
@@ -24,6 +25,7 @@
       <w>createmasternode</w>
       <w>currentblocktx</w>
       <w>currentblockweight</w>
+      <w>dakotacrescentheight</w>
       <w>dakotaheight</w>
       <w>debugexclude</w>
       <w>defi</w>
@@ -100,6 +102,7 @@
       <w>thedoublejay</w>
       <w>toaltstack</w>
       <w>txid</w>
+      <w>txindex</w>
       <w>txnotokens</w>
       <w>uacomment</w>
       <w>unpkg</w>

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -12,6 +12,8 @@ export class RegTestContainer extends DeFiDContainer {
       '-regtest=1',
       '-txnotokens=0',
       '-logtimemicros',
+      '-txindex=1',
+      '-acindex=1',
       '-amkheight=0',
       '-bayfrontheight=1',
       '-bayfrontgardensheight=2',


### PR DESCRIPTION
#### What kind of PR is this?:
/kind chore

#### What this PR does / why we need it:

Making testcontainers easier for testing, enabled these 2 flags.

- txindex
Maintain a full transaction index, used by the getrawtransaction rpc call
- acindex
Maintain a full account history index, tracking all accounts balances changes. Used by the listaccounthistory and accounthistorycount rpc calls

/cc @canonbrother