### PR TITLE
api-core to use named export instead of *

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/blockchain.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain.test.ts
@@ -1,7 +1,7 @@
 import { RegTestContainer, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../container_adapter_client'
 import waitForExpect from 'wait-for-expect'
-import { BigNumber, Block, Transaction } from '../../src'
+import { BigNumber, blockchain as bc } from '../../src'
 
 describe('non masternode', () => {
   const container = new RegTestContainer()
@@ -103,7 +103,7 @@ describe('masternode', () => {
 
     it('should getBlock with verbosity 1 and return block with tx as hex', async () => {
       const blockHash = await waitForBlockHash(1)
-      const block: Block<string> = await client.blockchain.getBlock(blockHash, 1)
+      const block: bc.Block<string> = await client.blockchain.getBlock(blockHash, 1)
 
       expect(block.hash.length).toBe(64)
 
@@ -139,7 +139,7 @@ describe('masternode', () => {
 
     it('should getBlock with verbosity 2 and return block with tx as RawText', async () => {
       const blockHash = await waitForBlockHash(1)
-      const block: Block<Transaction> = await client.blockchain.getBlock(blockHash, 2)
+      const block: bc.Block<bc.Transaction> = await client.blockchain.getBlock(blockHash, 2)
 
       expect(block.tx.length).toBeGreaterThanOrEqual(1)
       expect(block.tx[0].vin[0].coinbase).toStrictEqual('5100')

--- a/packages/jellyfish-api-core/__tests__/index.test.ts
+++ b/packages/jellyfish-api-core/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import { MintingInfo, ApiClient, ClientApiError } from '../src'
+import { mining, ApiClient, ClientApiError } from '../src'
 import { ContainerAdapterClient } from './container_adapter_client'
 import { RegTestContainer } from '@defichain/testcontainers'
 
@@ -17,7 +17,7 @@ it('should export client', async () => {
 it('should export categories', async () => {
   const client = new TestClient()
   await expect(async () => {
-    const info: MintingInfo = await client.mining.getMintingInfo()
+    const info: mining.MintingInfo = await client.mining.getMintingInfo()
     console.log(info)
   }).rejects.toThrowError(ClientApiError)
 })

--- a/packages/jellyfish-api-core/src/index.ts
+++ b/packages/jellyfish-api-core/src/index.ts
@@ -4,9 +4,9 @@ import { Mining } from './category/mining'
 import { Wallet } from './category/wallet'
 
 export * from '@defichain/jellyfish-json'
-export * from './category/blockchain'
-export * from './category/mining'
-export * from './category/wallet'
+export * as blockchain from './category/blockchain'
+export * as mining from './category/mining'
+export * as wallet from './category/wallet'
 
 /**
  * ApiClient; a protocol agnostic DeFiChain node client, RPC calls are separated into their category.


### PR DESCRIPTION
#### What kind of PR is this?:

/kind refactor

#### What this PR does / why we need it:

To prevent conflicts due to the massive amount of data to type, export should be named.

/cc @canonbrother might cause your pending PR to break, hence this should merge after #112 and then this PR should be updated.
