### PR TITLE
new testcontainers utils for raw tx QOL testing

### DIFF
--- a/packages/testcontainers/__tests__/chains/container.test.ts
+++ b/packages/testcontainers/__tests__/chains/container.test.ts
@@ -54,4 +54,12 @@ describe('container error handling', () => {
     await expect(container.waitForReady(100))
       .rejects.toThrow(/DeFiDContainer docker not ready within given timeout of/)
   })
+
+  it('should fail waitForCondition as condition is never valid', async () => {
+    container = new RegTestContainer()
+    await container.start()
+    await container.waitForReady()
+    return await expect(container.waitForCondition(async () => false, 3000))
+      .rejects.toThrow('waitForCondition is not ready within given timeout of 3000ms.')
+  })
 })

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -110,4 +110,53 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
   async waitForWalletCoinbaseMaturity (): Promise<void> {
     await this.generate(100)
   }
+
+  /**
+   * Wait for in wallet balance to be greater than an amount.
+   * This allow test that require fund to wait for fund to be filled up before running the tests.
+   *
+   * @param balance {number} to wait for in wallet to be greater than or equal
+   * @param timeout {number} default to 30000ms
+   * @see waitForWalletCoinbaseMaturity
+   */
+  async waitForWalletBalanceGTE (balance: number, timeout = 30000): Promise<void> {
+    return await this.waitForCondition(async () => {
+      const getbalance = await this.call('getbalance')
+      return getbalance >= balance
+    }, timeout)
+  }
+
+  /**
+   * Fund an address with an amount for testing.
+   * Funded address don't have to be tracked within the node wallet.
+   * This allow for light wallet implementation testing.
+   *
+   * Note, please use whole number as BigNumber is not used here.
+   *
+   * @param address {string} to fund
+   * @param amount {number} to fund address
+   * @return string txid of the transaction
+   * @see waitForWalletCoinbaseMaturity
+   * @see waitForWalletBalanceGTE
+   */
+  async fundAddress (address: string, amount: number): Promise<string> {
+    return await this.call('sendtoaddress', [address, amount])
+  }
+
+  /**
+   * Create a new bech32 address and get the associated priv key for it.
+   * The address is created in the wallet and the priv key is dumped out.
+   * This is to facilitate raw tx feature testing, if you need an address that is not associated with the wallet,
+   * use jellyfish-crypto instead.
+   *
+   * This is not a deterministic feature, each time you run this, you get a different set of address and priv key.
+   *
+   * @return {Promise<{ address: string, privKey: string }>} a new address and it's associated privKey
+   */
+  async newAddressAndPrivKey (): Promise<{ address: string, privKey: string }> {
+    const address = await this.call('getnewaddress', ['', 'bech32'])
+    const privKey = await this.call('dumpprivkey', [address])
+
+    return { address, privKey }
+  }
 }


### PR DESCRIPTION
#### What kind of PR is this?:

/kind feature

#### What this PR does / why we need it:

new testcontainers utils for better raw tx testing quality of life.

1. `container.waitForCondition(async () => false, 3000))`
2. `container.waitForWalletBalanceGTE(200)`
3. `container.fundAddress(address, 10)`
4. `const { address, privKey } = await container.newAddressAndPrivKey()`

This makes it easier to test condition that require balance, funded address, or priv key.

#### Additional comments:
Also added `{ v: true }` flag so that associated docker volumes get removed after the test.