### PR TITLE
fix fundAddress should wait confirmations

### DIFF
--- a/packages/testcontainers/__tests__/chains/reg_test_container/index.test.ts
+++ b/packages/testcontainers/__tests__/chains/reg_test_container/index.test.ts
@@ -1,4 +1,4 @@
-import { RegTestContainer } from '../../src'
+import { RegTestContainer } from '../../../src'
 
 describe('regtest', () => {
   const container = new RegTestContainer()

--- a/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
+++ b/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
@@ -69,7 +69,7 @@ describe('coinbase maturity', () => {
     const privKey = 'cPuytfxySwc9RVrFpqQ9xheZ6jCmJD6pEe3XUPvev5hBwheivH5C'
     await container.waitForWalletBalanceGTE(100)
 
-    const { txid, index } = await container.fundAddress(address, 10)
+    const { txid, vout } = await container.fundAddress(address, 10)
     await container.call('importprivkey', [privKey])
     return await waitForExpect(async () => {
       const unspent = await container.call('listunspent', [
@@ -77,7 +77,7 @@ describe('coinbase maturity', () => {
       ])
 
       expect(unspent[0].txid).toBe(txid)
-      expect(unspent[0].vout).toBe(index)
+      expect(unspent[0].vout).toBe(vout)
       expect(unspent[0].address).toBe(address)
       expect(unspent[0].amount).toBe(10)
 

--- a/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
+++ b/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
@@ -1,4 +1,4 @@
-import { MasterNodeRegTestContainer } from '../../src'
+import { MasterNodeRegTestContainer } from '../../../src'
 import waitForExpect from 'wait-for-expect'
 
 describe('masternode', () => {
@@ -85,13 +85,16 @@ describe('coinbase maturity', () => {
     })
   })
 
-  it('should be able to get new address and priv key for testing', async () => {
-    const { address, privKey } = await container.newAddressAndPrivKey()
+  it('should be able to get new address and priv/pub key for testing', async () => {
+    const { address, privKey, pubKey } = await container.newAddressKeys()
     await container.waitForWalletBalanceGTE(10)
     const txid = await container.fundAddress(address, 1)
 
     const dumpprivkey = await container.call('dumpprivkey', [address])
     expect(dumpprivkey).toBe(privKey)
+
+    const getaddressinfo = await container.call('getaddressinfo', [address])
+    expect(getaddressinfo.pubkey).toBe(pubKey)
 
     return await waitForExpect(async () => {
       const unspent = await container.call('listunspent', [

--- a/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
+++ b/packages/testcontainers/__tests__/chains/reg_test_container/masternode.test.ts
@@ -69,7 +69,7 @@ describe('coinbase maturity', () => {
     const privKey = 'cPuytfxySwc9RVrFpqQ9xheZ6jCmJD6pEe3XUPvev5hBwheivH5C'
     await container.waitForWalletBalanceGTE(100)
 
-    const txid = await container.fundAddress(address, 10)
+    const { txid, index } = await container.fundAddress(address, 10)
     await container.call('importprivkey', [privKey])
     return await waitForExpect(async () => {
       const unspent = await container.call('listunspent', [
@@ -77,6 +77,7 @@ describe('coinbase maturity', () => {
       ])
 
       expect(unspent[0].txid).toBe(txid)
+      expect(unspent[0].vout).toBe(index)
       expect(unspent[0].address).toBe(address)
       expect(unspent[0].amount).toBe(10)
 
@@ -88,7 +89,7 @@ describe('coinbase maturity', () => {
   it('should be able to get new address and priv/pub key for testing', async () => {
     const { address, privKey, pubKey } = await container.newAddressKeys()
     await container.waitForWalletBalanceGTE(10)
-    const txid = await container.fundAddress(address, 1)
+    const { txid } = await container.fundAddress(address, 1)
 
     const dumpprivkey = await container.call('dumpprivkey', [address])
     expect(dumpprivkey).toBe(privKey)

--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -242,7 +242,8 @@ export abstract class DeFiDContainer {
   }
 
   /**
-   * Wait for rpc to be ready, default to 15000ms
+   * Wait for rpc to be ready
+   * @param {number} timeout duration, default to 15000ms
    */
   private async waitForRpc (timeout = 15000): Promise<void> {
     const expiredAt = Date.now() + timeout
@@ -266,8 +267,8 @@ export abstract class DeFiDContainer {
   }
 
   /**
-   * @param condition {() => Promise<boolean>} to wait for true
-   * @param timeout {number} duration to timeout when condition is not met
+   * @param {() => Promise<boolean>} condition to wait for true
+   * @param {number} timeout duration when condition is not met
    */
   async waitForCondition (condition: () => Promise<boolean>, timeout: number): Promise<void> {
     const expiredAt = Date.now() + timeout
@@ -290,6 +291,7 @@ export abstract class DeFiDContainer {
 
   /**
    * Wait for everything to be ready, override for additional hooks
+   * @param {number} timeout duration, default to 15000ms
    */
   async waitForReady (timeout = 15000): Promise<void> {
     return await this.waitForRpc(timeout)

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -117,8 +117,8 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    * Wait for in wallet balance to be greater than an amount.
    * This allow test that require fund to wait for fund to be filled up before running the tests.
    *
-   * @param balance {number} to wait for in wallet to be greater than or equal
-   * @param timeout {number} default to 30000ms
+   * @param {number} balance to wait for in wallet to be greater than or equal
+   * @param {number} timeout default to 30000ms
    * @see waitForWalletCoinbaseMaturity
    */
   async waitForWalletBalanceGTE (balance: number, timeout = 30000): Promise<void> {
@@ -131,24 +131,37 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
   /**
    * Fund an address with an amount and wait for 1 confirmation.
    * Funded address don't have to be tracked within the node wallet.
-   * This allow for light wallet implementation testing.
+   * This allows for light wallet implementation testing.
    *
-   * Note, please use whole number as BigNumber is not used here.
-   *
-   * @param address {string} to fund
-   * @param amount {number} to fund address
-   * @return string txid of the transaction
+   * @param {string} address to fund
+   * @param {number} amount to fund an address, take note of number precision issues, BigNumber not included in pkg.
+   * @return {Promise<{txid: string, index: number}>} txid and index of the transaction
    * @see waitForWalletCoinbaseMaturity
    * @see waitForWalletBalanceGTE
    */
-  async fundAddress (address: string, amount: number): Promise<string> {
+  async fundAddress (address: string, amount: number): Promise<{ txid: string, index: number }> {
     const txid = await this.call('sendtoaddress', [address, amount])
 
     await this.waitForCondition(async () => {
       const { confirmations } = await this.call('gettxout', [txid, 0, true])
       return confirmations > 0
     }, 10000)
-    return txid
+
+    const { vout }: {
+      vout: Array<{
+        n: number
+        scriptPubKey: {
+          addresses: string[]
+        }
+      }>
+    } = await this.call('getrawtransaction', [txid, true])
+    for (const out of vout) {
+      if (out.scriptPubKey.addresses.includes(address)) {
+        return { txid, index: out.n }
+      }
+    }
+
+    throw new Error('getrawtransaction will always return the required vout')
   }
 
   /**
@@ -157,7 +170,7 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    * This is to facilitate raw tx feature testing, if you need an address that is not associated with the wallet,
    * use jellyfish-crypto instead.
    *
-   * This is not a deterministic feature, each time you run this, you get a different set of address and priv key.
+   * This is not a deterministic feature, each time you run this, you get a different set of address and keys.
    *
    * @return {Promise<{ address: string, privKey: string, pubKey: string }>} a new address and it's associated privKey
    */

--- a/packages/testcontainers/src/chains/reg_test_container.ts
+++ b/packages/testcontainers/src/chains/reg_test_container.ts
@@ -135,11 +135,11 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    *
    * @param {string} address to fund
    * @param {number} amount to fund an address, take note of number precision issues, BigNumber not included in pkg.
-   * @return {Promise<{txid: string, index: number}>} txid and index of the transaction
+   * @return {Promise<{txid: string, vout: number}>} txid and index of the transaction
    * @see waitForWalletCoinbaseMaturity
    * @see waitForWalletBalanceGTE
    */
-  async fundAddress (address: string, amount: number): Promise<{ txid: string, index: number }> {
+  async fundAddress (address: string, amount: number): Promise<{ txid: string, vout: number }> {
     const txid = await this.call('sendtoaddress', [address, amount])
 
     await this.waitForCondition(async () => {
@@ -157,7 +157,7 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
     } = await this.call('getrawtransaction', [txid, true])
     for (const out of vout) {
       if (out.scriptPubKey.addresses.includes(address)) {
-        return { txid, index: out.n }
+        return { txid, vout: out.n }
       }
     }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
/kind fix

#### What this PR does / why we need it:

1. fundAddress implies it's funding an address for use, it should wait for confirmations
2. refactor newAddressAndPrivKey to newAddressKeys as it return both pub/priv for better testing OOL