### PR TITLE
added bech32 & wif into jellyfish-crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13230,6 +13230,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/wif": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/wif/-/wif-2.0.2.tgz",
+      "integrity": "sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "15.0.13",
       "dev": true,
@@ -14075,8 +14084,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "dev": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -14329,6 +14336,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/bser": {
@@ -28749,6 +28774,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "dependencies": {
+        "bs58check": "<3.0.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "dev": true,
@@ -29068,11 +29101,13 @@
       "dependencies": {
         "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
-        "tiny-secp256k1": "^1.1.6"
+        "tiny-secp256k1": "^1.1.6",
+        "wif": "^2.0.6"
       },
       "devDependencies": {
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
+        "@types/wif": "^2.0.2",
         "typescript": ">=4.2.0"
       }
     },
@@ -30308,10 +30343,12 @@
       "requires": {
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
+        "@types/wif": "^2.0.2",
         "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
         "tiny-secp256k1": "^1.1.6",
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.2.0",
+        "wif": "^2.0.6"
       }
     },
     "@defichain/jellyfish-json": {
@@ -39684,6 +39721,15 @@
         "@types/node": "*"
       }
     },
+    "@types/wif": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/wif/-/wif-2.0.2.tgz",
+      "integrity": "sha512-IiIuBeJzlh4LWJ7kVTrX0nwB60OG0vvGTaWC/SgSbVFw7uYUTF6gEuvDZ1goWkeirekJDD58Y8g7NljQh2fNkA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "15.0.13",
       "dev": true,
@@ -40245,8 +40291,6 @@
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-      "dev": true,
-      "peer": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -40430,6 +40474,24 @@
       "dev": true,
       "requires": {
         "fast-json-stable-stringify": "2.x"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "requires": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
       }
     },
     "bser": {
@@ -50697,6 +50759,14 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=",
+      "requires": {
+        "bs58check": "<3.0.0"
       }
     },
     "word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13085,6 +13085,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/bech32": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/bech32/-/bech32-1.1.2.tgz",
+      "integrity": "sha512-D2tG6kfIcZD3pjtnnvGrwiZiz+HGBsoy0pdGlpBeMbhlKJ4l4r1zB8SEQPL790kTdSS8lhyC/w9API7L2YBOxw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -14123,6 +14132,11 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/before-after-hook": {
       "version": "2.2.0",
@@ -29099,12 +29113,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "bech32": "^2.0.0",
         "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
         "tiny-secp256k1": "^1.1.6",
         "wif": "^2.0.6"
       },
       "devDependencies": {
+        "@types/bech32": "^1.1.2",
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
         "@types/wif": "^2.0.2",
@@ -30341,9 +30357,11 @@
     "@defichain/jellyfish-crypto": {
       "version": "file:packages/jellyfish-crypto",
       "requires": {
+        "@types/bech32": "^1.1.2",
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
         "@types/wif": "^2.0.2",
+        "bech32": "^2.0.0",
         "bip66": "^1.1.5",
         "create-hash": "^1.2.0",
         "tiny-secp256k1": "^1.1.6",
@@ -39592,6 +39610,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bech32": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/bech32/-/bech32-1.1.2.tgz",
+      "integrity": "sha512-D2tG6kfIcZD3pjtnnvGrwiZiz+HGBsoy0pdGlpBeMbhlKJ4l4r1zB8SEQPL790kTdSS8lhyC/w9API7L2YBOxw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/create-hash": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
@@ -40303,6 +40330,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "before-after-hook": {
       "version": "2.2.0",

--- a/packages/jellyfish-crypto/__tests__/bech32.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bech32.test.ts
@@ -1,0 +1,41 @@
+import { fromBech32, toBech32 } from '../src/bech32'
+import { HASH160 } from '../src'
+
+const hrp = 'bcrt'
+const bech32 = 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn'
+const pubKey = '03987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe81'
+
+it('should convert bech32 to pubkey', () => {
+  const buffer: Buffer = fromBech32(bech32)
+  const hash160 = HASH160(Buffer.from(pubKey, 'hex'))
+  expect(buffer.toString('hex')).toBe(hash160.toString('hex'))
+})
+
+it('should convert bech32 to pubkey with hrp and version', () => {
+  const buffer: Buffer = fromBech32(bech32, 'bcrt', 0x00)
+  const hash160 = HASH160(Buffer.from(pubKey, 'hex'))
+  expect(buffer.toString('hex')).toBe(hash160.toString('hex'))
+})
+
+it('should fail convert bech32 to pubkey with invalid hrp', () => {
+  expect(() => {
+    fromBech32(bech32, 'tf', 0x00)
+  }).toThrow('Invalid HRP: human readable part')
+})
+
+it('should fail convert bech32 to pubkey with invalid version', () => {
+  expect(() => {
+    // @ts-expect-error
+    fromBech32(bech32, 'bcrt', 0x01)
+  }).toThrow('Invalid witness version')
+})
+
+it('should convert pubkey to bech32', () => {
+  const bech32 = toBech32(Buffer.from(pubKey, 'hex'), hrp)
+  expect(bech32).toBe(bech32)
+})
+
+it('should convert pubkey to bech32 with witness version', () => {
+  const bech32 = toBech32(Buffer.from(pubKey, 'hex'), hrp, 0x00)
+  expect(bech32).toBe(bech32)
+})

--- a/packages/jellyfish-crypto/__tests__/elliptic.test.ts
+++ b/packages/jellyfish-crypto/__tests__/elliptic.test.ts
@@ -109,8 +109,13 @@ describe('DER Signature: sign and verify', () => {
       return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
     })
 
-    it('should sign hash Buffer and get signature', async () => {
-      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    it('should sign hash Buffer and verify signature', async () => {
+      const privateKey = Buffer.from(privateKeyHex, 'hex')
+      const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+      const hash = Buffer.from(hashHex, 'hex')
+      const signature = await curvePair.sign(hash)
+      expect(curvePair.verify(hash, signature)).toBeTruthy()
     })
 
     it('should verify hash with signature', async () => {
@@ -128,8 +133,13 @@ describe('DER Signature: sign and verify', () => {
       return await shouldReturnPubKeyFromPubKey(privateKeyHex, publicKeyHex)
     })
 
-    it('should sign hash Buffer and get signature', async () => {
-      return await shouldSignHashBufferGetSignature(privateKeyHex, hashHex, signatureHex)
+    it('should sign hash Buffer and verify signature', async () => {
+      const privateKey = Buffer.from(privateKeyHex, 'hex')
+      const curvePair = getEllipticPairFromPrivateKey(privateKey)
+
+      const hash = Buffer.from(hashHex, 'hex')
+      const signature = await curvePair.sign(hash)
+      expect(curvePair.verify(hash, signature)).toBeTruthy()
     })
 
     it('should verify hash with signature', async () => {

--- a/packages/jellyfish-crypto/__tests__/wif.test.ts
+++ b/packages/jellyfish-crypto/__tests__/wif.test.ts
@@ -1,0 +1,37 @@
+import { encode, decode, decodeAsEllipticPair } from '../src'
+
+const REG_TEST_WIF = 'cQSsfYvYkK5tx3u1ByK2ywTTc9xJrREc1dd67ZrJqJUEMwgktPWN'
+const privKey = '557c4bdff86e59015987c1c7f3328a1fb4c2177b5e834f09c8cd10fae51af93b'
+
+it('should decode without version', () => {
+  const decoded = decode(REG_TEST_WIF)
+
+  expect(decoded.version).toBe(0xef)
+  expect(decoded.compressed).toBe(true)
+  expect(decoded.privateKey.toString('hex')).toBe(privKey)
+})
+
+it('should decode with failed version', () => {
+  expect(() => {
+    decode(REG_TEST_WIF, 0x80)
+  }).toThrow('Invalid network version')
+})
+
+it('should decode with correct version', () => {
+  const decoded = decode(REG_TEST_WIF, 0xef)
+
+  expect(decoded.version).toBe(0xef)
+  expect(decoded.compressed).toBe(true)
+  expect(decoded.privateKey.toString('hex')).toBe(privKey)
+})
+
+it('should decode decodeAsEllipticPair', async () => {
+  const pair = decodeAsEllipticPair(REG_TEST_WIF, 0xef)
+  const key = await pair.privateKey()
+  expect(key.toString('hex')).toBe(privKey)
+})
+
+it('should encode', () => {
+  const wif = encode(0xef, Buffer.from(privKey, 'hex'))
+  expect(wif).toBe(REG_TEST_WIF)
+})

--- a/packages/jellyfish-crypto/__tests__/wif.test.ts
+++ b/packages/jellyfish-crypto/__tests__/wif.test.ts
@@ -2,6 +2,7 @@ import { encode, decode, decodeAsEllipticPair } from '../src'
 
 const REG_TEST_WIF = 'cQSsfYvYkK5tx3u1ByK2ywTTc9xJrREc1dd67ZrJqJUEMwgktPWN'
 const privKey = '557c4bdff86e59015987c1c7f3328a1fb4c2177b5e834f09c8cd10fae51af93b'
+const pubKey = '03987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe81'
 
 it('should decode without version', () => {
   const decoded = decode(REG_TEST_WIF)
@@ -27,8 +28,10 @@ it('should decode with correct version', () => {
 
 it('should decode decodeAsEllipticPair', async () => {
   const pair = decodeAsEllipticPair(REG_TEST_WIF, 0xef)
-  const key = await pair.privateKey()
-  expect(key.toString('hex')).toBe(privKey)
+  const privateKey = await pair.privateKey()
+  const publicKey = await pair.publicKey()
+  expect(privateKey.toString('hex')).toBe(privKey)
+  expect(publicKey.toString('hex')).toBe(pubKey)
 })
 
 it('should encode', () => {

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -39,11 +39,13 @@
   "dependencies": {
     "bip66": "^1.1.5",
     "create-hash": "^1.2.0",
-    "tiny-secp256k1": "^1.1.6"
+    "tiny-secp256k1": "^1.1.6",
+    "wif": "^2.0.6"
   },
   "devDependencies": {
     "@types/create-hash": "^1.2.2",
     "@types/tiny-secp256k1": "^1.0.0",
+    "@types/wif": "^2.0.2",
     "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -37,12 +37,14 @@
     "publish:latest": "npm publish --tag latest --access public"
   },
   "dependencies": {
+    "bech32": "^2.0.0",
     "bip66": "^1.1.5",
     "create-hash": "^1.2.0",
     "tiny-secp256k1": "^1.1.6",
     "wif": "^2.0.6"
   },
   "devDependencies": {
+    "@types/bech32": "^1.1.2",
     "@types/create-hash": "^1.2.2",
     "@types/tiny-secp256k1": "^1.0.0",
     "@types/wif": "^2.0.2",

--- a/packages/jellyfish-crypto/src/bech32.ts
+++ b/packages/jellyfish-crypto/src/bech32.ts
@@ -26,7 +26,7 @@ export function toBech32 (pubKey: Buffer, hrp: HRP, version: 0x00 = 0x00): strin
  * @param {string} address to decode from bech32
  * @param {'df'|'tf'|'bcrt'} hrp is the human readable part
  * @param {number} version witness version, OP_0
- * @return {Buffer} pubkey
+ * @return {Buffer} hash160 of the pubkey
  * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
  */
 export function fromBech32 (address: string, hrp?: HRP, version?: 0x00): Buffer {

--- a/packages/jellyfish-crypto/src/bech32.ts
+++ b/packages/jellyfish-crypto/src/bech32.ts
@@ -1,0 +1,44 @@
+import { bech32 } from 'bech32'
+import { SHA256 } from './hash'
+
+/**
+ * df   - DeFi MainNet
+ * tf   - DeFi TestNet
+ * bcrt - DeFi RegTest
+ */
+export type HRP = 'df' | 'tf' | 'bcrt'
+
+/**
+ * @param {Buffer} pubKey to format into bech32
+ * @param {'df'|'tf'|'bcrt'} hrp is the human readable part
+ * @param {number} version witness version, OP_0
+ * @return {string} bech32 encoded address
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ */
+export function toBech32 (pubKey: Buffer, hrp: HRP, version: 0x00 = 0x00): string {
+  const hash = SHA256(pubKey)
+  const words = bech32.toWords(hash)
+  words.unshift(version)
+  return bech32.encode(hrp, words)
+}
+
+/**
+ * @param {string} address to decode from bech32
+ * @param {'df'|'tf'|'bcrt'} hrp is the human readable part
+ * @param {number} version witness version, OP_0
+ * @return {Buffer} pubkey
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
+ */
+export function fromBech32 (address: string, hrp?: HRP, version?: 0x00): Buffer {
+  const { prefix, words } = bech32.decode(address)
+  if (hrp !== undefined && prefix !== hrp) {
+    throw new Error('Invalid HRP: human readable part')
+  }
+
+  const witnessVersion = words.splice(0, 1)[0]
+  if (version !== undefined && version !== witnessVersion) {
+    throw new Error('Invalid witness version')
+  }
+
+  return Buffer.from(bech32.fromWords(words))
+}

--- a/packages/jellyfish-crypto/src/bech32.ts
+++ b/packages/jellyfish-crypto/src/bech32.ts
@@ -2,6 +2,8 @@ import { bech32 } from 'bech32'
 import { SHA256 } from './hash'
 
 /**
+ * Human Readable Part, prefixed to all bech32/segwit native address
+ *
  * df   - DeFi MainNet
  * tf   - DeFi TestNet
  * bcrt - DeFi RegTest

--- a/packages/jellyfish-crypto/src/index.ts
+++ b/packages/jellyfish-crypto/src/index.ts
@@ -1,3 +1,4 @@
+export * from './bech32'
 export * from './der'
 export * from './elliptic'
 export * from './hash'

--- a/packages/jellyfish-crypto/src/index.ts
+++ b/packages/jellyfish-crypto/src/index.ts
@@ -1,3 +1,4 @@
 export * from './der'
 export * from './elliptic'
 export * from './hash'
+export * from './wif'

--- a/packages/jellyfish-crypto/src/wif.ts
+++ b/packages/jellyfish-crypto/src/wif.ts
@@ -1,0 +1,40 @@
+import wif from 'wif'
+import { EllipticPair, getEllipticPairFromPrivateKey } from './elliptic'
+
+interface DecodedWIF {
+  readonly version: number
+  readonly privateKey: Buffer
+  readonly compressed: boolean
+}
+
+/**
+ * @param {string} wifEncoded private key
+ * @param {number} version network to optionally validate
+ * @return DecodedWIF
+ * @throws Error invalid network version if version mismatch
+ */
+export function decode (wifEncoded: string, version?: number): DecodedWIF {
+  return wif.decode(wifEncoded, version)
+}
+
+/**
+ * Get a EllipticPair from WIF encoded private key
+ *
+ * @param {string} wifEncoded private key
+ * @param {number} version network to optionally validate
+ * @return EllipticPair
+ * @throws Error invalid network version if version mismatch
+ */
+export function decodeAsEllipticPair (wifEncoded: string, version?: number): EllipticPair {
+  const { privateKey } = decode(wifEncoded, version)
+  return getEllipticPairFromPrivateKey(privateKey)
+}
+
+/**
+ * @param {number} version network version to encoded WIF with
+ * @param {Buffer} privKey to encode
+ * @return {string} encoded WIF
+ */
+export function encode (version: number, privKey: Buffer): string {
+  return wif.encode(version, privKey, true)
+}


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:

Added WIF to jellyfish-crypto since it can be used to get a private key using secp256k1.
Added bech32 address `from` and `to` utils to jellyfish-crypto as it uses HASH160 function to encode addresses.