### PR TITLE
removed devDependencies.typescript from sub-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "size-limit": "^4.10.1",
     "ts-jest": "26.5.5",
     "ts-standard": "^10.0.0",
-    "typescript": ">=4.2.0",
+    "typescript": "4.2.3",
     "wait-for-expect": "^3.0.2"
   },
   "lint-staged": {

--- a/packages/jellyfish-api-core/package.json
+++ b/packages/jellyfish-api-core/package.json
@@ -38,7 +38,6 @@
     "@defichain/jellyfish-json": "0.0.0"
   },
   "devDependencies": {
-    "@defichain/testcontainers": "0.0.0",
-    "typescript": ">=4.2.0"
+    "@defichain/testcontainers": "0.0.0"
   }
 }

--- a/packages/jellyfish-api-jsonrpc/package.json
+++ b/packages/jellyfish-api-jsonrpc/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@defichain/testcontainers": "0.0.0",
-    "nock": "^13.0.11",
-    "typescript": ">=4.2.0"
+    "nock": "^13.0.11"
   }
 }

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -45,7 +45,6 @@
     "@types/bech32": "^1.1.2",
     "@types/create-hash": "^1.2.2",
     "@types/tiny-secp256k1": "^1.0.0",
-    "@types/wif": "^2.0.2",
-    "typescript": ">=4.2.0"
+    "@types/wif": "^2.0.2"
   }
 }

--- a/packages/jellyfish-json/package.json
+++ b/packages/jellyfish-json/package.json
@@ -41,7 +41,6 @@
     "lossless-json": "^1.0.4"
   },
   "devDependencies": {
-    "@types/lossless-json": "^1.0.0",
-    "typescript": ">=4.2.0"
+    "@types/lossless-json": "^1.0.0"
   }
 }

--- a/packages/jellyfish-network/package.json
+++ b/packages/jellyfish-network/package.json
@@ -33,8 +33,5 @@
   ],
   "scripts": {
     "build": "tsc"
-  },
-  "devDependencies": {
-    "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-transaction/package.json
+++ b/packages/jellyfish-transaction/package.json
@@ -40,8 +40,5 @@
   "dependencies": {
     "@defichain/jellyfish-crypto": "0.0.0",
     "smart-buffer": "^4.1.0"
-  },
-  "devDependencies": {
-    "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-wallet-mnemonic/package.json
+++ b/packages/jellyfish-wallet-mnemonic/package.json
@@ -39,8 +39,5 @@
     "@defichain/jellyfish-transaction": "0.0.0",
     "bip32": "^2.0.6",
     "bip39": "^3.0.3"
-  },
-  "devDependencies": {
-    "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-wallet-whale/package.json
+++ b/packages/jellyfish-wallet-whale/package.json
@@ -38,8 +38,5 @@
     "@defichain/jellyfish-crypto": "0.0.0",
     "@defichain/jellyfish-network": "0.0.0",
     "@defichain/jellyfish-wallet": "0.0.0"
-  },
-  "devDependencies": {
-    "typescript": ">=4.2.0"
   }
 }

--- a/packages/jellyfish-wallet/package.json
+++ b/packages/jellyfish-wallet/package.json
@@ -40,8 +40,5 @@
   "dependencies": {
     "@defichain/jellyfish-crypto": "0.0.0",
     "@defichain/jellyfish-transaction": "0.0.0"
-  },
-  "devDependencies": {
-    "typescript": ">=4.2.0"
   }
 }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@types/dockerode": "^3.2.2",
-    "@types/node-fetch": "^2.5.8",
-    "typescript": ">=4.2.0"
+    "@types/node-fetch": "^2.5.8"
   }
 }

--- a/packages/testcontainers/tsconfig.json
+++ b/packages/testcontainers/tsconfig.json
@@ -5,6 +5,6 @@
   ],
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "./src"
   }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

removed devDependencies.typescript from sub-packages as it's only required at the package root.