### PR TITLE
removed bigint to only use bignumber

### DIFF
--- a/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
+++ b/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
@@ -253,7 +253,7 @@ describe('ComposableBuffer.varUIntArray', () => {
 
 describe('ComposableBuffer.array', () => {
   interface Item {
-    value: BigInt // 8 bytes
+    value: BigNumber // 8 bytes
     txid: string // 32 bytes
   }
 
@@ -262,7 +262,7 @@ describe('ComposableBuffer.array', () => {
   class CItem extends ComposableBuffer<Item> {
     composers (data: Item): BufferComposer[] {
       return [
-        ComposableBuffer.bigUInt64(() => data.value, v => data.value = v),
+        ComposableBuffer.bigNumberUInt64(() => data.value, v => data.value = v),
         ComposableBuffer.hex(32, () => data.txid, v => data.txid = v)
       ]
     }
@@ -282,11 +282,11 @@ describe('ComposableBuffer.array', () => {
 
     const val = [
       {
-        value: BigInt('0x0008000800080008'),
+        value: new BigNumber('0x0008000800080008'),
         txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
       },
       {
-        value: BigInt('0x01aa535d3d0c0000'),
+        value: new BigNumber('0x01aa535d3d0c0000'),
         txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
       }
     ]
@@ -305,7 +305,7 @@ describe('ComposableBuffer.array', () => {
     it('should fail toBuffer deeply due to hex invalid length', () => {
       items = [
         {
-          value: BigInt('0x0008000800080008'),
+          value: new BigNumber('0x0008000800080008'),
           txid: 'fff7f7881a8099afa6940d42d1e7f636'
         }
       ]
@@ -318,14 +318,14 @@ describe('ComposableBuffer.array', () => {
     it('should fail toBuffer deeply due to value out of range', () => {
       items = [
         {
-          value: BigInt('0x100008000800080008'),
+          value: new BigNumber('0x100008000800080008'),
           txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
         }
       ]
 
       expect(() => {
         composer.toBuffer(new SmartBuffer())
-      }).toThrow('It must be >= 0n and < 2n ** 64n. Received 295_150_157_013_526_773_768n')
+      }).toThrow('It must be >= 0n and < 2n ** 64n. Received 295150157013526773768')
     })
   })
 })
@@ -611,66 +611,66 @@ describe('ComposableBuffer.uInt32', () => {
   })
 })
 
-describe('ComposableBuffer.bigUInt64', () => {
-  let value: BigInt = BigInt('0x01')
-  const composer = ComposableBuffer.bigUInt64(() => value, (v: BigInt) => value = v)
+describe('ComposableBuffer.bigNumberUInt64', () => {
+  let value: BigNumber = new BigNumber('0x01')
+  const composer = ComposableBuffer.bigNumberUInt64(() => value, (v: BigNumber) => value = v)
 
   describe('0x0000000000000001', () => {
     it('should fromBuffer', () => {
-      shouldFromBuffer(composer, '0100000000000000', BigInt('0x0000000000000001'), () => value)
+      shouldFromBuffer(composer, '0100000000000000', new BigNumber('0x0000000000000001'), () => value)
     })
 
     it('should toBuffer', () => {
-      shouldToBuffer(composer, '0100000000000000', BigInt('0x0000000000000001'), v => value = v)
+      shouldToBuffer(composer, '0100000000000000', new BigNumber('0x0000000000000001'), v => value = v)
     })
   })
 
   describe('0x8000000000000001', () => {
     it('should fromBuffer', () => {
-      shouldFromBuffer(composer, '0100000000000080', BigInt('0x8000000000000001'), () => value)
+      shouldFromBuffer(composer, '0100000000000080', new BigNumber('0x8000000000000001'), () => value)
     })
 
     it('should toBuffer', () => {
-      shouldToBuffer(composer, '0100000000000080', BigInt('0x8000000000000001'), v => value = v)
+      shouldToBuffer(composer, '0100000000000080', new BigNumber('0x8000000000000001'), v => value = v)
     })
   })
 
   describe('0xff00000000000001', () => {
     it('should fromBuffer', () => {
-      shouldFromBuffer(composer, '01000000000000ff', BigInt('0xff00000000000001'), () => value)
+      shouldFromBuffer(composer, '01000000000000ff', new BigNumber('0xff00000000000001'), () => value)
     })
 
     it('should toBuffer', () => {
-      shouldToBuffer(composer, '01000000000000ff', BigInt('0xff00000000000001'), v => value = v)
+      shouldToBuffer(composer, '01000000000000ff', new BigNumber('0xff00000000000001'), v => value = v)
     })
   })
 
   describe('4000000000', () => {
     it('should fromBuffer', () => {
-      shouldFromBuffer(composer, '00286bee00000000', BigInt(4000000000), () => value)
+      shouldFromBuffer(composer, '00286bee00000000', new BigNumber(4000000000), () => value)
     })
 
     it('should toBuffer', () => {
-      shouldToBuffer(composer, '00286bee00000000', BigInt(4000000000), v => value = v)
+      shouldToBuffer(composer, '00286bee00000000', new BigNumber(4000000000), v => value = v)
     })
   })
 
   describe('120000000000000000 MAX DFI Supply', () => {
     it('should fromBuffer', () => {
-      shouldFromBuffer(composer, '00000c3d5d53aa01', BigInt('120000000000000000'), () => value)
+      shouldFromBuffer(composer, '00000c3d5d53aa01', new BigNumber('120000000000000000'), () => value)
     })
 
     it('should toBuffer', () => {
-      shouldToBuffer(composer, '00000c3d5d53aa01', BigInt('120000000000000000'), v => value = v)
+      shouldToBuffer(composer, '00000c3d5d53aa01', new BigNumber('120000000000000000'), v => value = v)
     })
   })
 
   it('should fail toBuffer validate', () => {
-    value = BigInt('0x10000000000000001')
+    value = new BigNumber('0x10000000000000001')
 
     expect(() => {
       composer.toBuffer(new SmartBuffer())
-    }).toThrow('It must be >= 0n and < 2n ** 64n. Received 18_446_744_073_709_551_617n')
+    }).toThrow('It must be >= 0n and < 2n ** 64n. Received 18446744073709551617')
   })
 })
 

--- a/packages/jellyfish-transaction/src/buffer/buffer_bignumber.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_bignumber.ts
@@ -1,0 +1,28 @@
+import BigNumber from 'bignumber.js'
+import { SmartBuffer } from 'smart-buffer'
+
+export const ONE_HUNDRED_MILLION = new BigNumber('100000000')
+
+/**
+ * @param {SmartBuffer} buffer to read as unsigned BigNumber (LE)
+ * @return BigNumber
+ */
+export function readBigNumberUInt64 (buffer: SmartBuffer): BigNumber {
+  const second = buffer.readUInt32LE()
+  const first = buffer.readUInt32LE()
+  return new BigNumber(first).multipliedBy(0x100000000).plus(second)
+}
+
+/**
+ * @param {BigNumber} bigNumber
+ * @param {SmartBuffer} buffer to write to as unsigned BigNumber (LE)
+ */
+export function writeBigNumberUInt64 (bigNumber: BigNumber, buffer: SmartBuffer): void {
+  if (bigNumber.isGreaterThan(new BigNumber('18446744073709551615'))) {
+    throw new Error(`It must be >= 0n and < 2n ** 64n. Received ${bigNumber.toString(10)}`)
+  }
+  const second = bigNumber.mod(0x100000000)
+  const first = bigNumber.minus(second).dividedBy(0x100000000)
+  buffer.writeUInt32LE(second.toNumber())
+  buffer.writeUInt32LE(first.toNumber())
+}

--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -1,8 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { SmartBuffer } from 'smart-buffer'
 import { writeVarUInt, readVarUInt } from './buffer_varuint'
-
-const ONE_HUNDRED_MILLION = new BigNumber('100000000')
+import { ONE_HUNDRED_MILLION, readBigNumberUInt64, writeBigNumberUInt64 } from './buffer_bignumber'
 
 export interface BufferComposer {
   fromBuffer: (buffer: SmartBuffer) => void
@@ -26,7 +25,7 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   constructor (data: T)
 
   /**
-   * @param buffer to compose into Object
+   * @param {SmartBuffer} buffer to compose into Object
    */
   constructor (buffer: SmartBuffer)
 
@@ -271,36 +270,34 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
-   * Unsigned BigInt, 8 bytes
+   * Unsigned BigNumber, 8 bytes
    *
    * @param getter to read from to buffer
    * @param setter to set to from buffer
    */
-  static bigUInt64 (getter: () => BigInt, setter: (data: BigInt) => void): BufferComposer {
+  static bigNumberUInt64 (getter: () => BigNumber, setter: (data: BigNumber) => void): BufferComposer {
     return {
       fromBuffer: (buffer: SmartBuffer): void => {
-        setter(buffer.readBigUInt64LE())
+        setter(readBigNumberUInt64(buffer))
       },
       toBuffer: (buffer: SmartBuffer): void => {
-        buffer.writeBigUInt64LE(getter().valueOf())
+        writeBigNumberUInt64(getter(), buffer)
       }
     }
   }
 
   /**
-   * Unsigned bigint/satoshi as BigNumber, 8 bytes
+   * Unsigned satoshi as BigNumber, 8 bytes
    * BigNumber is multiplied/divided by 100,000,000
    *
    * @param getter to read from to buffer
    * @param setter to set to from buffer
    */
   static satoshiAsBigNumber (getter: () => BigNumber, setter: (data: BigNumber) => void): BufferComposer {
-    return ComposableBuffer.bigUInt64(() => {
-      const number = getter().multipliedBy(ONE_HUNDRED_MILLION).toString(10)
-      return BigInt(number)
+    return ComposableBuffer.bigNumberUInt64(() => {
+      return getter().multipliedBy(ONE_HUNDRED_MILLION)
     }, v => {
-      const number = new BigNumber(v.toString()).dividedBy(ONE_HUNDRED_MILLION)
-      setter(number)
+      setter(v.dividedBy(ONE_HUNDRED_MILLION))
     })
   }
 

--- a/packages/jellyfish-transaction/src/buffer/buffer_varuint.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_varuint.ts
@@ -1,8 +1,8 @@
 import { SmartBuffer } from 'smart-buffer'
 
 /**
- * @param num to write as VarUInt (1-9 bytes)
- * @param buffer to write to
+ * @param {number} num to write as VarUInt (1-9 bytes)
+ * @param {SmartBuffer} buffer to write to
  */
 export function writeVarUInt (num: number, buffer: SmartBuffer): void {
   validateUInt53(num)
@@ -35,7 +35,7 @@ export function writeVarUInt (num: number, buffer: SmartBuffer): void {
 
 /**
  * Read VarUInt as number
- * @param buffer to read VarUInt from (1-9 bytes)
+ * @param {SmartBuffer} buffer to read VarUInt from (1-9 bytes)
  * @throws RangeError 'out of Number.MAX_SAFE_INTEGER range' when it's out of MAX_SAFE_INTEGER
  */
 export function readVarUInt (buffer: SmartBuffer): number {
@@ -58,7 +58,7 @@ export function readVarUInt (buffer: SmartBuffer): number {
 }
 
 /**
- * @param num to get total number bytes (1-9 bytes)
+ * @param {number} num to get total number bytes (1-9 bytes)
  */
 export function byteLength (num: number): number {
   validateUInt53(num)
@@ -66,7 +66,7 @@ export function byteLength (num: number): number {
 }
 
 /**
- * @param num to validate
+ * @param {number} num to validate
  * @throws RangeError 'out of Number.MAX_SAFE_INTEGER range' when it's out of MAX_SAFE_INTEGER
  */
 function validateUInt53 (num: number): void {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

BigInt causes platform compatibility issues and it's difficult to polyfill/ponyfill. This PR moved all bigint implementation to use BigNumber.

#### Which issue(s) does this PR fixes?:
Fixes #152
