### PR TITLE
bump docker to defi/defichain:1.6.3

### DIFF
--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -92,7 +92,7 @@ async function pullImage (docker: Dockerode): Promise<void> {
 export abstract class DeFiDContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
-  public static readonly image = 'defi/defichain:1.6.0'
+  public static readonly image = 'defi/defichain:1.6.3'
 
   protected readonly docker: Dockerode
   protected readonly network: Network


### PR DESCRIPTION
#### What kind of PR is this?:
/kind dependencies

#### What this PR does / why we need it:

Bump `defi/defichain` docker image from `1.6.0` to `1.6.3`.