### PR TITLE
additional test to craft_sign_send_tx using your own private key

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -106,7 +106,9 @@
       <w>mediantime</w>
       <w>mempool</w>
       <w>merkleroot</w>
+      <w>mintable</w>
       <w>mintedblocks</w>
+      <w>minttokens</w>
       <w>modifiedfee</w>
       <w>multisig</w>
       <w>nblocks</w>
@@ -121,6 +123,8 @@
       <w>numnotequal</w>
       <w>paytxfee</w>
       <w>pooledtx</w>
+      <w>poolpair</w>
+      <w>poolswap</w>
       <w>previousblockhash</w>
       <w>prevout</w>
       <w>prevouts</w>
@@ -158,6 +162,7 @@
       <w>testmempoolaccept</w>
       <w>thedoublejay</w>
       <w>toaltstack</w>
+      <w>tradeable</w>
       <w>txcount</w>
       <w>txid</w>
       <w>txindex</w>

--- a/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
+++ b/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
@@ -1,0 +1,111 @@
+import BigNumber from 'bignumber.js'
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+import { CTransactionSegWit, DeFiTransactionConstants, Transaction, TransactionSigner } from '../src'
+import { OP_CODES } from '../src/script'
+import { decodeAsEllipticPair, HASH160 } from '@defichain/jellyfish-crypto'
+import { SmartBuffer } from 'smart-buffer'
+
+const container = new MasterNodeRegTestContainer()
+let client: JsonRpcClient
+
+beforeAll(async () => {
+  await container.start()
+  await container.waitForReady()
+  await container.waitForWalletCoinbaseMaturity()
+  client = new JsonRpcClient(await container.getCachedRpcUrl())
+})
+
+afterAll(async () => {
+  await container.stop()
+})
+
+beforeEach(async () => {
+  await container.waitForWalletBalanceGTE(100)
+})
+
+it('should craft, sign and broadcast a txn', async () => {
+  // From Address P2WPKH
+  const input = {
+    bech32: 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn',
+    privKey: 'cQSsfYvYkK5tx3u1ByK2ywTTc9xJrREc1dd67ZrJqJUEMwgktPWN'
+  }
+
+  // To Address P2WPKH
+  const output = {
+    bech32: 'bcrt1qf26rj8895uewxcfeuukhng5wqxmmpqp555z5a7',
+    privKey: 'cQbfHFbdJNhg3UGaBczir2m5D4hiFRVRKgoU8GJoxmu2gEhzqHtV'
+  }
+
+  const inputPair = decodeAsEllipticPair(input.privKey)
+  const outputPair = decodeAsEllipticPair(output.privKey)
+
+  // Fund an untracked address for 10.0 DFI for testing
+  const { txid, vout } = await container.fundAddress(input.bech32, 10)
+
+  // Create transaction to sign
+  const transaction: Transaction = {
+    version: DeFiTransactionConstants.Version,
+    vin: [
+      {
+        index: vout,
+        script: { stack: [] },
+        sequence: 0xffffffff,
+        // container.fundAddress returns in BE
+        txid: Buffer.from(txid, 'hex').reverse().toString('hex')
+      }
+    ],
+    vout: [
+      {
+        value: new BigNumber('9.999'), // 0.001 as fees
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            OP_CODES.OP_PUSHDATA(
+              HASH160(await outputPair.publicKey()),
+              'little'
+            )
+          ]
+        },
+        dct_id: 0x00
+      }
+    ],
+    lockTime: 0x00000000
+  }
+
+  // Signing a transaction
+  const signed = await TransactionSigner.sign(transaction, [{
+    prevout: {
+      value: new BigNumber(10),
+      script: {
+        stack: [
+          OP_CODES.OP_0,
+          OP_CODES.OP_PUSHDATA(
+            HASH160(await inputPair.publicKey()),
+            'little'
+          )
+        ]
+      },
+      dct_id: 0x00
+    },
+    ellipticPair: inputPair
+  }])
+
+  // Get it as a buffer and send to container
+  const buffer = new SmartBuffer()
+  new CTransactionSegWit(signed).toBuffer(buffer)
+  await client.rawtx.sendRawTransaction(
+    buffer.toBuffer().toString('hex')
+  )
+
+  // Import and track that address
+  await container.generate(1)
+  await container.call('importprivkey', [output.privKey])
+
+  const unspent = await container.call('listunspent', [
+    0, 9999999, [output.bech32]
+  ])
+
+  // Amount is exact to what I send
+  expect(unspent[0].amount).toBe(9.999)
+})

--- a/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
+++ b/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
@@ -24,7 +24,7 @@ beforeEach(async () => {
   await container.waitForWalletBalanceGTE(100)
 })
 
-it('should craft, sign and broadcast a txn', async () => {
+it('should craft, sign and broadcast a txn from scratch', async () => {
   // From Address P2WPKH
   const input = {
     bech32: 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn',
@@ -37,10 +37,12 @@ it('should craft, sign and broadcast a txn', async () => {
     privKey: 'cQbfHFbdJNhg3UGaBczir2m5D4hiFRVRKgoU8GJoxmu2gEhzqHtV'
   }
 
+  // Decode 2 set of deterministic EllipticPair using WIF
+  // You can use 'jellyfish-wallet' or 'jellyfish-crypto' to generate your pair
   const inputPair = decodeAsEllipticPair(input.privKey)
   const outputPair = decodeAsEllipticPair(output.privKey)
 
-  // Fund an untracked address for 10.0 DFI for testing
+  // Fund an untracked address with 10.0 DFI for testing
   const { txid, vout } = await container.fundAddress(input.bech32, 10)
 
   // Create transaction to sign
@@ -98,7 +100,7 @@ it('should craft, sign and broadcast a txn', async () => {
     buffer.toBuffer().toString('hex')
   )
 
-  // Import and track that address
+  // For testing you actually received it, import and track that address
   await container.generate(1)
   await container.call('importprivkey', [output.privKey])
 
@@ -106,6 +108,7 @@ it('should craft, sign and broadcast a txn', async () => {
     0, 9999999, [output.bech32]
   ])
 
-  // Amount is exact to what I send
+  // Amount is exact to what I send and I can unlock it
   expect(unspent[0].amount).toBe(9.999)
+  expect(unspent[0].spendable).toBe(true)
 })

--- a/packages/jellyfish-transaction/jest.config.js
+++ b/packages/jellyfish-transaction/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
   testMatch: [
+    '**/__testcontainers__/**/*.test.ts',
     '**/__tests__/**/*.test.ts'
   ],
   transform: {

--- a/packages/jellyfish-transaction/package.json
+++ b/packages/jellyfish-transaction/package.json
@@ -40,5 +40,10 @@
   "dependencies": {
     "@defichain/jellyfish-crypto": "0.0.0",
     "smart-buffer": "^4.1.0"
+  },
+  "devDependencies": {
+    "@defichain/jellyfish-api-core": "0.0.0",
+    "@defichain/jellyfish-api-jsonrpc": "0.0.0",
+    "@defichain/testcontainers": "0.0.0"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Implement part of #150 as `jellyfish-transaction` tests should be run against `testcontainers` for extra compatibility