### PR TITLE
fix bech32 as it should use HASH160 not SHA256

### DIFF
--- a/packages/jellyfish-crypto/__tests__/bech32.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bech32.test.ts
@@ -1,40 +1,56 @@
-import { HASH160, Bech32 } from '../src'
+import { HASH160, Bech32, HRP } from '../src'
 
-const hrp = 'bcrt'
-const bech32 = 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn'
-const pubKey = '03987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe81'
+const keypair = {
+  hrp: 'bcrt' as HRP,
+  bech32: 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn',
+  pubKey: '03987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe81'
+}
 
-it('should convert bech32 to pubkey', () => {
-  const buffer: Buffer = Bech32.toPubKey(bech32)
-  const hash160 = HASH160(Buffer.from(pubKey, 'hex'))
+it('should convert bech32 to hash160', () => {
+  const buffer: Buffer = Bech32.toHash160(keypair.bech32)
+
+  const pubKey = Buffer.from(keypair.pubKey, 'hex')
+  const hash160 = HASH160(pubKey)
+
   expect(buffer.toString('hex')).toBe(hash160.toString('hex'))
 })
 
-it('should convert bech32 to pubkey with hrp and version', () => {
-  const buffer: Buffer = Bech32.toPubKey(bech32, 'bcrt', 0x00)
-  const hash160 = HASH160(Buffer.from(pubKey, 'hex'))
+it('should convert bech32 to hash160 with hrp and version', () => {
+  const buffer: Buffer = Bech32.toHash160(keypair.bech32, 'bcrt', 0x00)
+
+  const pubKey = Buffer.from(keypair.pubKey, 'hex')
+  const hash160 = HASH160(pubKey)
+
   expect(buffer.toString('hex')).toBe(hash160.toString('hex'))
 })
 
 it('should fail convert bech32 to pubkey with invalid hrp', () => {
   expect(() => {
-    Bech32.toPubKey(bech32, 'tf', 0x00)
+    Bech32.toHash160(keypair.bech32, 'tf', 0x00)
   }).toThrow('Invalid HRP: human readable part')
 })
 
 it('should fail convert bech32 to pubkey with invalid version', () => {
   expect(() => {
     // @ts-expect-error
-    Bech32.toPubKey(bech32, 'bcrt', 0x01)
+    Bech32.toHash160(keypair.bech32, 'bcrt', 0x01)
   }).toThrow('Invalid witness version')
 })
 
 it('should convert pubkey to bech32', () => {
-  const bech32 = Bech32.fromPubKey(Buffer.from(pubKey, 'hex'), hrp)
-  expect(bech32).toBe(bech32)
+  const pubKey = Buffer.from(keypair.pubKey, 'hex')
+  const bech32 = Bech32.fromPubKey(pubKey, keypair.hrp)
+  expect(bech32).toBe(keypair.bech32)
 })
 
 it('should convert pubkey to bech32 with witness version', () => {
-  const bech32 = Bech32.fromPubKey(Buffer.from(pubKey, 'hex'), hrp, 0x00)
-  expect(bech32).toBe(bech32)
+  const pubKey = Buffer.from(keypair.pubKey, 'hex')
+  const bech32 = Bech32.fromPubKey(pubKey, keypair.hrp, 0x00)
+  expect(bech32).toBe(keypair.bech32)
+})
+
+it('should from bech32 to hash160 back to bech32', async () => {
+  const hash160: Buffer = Bech32.toHash160(keypair.bech32)
+  const bech32 = Bech32.fromHash160(hash160, keypair.hrp)
+  expect(bech32).toBe(keypair.bech32)
 })

--- a/packages/jellyfish-crypto/__tests__/index.test.ts
+++ b/packages/jellyfish-crypto/__tests__/index.test.ts
@@ -1,0 +1,29 @@
+import { Bech32, Elliptic, WIF } from '../src'
+
+describe('keySet 1', () => {
+  const keySet = {
+    bech32: 'bcrt1qykj5fsrne09yazx4n72ue4fwtpx8u65zac9zhn',
+    wif: 'cQSsfYvYkK5tx3u1ByK2ywTTc9xJrREc1dd67ZrJqJUEMwgktPWN'
+  }
+
+  it('should convert from WIF to priv to pub to bech32', async () => {
+    const wifDecoded = WIF.decode(keySet.wif)
+    const privKey = wifDecoded.privateKey
+    const pubKey = await Elliptic.fromPrivKey(privKey).publicKey()
+    expect(Bech32.fromPubKey(pubKey, 'bcrt')).toBe(keySet.bech32)
+  })
+})
+
+describe('keySet 2', () => {
+  const keySet = {
+    bech32: 'bcrt1qf26rj8895uewxcfeuukhng5wqxmmpqp555z5a7',
+    wif: 'cQbfHFbdJNhg3UGaBczir2m5D4hiFRVRKgoU8GJoxmu2gEhzqHtV'
+  }
+
+  it('should convert from WIF to priv to pub to bech32', async () => {
+    const wifDecoded = WIF.decode(keySet.wif)
+    const privKey = wifDecoded.privateKey
+    const pubKey = await Elliptic.fromPrivKey(privKey).publicKey()
+    expect(Bech32.fromPubKey(pubKey, 'bcrt')).toBe(keySet.bech32)
+  })
+})

--- a/packages/jellyfish-crypto/src/bech32.ts
+++ b/packages/jellyfish-crypto/src/bech32.ts
@@ -1,5 +1,5 @@
 import { bech32 } from 'bech32'
-import { SHA256 } from './hash'
+import { HASH160 } from './hash'
 
 /**
  * Human Readable Part, prefixed to all bech32/segwit native address
@@ -11,15 +11,14 @@ import { SHA256 } from './hash'
 export type HRP = 'df' | 'tf' | 'bcrt'
 
 /**
- * @param {Buffer} pubKey to format into bech32
+ * @param {Buffer} hash160 to format into bech32
  * @param {'df'|'tf'|'bcrt'} hrp is the human readable part
  * @param {number} [version=0x00] witness version, OP_0
  * @return {string} bech32 encoded address
  * @see https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki
  */
-function toBech32 (pubKey: Buffer, hrp: HRP, version: 0x00 = 0x00): string {
-  const hash = SHA256(pubKey)
-  const words = bech32.toWords(hash)
+function toBech32 (hash160: Buffer, hrp: HRP, version: 0x00 = 0x00): string {
+  const words = bech32.toWords(hash160)
   words.unshift(version)
   return bech32.encode(hrp, words)
 }
@@ -53,7 +52,17 @@ export const Bech32 = {
    * @return {string} bech32 encoded address
    */
   fromPubKey (pubKey: Buffer, hrp: HRP, version: 0x00 = 0x00): string {
-    return toBech32(pubKey, hrp, version)
+    const hash = HASH160(pubKey)
+    return toBech32(hash, hrp, version)
+  },
+  /**
+   * @param {Buffer} hash160 to format into bech32
+   * @param {'df'|'tf'|'bcrt'} hrp is the human readable part
+   * @param {number} [version=0x00] witness version, OP_0
+   * @return {string} bech32 encoded address
+   */
+  fromHash160 (hash160: Buffer, hrp: HRP, version: 0x00 = 0x00) {
+    return toBech32(hash160, hrp, version)
   },
   /**
    * @param {string} address to decode from bech32
@@ -61,7 +70,7 @@ export const Bech32 = {
    * @param {number} [version] witness version, OP_0
    * @return {Buffer} hash160 of the pubkey
    */
-  toPubKey (address: string, hrp?: HRP, version?: 0x00): Buffer {
+  toHash160 (address: string, hrp?: HRP, version?: 0x00): Buffer {
     return fromBech32(address, hrp, version)
   }
 }

--- a/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_1.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_1.test.ts
@@ -42,7 +42,7 @@ it('sign transaction', async () => {
       script: {
         stack: [
           OP_CODES.OP_0,
-          OP_CODES.OP_PUSHDATA(Bech32.toPubKey(input.bech32, 'bcrt', 0x00), 'little')
+          OP_CODES.OP_PUSHDATA(Bech32.toHash160(input.bech32, 'bcrt', 0x00), 'little')
         ]
       },
       value: new BigNumber('10'),

--- a/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_2.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_2.test.ts
@@ -42,7 +42,7 @@ it('sign transaction', async () => {
       script: {
         stack: [
           OP_CODES.OP_0,
-          OP_CODES.OP_PUSHDATA(Bech32.toPubKey(input.bech32, 'bcrt', 0x00), 'little')
+          OP_CODES.OP_PUSHDATA(Bech32.toHash160(input.bech32, 'bcrt', 0x00), 'little')
         ]
       },
       value: new BigNumber('10'),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

fix Bech32.fromPubKey as it should use HASH160 not SHA256
also added Bech32.fromHash160
