### PR TITLE
fix wait for wallet coinbase maturity should use getBlockCount

### DIFF
--- a/packages/testcontainers/README.md
+++ b/packages/testcontainers/README.md
@@ -1,5 +1,5 @@
-[![npm](https://img.shields.io/npm/v/@defichain/testcontainer)](https://www.npmjs.com/package/@defichain/testcontainer/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/testcontainer/next)](https://www.npmjs.com/package/@defichain/testcontainer/v/next)
+[![npm](https://img.shields.io/npm/v/@defichain/testcontainers)](https://www.npmjs.com/package/@defichain/testcontainers/v/latest)
+[![npm@next](https://img.shields.io/npm/v/@defichain/testcontainers/next)](https://www.npmjs.com/package/@defichain/testcontainers/v/next)
 
 # @defichain/testcontainers
 

--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -269,8 +269,9 @@ export abstract class DeFiDContainer {
   /**
    * @param {() => Promise<boolean>} condition to wait for true
    * @param {number} timeout duration when condition is not met
+   * @param {number} [interval=200] duration in ms
    */
-  async waitForCondition (condition: () => Promise<boolean>, timeout: number): Promise<void> {
+  async waitForCondition (condition: () => Promise<boolean>, timeout: number, interval: number = 200): Promise<void> {
     const expiredAt = Date.now() + timeout
 
     return await new Promise((resolve, reject) => {
@@ -281,7 +282,7 @@ export abstract class DeFiDContainer {
         } else if (expiredAt < Date.now()) {
           reject(new Error(`waitForCondition is not ready within given timeout of ${timeout}ms.`))
         } else {
-          setTimeout(() => void checkCondition(), 200)
+          setTimeout(() => void checkCondition(), interval)
         }
       }
 

--- a/packages/testcontainers/src/chains/reg_test_container/masternode.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/masternode.ts
@@ -89,11 +89,14 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    *
    * A coinbase transaction must be 100 blocks deep before you can spend its outputs.
    * This is a safeguard to prevent outputs that originate
-   * from the coinbase transaction from becoming unspendable
-   * (in the event the mined block moves out of the active chaindue to a fork).
+   * from the coinbase transaction from becoming un-spendable
+   * (in the event the mined block moves out of the active chain due to a fork).
    */
-  async waitForWalletCoinbaseMaturity (): Promise<void> {
-    await this.generate(100)
+  async waitForWalletCoinbaseMaturity (timeout = 90000): Promise<void> {
+    return await this.waitForCondition(async () => {
+      const count = await this.getBlockCount()
+      return count > 100
+    }, timeout)
   }
 
   /**

--- a/packages/testcontainers/src/chains/reg_test_container/masternode.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/masternode.ts
@@ -94,9 +94,10 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    */
   async waitForWalletCoinbaseMaturity (timeout = 90000): Promise<void> {
     return await this.waitForCondition(async () => {
+      await this.generate(1)
       const count = await this.getBlockCount()
       return count > 100
-    }, timeout)
+    }, timeout, 100)
   }
 
   /**


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

wait for wallet coinbase maturity should use getBlockCount instead as it checks block count instead of generating 100 blocks. As blocks would start generating when container start, getBlockCount would reflect the actual coinbase status.