### PR TITLE
fix test as signature length should not be compared

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/rawtx.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx.test.ts
@@ -115,7 +115,7 @@ describe('signRawTransactionWithKey', () => {
 
     expect(signed.complete).toBe(true)
     expect(signed.hex.substr(0, 14)).toBe('04000000000101')
-    expect(signed.hex.substr(86, 88)).toBe('00ffffffff010065cd1d000000001600144ab4391ce5a732e36139e72d79a28e01b7b0803400024730440220')
+    expect(signed.hex.substr(86, 82)).toBe('00ffffffff010065cd1d000000001600144ab4391ce5a732e36139e72d79a28e01b7b0803400024730')
     expect(signed.hex).toContain('012103987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe8100000000')
   })
 
@@ -135,7 +135,7 @@ describe('signRawTransactionWithKey', () => {
 
     expect(signed.complete).toBe(true)
     expect(signed.hex.substr(0, 14)).toBe('04000000000101')
-    expect(signed.hex.substr(86, 152)).toBe('00ffffffff020065cd1d000000001600144ab4391ce5a732e36139e72d79a28e01b7b080340080ce341d0000000016001425a544c073cbca4e88d59f95ccd52e584c7e6a8200024730440220')
+    expect(signed.hex.substr(86, 146)).toBe('00ffffffff020065cd1d000000001600144ab4391ce5a732e36139e72d79a28e01b7b080340080ce341d0000000016001425a544c073cbca4e88d59f95ccd52e584c7e6a8200024730')
     expect(signed.hex).toContain('012103987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe8100000000')
   })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

1. `30440220`
1. `30430220`

DER signature length should not be compared in the test as it's a variable number.