### PR TITLE
ignored test coverage for tryPullImage due to race conditions

### DIFF
--- a/packages/testcontainers/src/chains/container.ts
+++ b/packages/testcontainers/src/chains/container.ts
@@ -72,6 +72,7 @@ async function tryPullImage (docker: Dockerode): Promise<void> {
     return
   }
 
+  /* istanbul ignore next */
   return await new Promise((resolve, reject) => {
     docker.pull(DeFiDContainer.image, {}, (error, result) => {
       if (error instanceof Error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Due to race conditions tryPullImage test coverage is flaky, should not add tests to get this coverage as it's will causes race conditions conflicting errors.