### PR TITLE
txn input validation (length, mismatch prevout)

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -85,6 +85,7 @@
       <w>isvalid</w>
       <w>iswatchonly</w>
       <w>iswitness</w>
+      <w>jingyi</w>
       <w>jsonrpc</w>
       <w>keyhash</w>
       <w>keypoololdest</w>

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
@@ -149,6 +149,24 @@ describe('sign single input', () => {
       .rejects.toThrow('witnessScript required, only P2WPKH can be guessed')
   })
 
+  it('should fail as isV0P2WPKH cannot match provided prevout ', async () => {
+    return await expect(TransactionSigner.signInput(transaction, 1, {
+      prevout: {
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            // hash is invalid
+            OP_CODES.OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a0', 'hex'), 'little')
+          ]
+        },
+        value: new BigNumber('6'),
+        dct_id: 0x00
+      },
+      ellipticPair: keyPair
+    }, SIGHASH.ALL))
+      .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+  })
+
   describe('SIGHASH for consistency should err-out as they are not implemented', () => {
     it('should err SIGHASH.NONE', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
@@ -69,6 +69,16 @@ describe('sign transaction', () => {
   })
 
   describe('validate', () => {
+    it('should fail as vin.length == 0', async () => {
+      const txn: Transaction = {
+        ...transaction,
+        vin: []
+      }
+      return await expect(TransactionSigner.sign(txn, [], {
+        sigHashType: SIGHASH.NONE
+      })).rejects.toThrow('vin.length = 0 - attempting to sign transaction without vin is not allowed')
+    })
+
     it('should fail as vin.length != inputOptions.length', async () => {
       return await expect(TransactionSigner.sign(transaction, [inputOption, inputOption], {
         sigHashType: SIGHASH.NONE

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
@@ -68,21 +68,37 @@ describe('sign transaction', () => {
     expect(signed.lockTime).toBe(0x00000000)
   })
 
-  describe('validate', () => {
+  describe('validation', () => {
     it('should fail as vin.length == 0', async () => {
       const txn: Transaction = {
         ...transaction,
         vin: []
       }
-      return await expect(TransactionSigner.sign(txn, [], {
-        sigHashType: SIGHASH.NONE
-      })).rejects.toThrow('vin.length = 0 - attempting to sign transaction without vin is not allowed')
+      return await expect(TransactionSigner.sign(txn, []))
+        .rejects.toThrow('vin.length = 0 - attempting to sign transaction without vin is not allowed')
+    })
+
+    it('should fail as provided prevout and ellipticPair is mismatched', async () => {
+      const input = {
+        prevout: {
+          script: {
+            stack: [
+              OP_CODES.OP_0,
+              OP_CODES.OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a0', 'hex'), 'little')
+            ]
+          },
+          value: new BigNumber('1000'),
+          dct_id: 0x00
+        },
+        ellipticPair: keyPair
+      }
+      return await expect(TransactionSigner.sign(transaction, [input]))
+        .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
     })
 
     it('should fail as vin.length != inputOptions.length', async () => {
-      return await expect(TransactionSigner.sign(transaction, [inputOption, inputOption], {
-        sigHashType: SIGHASH.NONE
-      })).rejects.toThrow('vin.length and inputOptions.length must match')
+      return await expect(TransactionSigner.sign(transaction, [inputOption, inputOption]))
+        .rejects.toThrow('vin.length and inputOptions.length must match')
     })
 
     it('should fail if version is different from DeFiTransactionConstants.Version', async () => {

--- a/packages/jellyfish-transaction/src/tx_signature.ts
+++ b/packages/jellyfish-transaction/src/tx_signature.ts
@@ -196,6 +196,10 @@ export const TransactionSigner = {
   validate (transaction: Transaction, inputOptions: SignInputOption[], option: SignOption) {
     const { version = true, lockTime = true } = (option.validate !== undefined) ? option.validate : {}
 
+    if (transaction.vin.length === 0) {
+      throw new Error('vin.length = 0 - attempting to sign transaction without vin is not allowed')
+    }
+
     if (transaction.vin.length !== inputOptions.length) {
       throw new Error('vin.length and inputOptions.length must match')
     }

--- a/packages/jellyfish-transaction/src/tx_signature.ts
+++ b/packages/jellyfish-transaction/src/tx_signature.ts
@@ -82,22 +82,43 @@ function hashOutputs (transaction: Transaction, sigHashType: SIGHASH): string {
 }
 
 /**
+ *
+ * The witness must consist of exactly 2 items.
+ * The '0' in scriptPubKey indicates the following push is a version 0 witness program.
+ * The length of 20 indicates that it is a P2WPKH type.
+ *
+ * @param {SignInputOption} signInputOption to check is is V0 P2WPKH
+ */
+async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
+  const stack = signInputOption.prevout.script.stack
+
+  if (stack.length === 2 && stack[1] instanceof OP_PUSHDATA && (stack[1] as OP_PUSHDATA).length() === 20) {
+    const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+    const pubkeyHashHex = HASH160(pubkey).toString('hex')
+    const pushDataHex = (stack[1] as OP_PUSHDATA).hex
+
+    if (pubkeyHashHex === pushDataHex) {
+      return true
+    }
+
+    throw new Error('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+  }
+
+  return false
+}
+
+/**
  * If script is not provided, it needs to be guessed
  *
  * @param {Vin} vin of the script
  * @param {SignInputOption} signInputOption to sign the vin
  */
 async function getScriptCode (vin: Vin, signInputOption: SignInputOption): Promise<Script> {
-  const stack = signInputOption.prevout.script.stack
-
   if (signInputOption.witnessScript !== undefined) {
     return signInputOption.witnessScript
   }
 
-  // The witness must consist of exactly 2 items.
-  // The '0' in scriptPubKey indicates the following push is a version 0 witness program.
-  // The length of 20 indicates that it is a P2WPKH type.
-  if (stack.length === 2 && stack[1] instanceof OP_PUSHDATA && (stack[1] as OP_PUSHDATA).length() === 20) {
+  if (await isV0P2WPKH(signInputOption)) {
     const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
     const pubkeyHash = HASH160(pubkey)
 

--- a/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
@@ -2,6 +2,7 @@ import { MnemonicHdNode, MnemonicHdNodeProvider, mnemonicToSeed, generateMnemoni
 import BigNumber from 'bignumber.js'
 import { Transaction, Vout } from '@defichain/jellyfish-transaction'
 import { OP_CODES } from '@defichain/jellyfish-transaction/dist/script'
+import { HASH160 } from '@defichain/jellyfish-crypto'
 
 const regTestBip32Options = {
   bip32: {
@@ -80,7 +81,15 @@ describe('24 words: random', () => {
     })
 
     it('should sign tx', async () => {
-      const signed = await node.signTx(transaction, [prevout])
+      const signed = await node.signTx(transaction, [{
+        ...prevout,
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            OP_CODES.OP_PUSHDATA(HASH160(await node.publicKey()), 'little')
+          ]
+        }
+      }])
 
       expect(signed.witness.length).toBe(1)
       expect(signed.witness[0].scripts.length).toBe(2)
@@ -130,7 +139,15 @@ describe('24 words: abandon x23 art', () => {
     })
 
     it('should sign tx', async () => {
-      const signed = await node.signTx(transaction, [prevout])
+      const signed = await node.signTx(transaction, [{
+        ...prevout,
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            OP_CODES.OP_PUSHDATA(HASH160(await node.publicKey()), 'little')
+          ]
+        }
+      }])
 
       expect(signed.witness.length).toBe(1)
       expect(signed.witness[0].scripts.length).toBe(2)
@@ -169,7 +186,15 @@ describe('24 words: abandon x23 art', () => {
     })
 
     it('should sign tx', async () => {
-      const signed = await node.signTx(transaction, [prevout])
+      const signed = await node.signTx(transaction, [{
+        ...prevout,
+        script: {
+          stack: [
+            OP_CODES.OP_0,
+            OP_CODES.OP_PUSHDATA(HASH160(await node.publicKey()), 'little')
+          ]
+        }
+      }])
 
       expect(signed.witness.length).toBe(1)
       expect(signed.witness[0].scripts.length).toBe(2)

--- a/packages/jellyfish-wallet/__tests__/wallet_hd_node.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet_hd_node.test.ts
@@ -45,6 +45,6 @@ describe("WalletHdNode: 44'/1129'/0'", () => {
       vout: [],
       lockTime: 0
     }, [])
-    ).rejects.toThrow('option.validate.version = true - trying to sign a txn 0 different from 4 is not supported')
+    ).rejects.toThrow()
   })
 })


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:

Attempting to sign a txn without any vout will fail.
Attempting to sign a txn input P2WPKH will fail if provided prevout and elliptic pair are mismatched.

#### Which issue(s) does this PR fixes?:
Fixes #134 
