### PR TITLE
removed peer deps for internal deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,6 +1524,10 @@
       "resolved": "packages/testcontainers",
       "link": true
     },
+    "node_modules/@defichain/testing": {
+      "resolved": "packages/testing",
+      "link": true
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
@@ -29431,6 +29435,16 @@
         "@types/dockerode": "^3.2.3",
         "@types/node-fetch": "^2.5.10"
       }
+    },
+    "packages/testing": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": "0.0.0",
+        "@defichain/jellyfish-crypto": "0.0.0",
+        "@defichain/jellyfish-network": "0.0.0",
+        "@defichain/testcontainers": "0.0.0"
+      }
     }
   },
   "dependencies": {
@@ -30670,6 +30684,15 @@
         "@types/node-fetch": "^2.5.10",
         "dockerode": "^3.3.0",
         "node-fetch": "^2.6.1"
+      }
+    },
+    "@defichain/testing": {
+      "version": "file:packages/testing",
+      "requires": {
+        "@defichain/jellyfish-api-core": "0.0.0",
+        "@defichain/jellyfish-crypto": "0.0.0",
+        "@defichain/jellyfish-network": "0.0.0",
+        "@defichain/testcontainers": "0.0.0"
       }
     },
     "@eslint/eslintrc": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -34,13 +34,10 @@
   "scripts": {
     "build": "tsc"
   },
-  "peerDependencies": {
-    "bignumber.js": "^9.0.1",
-    "@defichain/testcontainers": "0.0.0"
-  },
   "dependencies": {
     "@defichain/jellyfish-api-core": "0.0.0",
     "@defichain/jellyfish-network": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0"
+    "@defichain/jellyfish-crypto": "0.0.0",
+    "@defichain/testcontainers": "0.0.0"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

moved from peer dependencies to just dependencies instead as Lerna automatically update the dependencies and it will conflict with peer resolution.