### PR TITLE
removed 2 redundant RPC that are never used in container.generate

### DIFF
--- a/packages/testcontainers/src/chains/reg_test_container/masternode.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/masternode.ts
@@ -29,21 +29,14 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    * It is set to auto mint every 1 second by default in regtest.
    * https://github.com/DeFiCh/ain/blob/6dc990c45788d6806ea/test/functional/test_framework/test_node.py#L160-L178
    */
-  async generate (nblocks: number, address: string = this.masternodeKey.operator.address, maxTries: number = 1000000): Promise<string[]> {
-    const mintedHashes: string[] = []
-
+  async generate (nblocks: number, address: string = this.masternodeKey.operator.address, maxTries: number = 1000000): Promise<void> {
     for (let minted = 0, tries = 0; minted < nblocks && tries < maxTries; tries++) {
       const result = await this.call('generatetoaddress', [1, address, 1])
 
       if (result === 1) {
         minted += 1
-        const count = await this.call('getblockcount')
-        const hash = await this.call('getblockhash', [count])
-        mintedHashes.push(hash)
       }
     }
-
-    return mintedHashes
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

`MasterNodeRegTestContainer.generate` make 2 additional RPC per generate to get block hash however, those block hash are never used in any context. Hence it's redundant, removing to speed up tests.
