### PR TITLE
renamed dct_id to tokenId to keep naming convention consistent

### DIFF
--- a/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
+++ b/packages/jellyfish-transaction/__testcontainers__/craft_sign_send_tx.test.ts
@@ -69,7 +69,7 @@ it('should craft, sign and broadcast a txn from scratch', async () => {
             )
           ]
         },
-        dct_id: 0x00
+        tokenId: 0x00
       }
     ],
     lockTime: 0x00000000
@@ -88,7 +88,7 @@ it('should craft, sign and broadcast a txn from scratch', async () => {
           )
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     },
     ellipticPair: inputPair
   }])

--- a/packages/jellyfish-transaction/__tests__/index.test.ts
+++ b/packages/jellyfish-transaction/__tests__/index.test.ts
@@ -28,7 +28,7 @@ it('should be able to use DeFiTransactionConstants constants to craft Transactio
           ]
         },
         value: new BigNumber('1'),
-        dct_id: 0x00
+        tokenId: 0x00
       }
     ],
     witness: [

--- a/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_1.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_1.test.ts
@@ -46,7 +46,7 @@ it('sign transaction', async () => {
         ]
       },
       value: new BigNumber('10'),
-      dct_id: 0
+      tokenId: 0
     },
     ellipticPair: WIF.asEllipticPair(input.privKey)
   }]

--- a/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_2.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx/p2wpkh_1_to_2.test.ts
@@ -46,7 +46,7 @@ it('sign transaction', async () => {
         ]
       },
       value: new BigNumber('10'),
-      dct_id: 0
+      tokenId: 0
     },
     ellipticPair: WIF.asEllipticPair(input.privKey)
   }]

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CTransaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CTransaction.test.ts
@@ -29,7 +29,7 @@ describe('CTransaction', () => {
               OP_CODES.OP_CHECKSIG
             ]
           },
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       lockTime: 0x00000011
@@ -85,7 +85,7 @@ describe('CTransaction', () => {
               OP_CODES.OP_CHECKSIG
             ]
           },
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           value: new BigNumber('2.2345'),
@@ -98,7 +98,7 @@ describe('CTransaction', () => {
               OP_CODES.OP_CHECKSIG
             ]
           },
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       lockTime: 0x00000011
@@ -139,7 +139,7 @@ describe('CTransaction', () => {
             ]
           },
           value: new BigNumber('1.999966'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           script: {
@@ -152,7 +152,7 @@ describe('CTransaction', () => {
             ]
           },
           value: new BigNumber('8'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       lockTime: 1170
@@ -201,7 +201,7 @@ describe('CTransaction', () => {
             ]
           },
           value: new BigNumber('50'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       lockTime: 0
@@ -242,7 +242,7 @@ describe('CTransaction', () => {
             ]
           },
           value: new BigNumber('0x0000000035a4e900').dividedBy('100000000'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           script: {
@@ -255,7 +255,7 @@ describe('CTransaction', () => {
             ]
           },
           value: new BigNumber('0x00000000052f83c0').dividedBy('100000000'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       lockTime: 0x00000000

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionSegWit.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionSegWit.test.ts
@@ -33,7 +33,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('1.1234'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       witness: [
@@ -103,7 +103,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('1.1234'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           script: {
@@ -116,7 +116,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('2.2345'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       witness: [
@@ -182,7 +182,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('0x000000000bebb4b8').dividedBy('100000000'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           script: {
@@ -195,7 +195,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('0x000000002faf0800').dividedBy('100000000'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       witness: [
@@ -260,7 +260,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('0x000000012a05f200').dividedBy('100000000'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       witness: [
@@ -323,7 +323,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('9'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         {
           script: {
@@ -336,7 +336,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           value: new BigNumber('0.87'),
-          dct_id: 0x00
+          tokenId: 0x00
         }
       ],
       witness: [

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionV2.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionV2.test.ts
@@ -11,7 +11,7 @@ describe('Transaction', () => {
     expect(composable.vin[0].txid).toBe('0000000000000000000000000000000000000000000000000000000000000000')
     expect(composable.vout.length).toBe(3)
 
-    expect(composable.vout[0].dct_id).toBeUndefined()
+    expect(composable.vout[0].tokenId).toBeUndefined()
     expect(composable.vout[0].value.toString()).toBe('194.99933826')
     expect(composable.vout[0].script.stack.length).toBe(5)
   })
@@ -40,7 +40,7 @@ describe('TransactionSegWit', () => {
     expect(composable.vin.length).toBe(1)
 
     expect(composable.vout.length).toBe(3)
-    expect(composable.vout[0].dct_id).toBeUndefined()
+    expect(composable.vout[0].tokenId).toBeUndefined()
     expect(composable.vout[0].value.toString()).toBe('194.99933826')
     expect(composable.vout[0].script.stack.length).toBe(5)
   })

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CVout.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CVout.test.ts
@@ -15,7 +15,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -37,7 +37,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -59,7 +59,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -81,7 +81,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -103,7 +103,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -125,7 +125,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -147,7 +147,7 @@ describe('CVoutV2', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -171,7 +171,7 @@ describe('CVoutV4', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0
+      tokenId: 0
     }
 
     it('should compose from Buffer to Composable to Object', () => {
@@ -196,7 +196,7 @@ describe('CVoutV4', () => {
           new OP_PUSHDATA(Buffer.from('1d0f172a0ecb48aee1be1f2687d2963ae33f71a1', 'hex'), 'little')
         ]
       },
-      dct_id: 0x00
+      tokenId: 0x00
     }
 
     it('should compose from Buffer to Composable to Object', () => {

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
@@ -36,7 +36,7 @@ describe('sign single input', () => {
             OP_CODES.OP_CHECKSIG
           ]
         },
-        dct_id: 0x00
+        tokenId: 0x00
       },
       {
         value: new BigNumber('2.2345'),
@@ -49,7 +49,7 @@ describe('sign single input', () => {
             OP_CODES.OP_CHECKSIG
           ]
         },
-        dct_id: 0x00
+        tokenId: 0x00
       }
     ],
     lockTime: 0x00000011
@@ -65,7 +65,7 @@ describe('sign single input', () => {
       ]
     },
     value: new BigNumber('6'),
-    dct_id: 0x00
+    tokenId: 0x00
   }
   const keyPair = Elliptic.fromPrivKey(privateKey)
 
@@ -142,7 +142,7 @@ describe('sign single input', () => {
           ]
         },
         value: new BigNumber('6'),
-        dct_id: 0x00
+        tokenId: 0x00
       },
       ellipticPair: keyPair
     }, SIGHASH.ALL))
@@ -160,7 +160,7 @@ describe('sign single input', () => {
           ]
         },
         value: new BigNumber('6'),
-        dct_id: 0x00
+        tokenId: 0x00
       },
       ellipticPair: keyPair
     }, SIGHASH.ALL))

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
@@ -88,7 +88,7 @@ describe('sign transaction', () => {
             ]
           },
           value: new BigNumber('1000'),
-          dct_id: 0x00
+          tokenId: 0x00
         },
         ellipticPair: keyPair
       }

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_transaction.test.ts
@@ -25,7 +25,7 @@ describe('sign transaction', () => {
             new OP_PUSHDATA(Buffer.from('3bde42dbee7e4dbe6a21b2d50ce2f0167faa8159', 'hex'), 'little')
           ]
         },
-        dct_id: 0x00
+        tokenId: 0x00
       }
     ],
     lockTime: 0x00000000
@@ -41,7 +41,7 @@ describe('sign transaction', () => {
       ]
     },
     value: new BigNumber('1000'),
-    dct_id: 0x00
+    tokenId: 0x00
   }
   const keyPair = Elliptic.fromPrivKey(privateKey)
   const inputOption = {

--- a/packages/jellyfish-transaction/src/tx.ts
+++ b/packages/jellyfish-transaction/src/tx.ts
@@ -11,7 +11,7 @@ export interface Transaction {
   /**
    * Version is either 2 or 4
    * V2 structure is the same as Bitcoin
-   * V4 contains dct_id in vout
+   * V4 contains tokenId in vout
    */
   version: number // -------------------| 4 bytes
   vin: Vin[] // ------------------------| c = VarUInt{1-9 bytes}, + c x Vin
@@ -45,7 +45,7 @@ export interface Vin {
 export interface Vout {
   value: BigNumber // ------------------| 8 bytes
   script: Script // --------------------| n = VarUInt{1-9 bytes}, + n bytes
-  dct_id: number // --------------------| 1 byte (Although it is VarUInt but disabled hence always 0x00)
+  tokenId: number // -------------------| 1 byte (Although it is VarUInt but disabled hence always 0x00)
 }
 
 /**

--- a/packages/jellyfish-transaction/src/tx_composer.ts
+++ b/packages/jellyfish-transaction/src/tx_composer.ts
@@ -107,7 +107,7 @@ export class CVoutV2 extends ComposableBuffer<Vout> implements Vout {
     return this.data.script
   }
 
-  public get dct_id (): number {
+  public get tokenId (): number {
     return 0x00
   }
 
@@ -135,15 +135,15 @@ export class CVoutV4 extends ComposableBuffer<Vout> implements Vout {
     return this.data.script
   }
 
-  public get dct_id (): number {
-    return this.data.dct_id
+  public get tokenId (): number {
+    return this.data.tokenId
   }
 
   composers (vout: Vout): BufferComposer[] {
     return [
       ComposableBuffer.satoshiAsBigNumber(() => vout.value, v => vout.value = v),
       ComposableBuffer.single<Script>(() => vout.script, v => vout.script = v, v => new CScript(v)),
-      ComposableBuffer.varUInt(() => vout.dct_id, v => vout.dct_id = v)
+      ComposableBuffer.varUInt(() => vout.tokenId, v => vout.tokenId = v)
     ]
   }
 }

--- a/packages/jellyfish-transaction/src/tx_signature.ts
+++ b/packages/jellyfish-transaction/src/tx_signature.ts
@@ -76,7 +76,7 @@ function hashOutputs (transaction: Transaction, sigHashType: SIGHASH): string {
     const satoshi = vout.value.multipliedBy(ONE_HUNDRED_MILLION)
     writeBigNumberUInt64(satoshi, buffer)
     scripting.fromOpCodesToBuffer(vout.script.stack, buffer)
-    writeVarUInt(vout.dct_id, buffer)
+    writeVarUInt(vout.tokenId, buffer)
   }
   return dSHA256(buffer.toBuffer()).toString('hex')
 }

--- a/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
@@ -29,7 +29,7 @@ const transaction: Transaction = {
       ]
     },
     value: new BigNumber('5.98'),
-    dct_id: 0x00
+    tokenId: 0x00
   }]
 }
 
@@ -41,7 +41,7 @@ const prevout: Vout = {
     ]
   },
   value: new BigNumber('6'),
-  dct_id: 0x00
+  tokenId: 0x00
 }
 
 describe('24 words: random', () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

`dct_id` naming convention is inconsistent with other variable and project across the field. Hence renaming to `tokenId` for consistency