### PR TITLE
add bs58 to jellyfish-crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@defich/jellyfish",
+  "name": "jellyfish",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -13112,6 +13112,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "dependencies": {
+        "base-x": "^3.0.6"
       }
     },
     "node_modules/@types/create-hash": {
@@ -29339,12 +29348,14 @@
       "dependencies": {
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
+        "bs58": "^4.0.1",
         "create-hash": "^1.2.0",
         "tiny-secp256k1": "^1.1.6",
         "wif": "^2.0.6"
       },
       "devDependencies": {
         "@types/bech32": "^1.1.2",
+        "@types/bs58": "^4.0.1",
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
         "@types/wif": "^2.0.2"
@@ -30610,11 +30621,13 @@
       "version": "file:packages/jellyfish-crypto",
       "requires": {
         "@types/bech32": "^1.1.2",
+        "@types/bs58": "^4.0.1",
         "@types/create-hash": "^1.2.2",
         "@types/tiny-secp256k1": "^1.0.0",
         "@types/wif": "^2.0.2",
         "bech32": "^2.0.0",
         "bip66": "^1.1.5",
+        "bs58": "^4.0.1",
         "create-hash": "^1.2.0",
         "tiny-secp256k1": "^1.1.6",
         "wif": "^2.0.6"
@@ -39898,6 +39911,15 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==",
+      "dev": true,
+      "requires": {
+        "base-x": "^3.0.6"
       }
     },
     "@types/create-hash": {

--- a/packages/jellyfish-crypto/__tests__/bech32.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bech32.test.ts
@@ -43,7 +43,7 @@ it('should convert pubkey to bech32', () => {
   expect(bech32).toBe(keypair.bech32)
 })
 
-it('should reject non 32 bytes long input (expected public key)', () => {
+it('should reject non 33 bytes long input (expected public key)', () => {
   expect(() => {
     // @ts-expect-error
     Bech32.fromPubKey(Buffer.from(keypair.pubKey, 'hex').slice(1), 'bcrt', 0x01)

--- a/packages/jellyfish-crypto/__tests__/bech32.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bech32.test.ts
@@ -43,6 +43,13 @@ it('should convert pubkey to bech32', () => {
   expect(bech32).toBe(keypair.bech32)
 })
 
+it('should reject non 32 bytes long input (expected public key)', () => {
+  expect(() => {
+    // @ts-expect-error
+    Bech32.fromPubKey(Buffer.from(keypair.pubKey, 'hex').slice(1), 'bcrt', 0x01)
+  }).toThrow('InvalidPubKeyLength')
+})
+
 it('should convert pubkey to bech32 with witness version', () => {
   const pubKey = Buffer.from(keypair.pubKey, 'hex')
   const bech32 = Bech32.fromPubKey(pubKey, keypair.hrp, 0x00)

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -45,4 +45,13 @@ describe('fromHash160()', () => {
     const address = Bs58.fromHash160(fixture.h160, fixture.prefix)
     expect(address).toEqual(fixture.base58)
   })
+
+  it('should reject non 20 bytes long data', () => {
+    try {
+      Bs58.fromHash160(fixture.h160.substring(1), fixture.prefix)
+      throw new Error('should fail')
+    } catch (e) {
+      expect(e.message).toEqual('InvalidDataLength')
+    }
+  })
 })

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -3,10 +3,7 @@ import { Bs58, HASH160 } from '../src'
 const fixture = {
   base58: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFi',
   prefix: 0x5a,
-  h160: '25a544c073cbca4e88d59f95ccd52e584c7e6a82',
-
-  invalidCharset: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFI',
-  invalidChecksum: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFj'
+  h160: '25a544c073cbca4e88d59f95ccd52e584c7e6a82'
 }
 
 describe('toHash160()', () => {
@@ -17,14 +14,16 @@ describe('toHash160()', () => {
   })
 
   it('should reject invalid address, invalid charset', async () => {
+    // edited last char, invalida checksum
     expect(() => {
-      Bs58.toHash160(fixture.invalidCharset)
+      Bs58.toHash160('dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFj')
     }).toThrow('Non-base58 character')
   })
 
   it('should reject invalid address, invalid charset', async () => {
     expect(() => {
-      Bs58.toHash160(fixture.invalidChecksum)
+      // edited, put 'O' invalid character into a normal valid address
+      Bs58.toHash160('dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFO')
     }).toThrow('InvalidBase58Address')
   })
 })

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -17,14 +17,14 @@ describe('toHash160()', () => {
     // edited last char, invalida checksum
     expect(() => {
       Bs58.toHash160('dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFj')
-    }).toThrow('Non-base58 character')
+    }).toThrow('InvalidBase58Address')
   })
 
   it('should reject invalid address, invalid charset', async () => {
     expect(() => {
       // edited, put 'O' invalid character into a normal valid address
       Bs58.toHash160('dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFO')
-    }).toThrow('InvalidBase58Address')
+    }).toThrow('Non-base58 character')
   })
 })
 

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -1,0 +1,48 @@
+import { Bs58 } from '../src'
+
+const fixture = {
+  base58: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1Uf8',
+  prefix: 0x5a,
+  h160: '1410c734d66b986f2a7c2c340a1ee18d83d9b5a2',
+
+  invalidCharset: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1UfI',
+  invalidChecksum: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1Uf7'
+}
+
+describe('toHash160()', () => {
+  it('should convert base58 to hash160 + prefix', () => {
+    const decoded = Bs58.toHash160(fixture.base58)
+    expect(decoded.prefix).toEqual(fixture.prefix)
+    expect(decoded.buffer.toString('hex')).toEqual(fixture.h160)
+  })
+
+  it('should reject invalid address, invalid charset', async () => {
+    try {
+      Bs58.toHash160(fixture.invalidCharset)
+      throw new Error('should fail')
+    } catch (e) {
+      expect(e.message).toEqual('Non-base58 character')
+    }
+  })
+
+  it('should reject invalid address, invalid charset', async () => {
+    try {
+      Bs58.toHash160(fixture.invalidChecksum)
+      throw new Error('should fail')
+    } catch (e) {
+      expect(e.message).toEqual('InvalidBase58Address')
+    }
+  })
+})
+
+describe('fromHash160()', () => {
+  it('should convert prefix + hash160 to base58', () => {
+    const address = Bs58.fromHash160(Buffer.from(fixture.h160, 'hex'), fixture.prefix)
+    expect(address).toEqual(fixture.base58)
+  })
+
+  it('should be able to take in hash160 string', () => {
+    const address = Bs58.fromHash160(fixture.h160, fixture.prefix)
+    expect(address).toEqual(fixture.base58)
+  })
+})

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -1,12 +1,12 @@
-import { Bs58 } from '../src'
+import { Bs58, HASH160 } from '../src'
 
 const fixture = {
-  base58: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1Uf8',
+  base58: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFi',
   prefix: 0x5a,
-  h160: '1410c734d66b986f2a7c2c340a1ee18d83d9b5a2',
+  h160: '25a544c073cbca4e88d59f95ccd52e584c7e6a82',
 
-  invalidCharset: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1UfI',
-  invalidChecksum: 'dFFPENo7FPMJpDV6fUcfo4QfkZrfrV1Uf7'
+  invalidCharset: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFI',
+  invalidChecksum: 'dGrLbw2nTo7de6tKF6cxCyiymarNaB1jFj'
 }
 
 describe('toHash160()', () => {
@@ -17,21 +17,15 @@ describe('toHash160()', () => {
   })
 
   it('should reject invalid address, invalid charset', async () => {
-    try {
+    expect(() => {
       Bs58.toHash160(fixture.invalidCharset)
-      throw new Error('should fail')
-    } catch (e) {
-      expect(e.message).toEqual('Non-base58 character')
-    }
+    }).toThrow('Non-base58 character')
   })
 
   it('should reject invalid address, invalid charset', async () => {
-    try {
+    expect(() => {
       Bs58.toHash160(fixture.invalidChecksum)
-      throw new Error('should fail')
-    } catch (e) {
-      expect(e.message).toEqual('InvalidBase58Address')
-    }
+    }).toThrow('InvalidBase58Address')
   })
 })
 
@@ -47,11 +41,34 @@ describe('fromHash160()', () => {
   })
 
   it('should reject non 20 bytes long data', () => {
-    try {
+    expect(() => {
       Bs58.fromHash160(fixture.h160.substring(1), fixture.prefix)
-      throw new Error('should fail')
-    } catch (e) {
-      expect(e.message).toEqual('InvalidDataLength')
-    }
+    }).toThrow('InvalidDataLength')
+  })
+})
+
+describe('fromPubKey()', () => {
+  const thirdyThreeBytes = '03987aec2e508e124468f0f07a836d185b329026e7aaf75be48cf12be8f18cbe81'
+  const pubKey = Buffer.from(thirdyThreeBytes, 'hex')
+  const invalidPubKey = Buffer.from(thirdyThreeBytes.slice(2), 'hex') // less 1 byte
+
+  beforeAll(() => {
+    expect(HASH160(pubKey).toString('hex')).toEqual(fixture.h160)
+  })
+
+  it('should convert prefix + hash160 to base58', () => {
+    const address = Bs58.fromPubKey(pubKey, fixture.prefix)
+    expect(address).toEqual(fixture.base58)
+  })
+
+  it('should be able to take in hash160 string', () => {
+    const address = Bs58.fromPubKey(pubKey, fixture.prefix)
+    expect(address).toEqual(fixture.base58)
+  })
+
+  it('should reject non 33 bytes long data', () => {
+    expect(() => {
+      Bs58.fromPubKey(invalidPubKey, fixture.prefix)
+    }).toThrow('InvalidPubKeyLength')
   })
 })

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -74,7 +74,7 @@ describe('fromPubKey()', () => {
 
   it('should reject version prefix > 255 (1 byte)', () => {
     expect(() => {
-      Bs58.fromPubKey(invalidPubKey, 256)
+      Bs58.fromPubKey(pubKey, 256)
     }).toThrow('InvalidVersionPrefix')
   })
 })

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -60,11 +60,6 @@ describe('fromPubKey()', () => {
     expect(address).toEqual(fixture.base58)
   })
 
-  it('should be able to take in hash160 string', () => {
-    const address = Bs58.fromPubKey(pubKey, fixture.prefix)
-    expect(address).toEqual(fixture.base58)
-  })
-
   it('should reject non 33 bytes long data', () => {
     expect(() => {
       Bs58.fromPubKey(invalidPubKey, fixture.prefix)

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -44,6 +44,12 @@ describe('fromHash160()', () => {
       Bs58.fromHash160(fixture.h160.substring(1), fixture.prefix)
     }).toThrow('InvalidDataLength')
   })
+
+  it('should reject version prefix > 255 (1 byte)', () => {
+    expect(() => {
+      Bs58.fromHash160(fixture.h160.substring(1), 256)
+    }).toThrow('InvalidVersionPrefix')
+  })
 })
 
 describe('fromPubKey()', () => {
@@ -64,5 +70,11 @@ describe('fromPubKey()', () => {
     expect(() => {
       Bs58.fromPubKey(invalidPubKey, fixture.prefix)
     }).toThrow('InvalidPubKeyLength')
+  })
+
+  it('should reject version prefix > 255 (1 byte)', () => {
+    expect(() => {
+      Bs58.fromPubKey(invalidPubKey, 256)
+    }).toThrow('InvalidVersionPrefix')
   })
 })

--- a/packages/jellyfish-crypto/__tests__/bs58.test.ts
+++ b/packages/jellyfish-crypto/__tests__/bs58.test.ts
@@ -47,7 +47,7 @@ describe('fromHash160()', () => {
 
   it('should reject version prefix > 255 (1 byte)', () => {
     expect(() => {
-      Bs58.fromHash160(fixture.h160.substring(1), 256)
+      Bs58.fromHash160(fixture.h160, 256)
     }).toThrow('InvalidVersionPrefix')
   })
 })

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -37,12 +37,14 @@
   "dependencies": {
     "bech32": "^2.0.0",
     "bip66": "^1.1.5",
+    "bs58": "^4.0.1",
     "create-hash": "^1.2.0",
     "tiny-secp256k1": "^1.1.6",
     "wif": "^2.0.6"
   },
   "devDependencies": {
     "@types/bech32": "^1.1.2",
+    "@types/bs58": "^4.0.1",
     "@types/create-hash": "^1.2.2",
     "@types/tiny-secp256k1": "^1.0.0",
     "@types/wif": "^2.0.2"

--- a/packages/jellyfish-crypto/src/bech32.ts
+++ b/packages/jellyfish-crypto/src/bech32.ts
@@ -52,6 +52,9 @@ export const Bech32 = {
    * @return {string} bech32 encoded address
    */
   fromPubKey (pubKey: Buffer, hrp: HRP, version: 0x00 = 0x00): string {
+    if (pubKey.length !== 33) {
+      throw new Error('InvalidPubKeyLength')
+    }
     const hash = HASH160(pubKey)
     return toBech32(hash, hrp, version)
   },

--- a/packages/jellyfish-crypto/src/bs58.ts
+++ b/packages/jellyfish-crypto/src/bs58.ts
@@ -1,0 +1,64 @@
+import bs58 from 'bs58'
+import { SHA256 } from './hash'
+
+export interface DecodedB58 {
+  buffer: Buffer
+  prefix: number
+}
+
+function _checksum (twentyOneBytes: Buffer): Buffer {
+  return SHA256(SHA256(twentyOneBytes)).slice(0, 4)
+}
+
+/**
+ * Decode a base58 address into 20 bytes data, for p2pkh and p2sh use
+ * @param base58 33 to 35 characters string (utf8)
+ * @returns {DecodedB58} 20 bytes data + 1 byte prefix
+ */
+function toHash160 (base58: string): DecodedB58 {
+  const buffer = bs58.decode(base58)
+  if (buffer.length !== 25) {
+    throw new Error('InvalidBase58Address')
+  }
+
+  const withPrefix = buffer.slice(0, 21)
+  const checksum = buffer.slice(21, 25)
+
+  const expectedChecksum = _checksum(withPrefix)
+  if (checksum.compare(expectedChecksum) !== 0) {
+    throw new Error('InvalidBase58Address')
+  }
+
+  return {
+    prefix: withPrefix[0],
+    buffer: withPrefix.slice(1, 21)
+  }
+}
+
+/**
+ * To create Base58 address using 20 bytes data + prefix, for p2pkh and p2sh use
+ * @param data 20 bytes Buffer or 40 characters string
+ * @param prefix 2 | 4 (TBD, enforce DeFiChain prefix only)
+ * @returns Base58 address (in utf8)
+ */
+function fromHash160 (data: string | Buffer, prefix: number): string {
+  if (typeof data === 'string') {
+    if (data.length !== 40) {
+      throw new Error('InvalidDataLength')
+    }
+  } else {
+    if (data.length !== 20) {
+      throw new Error('InvalidDataLength')
+    }
+  }
+
+  const buffer = typeof data === 'string' ? Buffer.from(data, 'hex') : data
+  const withPrefix = Buffer.from([prefix, ...buffer])
+  const checksum = _checksum(withPrefix)
+  return bs58.encode(Buffer.from([...withPrefix, ...checksum]))
+}
+
+export const Bs58 = {
+  toHash160,
+  fromHash160
+}

--- a/packages/jellyfish-crypto/src/bs58.ts
+++ b/packages/jellyfish-crypto/src/bs58.ts
@@ -43,13 +43,13 @@ function toHash160 (base58: string): DecodedB58 {
  */
 function fromHash160 (data: string | Buffer, prefix: number): string {
   if (typeof data === 'string') {
+    // 40 hex char string only
     if (data.length !== 40) {
       throw new Error('InvalidDataLength')
     }
-  } else {
-    if (data.length !== 20) {
-      throw new Error('InvalidDataLength')
-    }
+  } else if (data.length !== 20) {
+    // 20 bytes buffer only
+    throw new Error('InvalidDataLength')
   }
 
   if (prefix > 255) {

--- a/packages/jellyfish-crypto/src/bs58.ts
+++ b/packages/jellyfish-crypto/src/bs58.ts
@@ -12,7 +12,7 @@ function _checksum (twentyOneBytes: Buffer): Buffer {
 
 /**
  * Decode a base58 address into 20 bytes data, for p2pkh and p2sh use
- * @param base58 33 to 35 characters string (utf8)
+ * @param {string} base58 33 to 35 characters string (utf8)
  * @returns {DecodedB58} 20 bytes data + 1 byte prefix
  */
 function toHash160 (base58: string): DecodedB58 {
@@ -37,8 +37,8 @@ function toHash160 (base58: string): DecodedB58 {
 
 /**
  * To create Base58 address using 20 bytes data + prefix, for p2pkh and p2sh use
- * @param data 20 bytes Buffer or 40 characters string
- * @param prefix 2 | 4 (TBD, enforce DeFiChain prefix only)
+ * @param {Buffer|string} data 20 bytes Buffer or 40 characters string
+ * @param {number} prefix max = 255 = 1 byte
  * @returns Base58 address (in utf8)
  */
 function fromHash160 (data: string | Buffer, prefix: number): string {
@@ -52,16 +52,31 @@ function fromHash160 (data: string | Buffer, prefix: number): string {
     }
   }
 
+  if (prefix > 255) {
+    throw new Error('InvalidVersionPrefix')
+  }
+
   const buffer = typeof data === 'string' ? Buffer.from(data, 'hex') : data
   const withPrefix = Buffer.from([prefix, ...buffer])
   const checksum = _checksum(withPrefix)
   return bs58.encode(Buffer.from([...withPrefix, ...checksum]))
 }
 
+/**
+ * To create Base58 address using a raw 33 bytes (compressed) public key, for p2pkh and p2sh use
+ * @param {Buffer} pubKey 33 bytes long public key
+ * @param {number} prefix max = 255 = 1 byte
+ * @returns {string} base58 encoded string
+ */
 function fromPubKey (pubKey: Buffer, prefix: number): string {
   if (pubKey.length !== 33) {
     throw new Error('InvalidPubKeyLength')
   }
+
+  if (prefix > 255) {
+    throw new Error('InvalidVersionPrefix')
+  }
+
   const hash = HASH160(pubKey)
   return fromHash160(hash, prefix)
 }

--- a/packages/jellyfish-crypto/src/bs58.ts
+++ b/packages/jellyfish-crypto/src/bs58.ts
@@ -1,5 +1,5 @@
 import bs58 from 'bs58'
-import { SHA256 } from './hash'
+import { SHA256, HASH160 } from './hash'
 
 export interface DecodedB58 {
   buffer: Buffer
@@ -58,7 +58,16 @@ function fromHash160 (data: string | Buffer, prefix: number): string {
   return bs58.encode(Buffer.from([...withPrefix, ...checksum]))
 }
 
+function fromPubKey (pubKey: Buffer, prefix: number): string {
+  if (pubKey.length !== 33) {
+    throw new Error('InvalidPubKeyLength')
+  }
+  const hash = HASH160(pubKey)
+  return fromHash160(hash, prefix)
+}
+
 export const Bs58 = {
   toHash160,
+  fromPubKey,
   fromHash160
 }

--- a/packages/jellyfish-crypto/src/index.ts
+++ b/packages/jellyfish-crypto/src/index.ts
@@ -1,4 +1,5 @@
 export * from './bech32'
+export * from './bs58'
 export * from './der'
 export * from './elliptic'
 export * from './hash'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
- utility for other package to encode/decode b58
- more generic, should for other network B58 address after ICX too

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
