### PR TITLE
added ability to override testcontainers docker image

### DIFF
--- a/packages/testcontainers/__tests__/index.test.ts
+++ b/packages/testcontainers/__tests__/index.test.ts
@@ -53,3 +53,18 @@ describe('regtest', () => {
     expect(chain).toBe('regtest')
   })
 })
+
+describe('regtest: override docker image', () => {
+  const container = new RegTestContainer('defi/defichain:1.6.0')
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should be able to getmintinginfo and chain should be regtest', async () => {
+    await container.start()
+    await container.waitForReady()
+    const { chain } = await container.getMintingInfo()
+    expect(chain).toBe('regtest')
+  })
+})

--- a/packages/testcontainers/src/chains/main_net_container.ts
+++ b/packages/testcontainers/src/chains/main_net_container.ts
@@ -2,8 +2,12 @@ import { DockerOptions } from 'dockerode'
 import { DeFiDContainer } from './container'
 
 export class MainNetContainer extends DeFiDContainer {
-  constructor (options?: DockerOptions) {
-    super('mainnet', options)
+  /**
+   * @param {string} image docker image name
+   * @param {DockerOptions} options
+   */
+  constructor (image: string = DeFiDContainer.image, options?: DockerOptions) {
+    super('mainnet', image, options)
   }
 
   async getRpcPort (): Promise<string> {

--- a/packages/testcontainers/src/chains/reg_test_container/index.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/index.ts
@@ -5,8 +5,12 @@ import { DeFiDContainer, StartOptions } from '../container'
  * RegTest DeFiD container
  */
 export class RegTestContainer extends DeFiDContainer {
-  constructor (options?: DockerOptions) {
-    super('regtest', options)
+  /**
+   * @param {string} image docker image name
+   * @param {DockerOptions} options
+   */
+  constructor (image: string = DeFiDContainer.image, options?: DockerOptions) {
+    super('regtest', image, options)
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/testcontainers/src/chains/reg_test_container/masternode.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/masternode.ts
@@ -1,6 +1,6 @@
 import { GenesisKeys, MasterNodeKey } from '../../testkeys'
 import { DockerOptions } from 'dockerode'
-import { StartOptions } from '../container'
+import { DeFiDContainer, StartOptions } from '../container'
 import { RegTestContainer } from './index'
 
 /**
@@ -9,8 +9,13 @@ import { RegTestContainer } from './index'
 export class MasterNodeRegTestContainer extends RegTestContainer {
   private readonly masternodeKey: MasterNodeKey
 
-  constructor (masternodeKey: MasterNodeKey = GenesisKeys[0], options?: DockerOptions) {
-    super(options)
+  /**
+   * @param {string} masternodeKey pair to use for minting
+   * @param {string} image docker image name
+   * @param {DockerOptions} options
+   */
+  constructor (masternodeKey: MasterNodeKey = GenesisKeys[0], image: string = DeFiDContainer.image, options?: DockerOptions) {
+    super(image, options)
     this.masternodeKey = masternodeKey
   }
 

--- a/packages/testcontainers/src/chains/test_net_container.ts
+++ b/packages/testcontainers/src/chains/test_net_container.ts
@@ -2,8 +2,12 @@ import { DockerOptions } from 'dockerode'
 import { DeFiDContainer, StartOptions } from './container'
 
 export class TestNetContainer extends DeFiDContainer {
-  constructor (options?: DockerOptions) {
-    super('testnet', options)
+  /**
+   * @param {string} image docker image name
+   * @param {DockerOptions} options
+   */
+  constructor (image: string = DeFiDContainer.image, options?: DockerOptions) {
+    super('testnet', image, options)
   }
 
   protected getCmd (opts: StartOptions): string[] {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind feat

#### What this PR does / why we need it:

With this, you can override testcontainers default docker image to test bleeding-edge features.