### PR TITLE
Add new getMiningInfo for multiple masternode support

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/mining.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/mining.test.ts
@@ -80,4 +80,34 @@ describe('masternode', () => {
       expect(result).toBeGreaterThan(0)
     })
   })
+
+  it('should getMiningInfo', async () => {
+    await waitForExpect(async () => {
+      const info = await client.mining.getMiningInfo()
+      await expect(info.blocks).toBeGreaterThan(1)
+    })
+
+    const info = await client.mining.getMiningInfo()
+    const mn1 = info.masternodes[0]
+
+    expect(info.blocks).toBeGreaterThan(0)
+
+    expect(info.currentblockweight).toBeGreaterThan(0)
+    expect(info.currentblocktx).toBe(0)
+
+    expect(info.difficulty).toBeDefined()
+    expect(info.isoperator).toBe(true)
+
+    expect(mn1.masternodeid).toBeDefined()
+    expect(mn1.masternodeoperator).toBeDefined()
+    expect(mn1.masternodestate).toBe('ENABLED')
+    expect(mn1.generate).toBe(true)
+    expect(mn1.mintedblocks).toBe(0)
+    expect(mn1.lastblockcreationattempt).toBe('0')
+
+    expect(info.networkhashps).toBeGreaterThan(0)
+    expect(info.pooledtx).toBe(0)
+    expect(info.chain).toBe('regtest')
+    expect(info.warnings).toBe('')
+  })
 })

--- a/packages/jellyfish-api-core/src/category/mining.ts
+++ b/packages/jellyfish-api-core/src/category/mining.ts
@@ -24,9 +24,18 @@ export class Mining {
   /**
    * Get minting-related information
    * @return {Promise<MintingInfo>}
+   * @deprecated Prefer using getMiningInfo.
    */
   async getMintingInfo (): Promise<MintingInfo> {
     return await this.client.call('getmintinginfo', [], 'number')
+  }
+
+  /**
+   * Get mining-related information, replaces deprecated getMintingInfo
+   * @return {Promise<MiningInfo>}
+   */
+  async getMiningInfo (): Promise<MiningInfo> {
+    return await this.client.call('getmininginfo', [], 'number')
   }
 }
 
@@ -48,4 +57,32 @@ export interface MintingInfo {
   pooledtx: number
   chain: 'main' | 'test' | 'regtest' | string
   warnings: string
+}
+
+/**
+ * Minting related information
+ */
+export interface MiningInfo {
+  blocks: number
+  currentblockweight?: number
+  currentblocktx?: number
+  difficulty: string
+  isoperator: boolean
+  masternodes: MasternodeInfo[]
+  networkhashps: number
+  pooledtx: number
+  chain: 'main' | 'test' | 'regtest' | string
+  warnings: string
+}
+
+/**
+ * Masternode related information
+ */
+export interface MasternodeInfo {
+  masternodeid?: string
+  masternodeoperator?: string
+  masternodestate?: 'PRE_ENABLED' | 'ENABLED' | 'PRE_RESIGNED' | 'RESIGNED' | 'PRE_BANNED' | 'BANNED'
+  generate?: boolean
+  mintedblocks?: number
+  lastblockcreationattempt?: string
 }

--- a/website/docs/jellyfish/api/mining.md
+++ b/website/docs/jellyfish/api/mining.md
@@ -33,6 +33,9 @@ Get minting-related information.
 
 ```ts title="client.mining.getMintingInfo()"
 interface mining {
+  /**
+   * @deprecated prefer getMiningInfo for multiple masternode support.
+   */
   getMintingInfo (): Promise<MintingInfo>
 }
 

--- a/website/docs/jellyfish/api/mining.md
+++ b/website/docs/jellyfish/api/mining.md
@@ -29,7 +29,7 @@ interface mining {
 
 ## getMintingInfo
 
-Get minting-related information.
+Get minting-related information. Deprecated in favour of `mining.getMiningInfo()`.
 
 ```ts title="client.mining.getMintingInfo()"
 interface mining {
@@ -55,8 +55,8 @@ interface MintingInfo {
   chain: 'main' | 'test' | 'regtest' | string
   warnings: string
 }
-
 ```
+
 ## getMiningInfo
 
 Get minting-related information.
@@ -66,7 +66,7 @@ interface mining {
   getMiningInfo (): Promise<MiningInfo>
 }
 
-export interface MiningInfo {
+interface MiningInfo {
   blocks: number
   currentblockweight?: number
   currentblocktx?: number
@@ -82,7 +82,7 @@ export interface MiningInfo {
 /**
  * Masternode related information
  */
-export interface MasternodeInfo {
+interface MasternodeInfo {
   masternodeid?: string
   masternodeoperator?: string
   masternodestate?: 'PRE_ENABLED' | 'ENABLED' | 'PRE_RESIGNED' | 'RESIGNED' | 'PRE_BANNED' | 'BANNED'

--- a/website/docs/jellyfish/api/mining.md
+++ b/website/docs/jellyfish/api/mining.md
@@ -52,4 +52,39 @@ interface MintingInfo {
   chain: 'main' | 'test' | 'regtest' | string
   warnings: string
 }
+
+```
+## getMiningInfo
+
+Get minting-related information.
+
+```ts title="client.mining.getMiningInfo()"
+interface mining {
+  getMiningInfo (): Promise<MiningInfo>
+}
+
+export interface MiningInfo {
+  blocks: number
+  currentblockweight?: number
+  currentblocktx?: number
+  difficulty: string
+  isoperator: boolean
+  masternodes: MasternodeInfo[],
+  networkhashps: number
+  pooledtx: number
+  chain: 'main' | 'test' | 'regtest' | string
+  warnings: string
+}
+
+/**
+ * Masternode related information
+ */
+export interface MasternodeInfo {
+  masternodeid?: string
+  masternodeoperator?: string
+  masternodestate?: 'PRE_ENABLED' | 'ENABLED' | 'PRE_RESIGNED' | 'RESIGNED' | 'PRE_BANNED' | 'BANNED'
+  generate?: boolean
+  mintedblocks?: number
+  lastblockcreationattempt?: string
+}
 ```


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:
`getMintingInfo` is deprecated since adding multiple masternode support from within one server:
https://github.com/DeFiCh/ain/blob/df796cb7d6dbbe0ed7d051e79db0f36630f77afb/src/rpc/mining.cpp#L220

This PR adds `getMiningInfo` which is the implementation to support multiple mining masternodes:
https://github.com/DeFiCh/ain/blob/df796cb7d6dbbe0ed7d051e79db0f36630f77afb/src/rpc/mining.cpp#L276

#### Additional comments?:
* Added docs with a deprecated comment for the old one, but please advise if this is the correct way
* `getMintingInfo` is used as an example in some places, let me know if this PR should replace the examples as well
* Let me know if the test data should include a second node now, since there's an array to test now