### PR TITLE
fixed bip32.test.ts flakiness test as signature length can be lesser than 70

### DIFF
--- a/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
@@ -74,7 +74,8 @@ describe('24 words: random', () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.length).toBe(70)
+      expect(signature.length).toBeLessThanOrEqual(70)
+      expect(signature.length).toBeGreaterThanOrEqual(67) // 0.00001 probability of being this length
 
       const valid = await node.verify(hash, signature)
       expect(valid).toBe(true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

As the signature is an integer if the integer is lesser than the 'encoded 70' it can be lesser. Probability is low but it's there.