### PR TITLE
refactor DeFiAddress to export const

### DIFF
--- a/packages/jellyfish-address/__tests__/base58_address.test.ts
+++ b/packages/jellyfish-address/__tests__/base58_address.test.ts
@@ -33,7 +33,7 @@ describe('Base58Address', () => {
     pubKeyHashPrefix: 0x12,
     scriptHashPrefix: 0x00,
     messagePrefix: '\x00Dummy Msg Prefix:\n'
-  }
+  } as any
 
   describe('extensible, should work for any defined network protocol', () => {
     it('fromAddress() - valid', () => {

--- a/packages/jellyfish-address/__tests__/bech32_address.test.ts
+++ b/packages/jellyfish-address/__tests__/bech32_address.test.ts
@@ -30,7 +30,7 @@ describe('Bech32Address', () => {
     pubKeyHashPrefix: 0x00,
     scriptHashPrefix: 0x00,
     messagePrefix: '\x00Dummy Msg Prefix:\n'
-  }
+  } as any
 
   describe('extensible, should work for any defined network protocol', () => {
     it('fromAddress() - valid', () => {

--- a/packages/jellyfish-address/__tests__/p2pkh.test.ts
+++ b/packages/jellyfish-address/__tests__/p2pkh.test.ts
@@ -2,8 +2,7 @@ import bs58 from 'bs58'
 import { MainNet, RegTest, TestNet } from '@defichain/jellyfish-network'
 import { OP_CODES } from '@defichain/jellyfish-transaction/src/script'
 import { RegTestContainer } from '@defichain/testcontainers'
-import * as DeFiAddress from '../src'
-import { P2PKH } from '../src'
+import { DeFiAddress, P2PKH } from '../src'
 
 describe('P2PKH', () => {
   const container = new RegTestContainer()

--- a/packages/jellyfish-address/__tests__/p2sh.test.ts
+++ b/packages/jellyfish-address/__tests__/p2sh.test.ts
@@ -2,8 +2,7 @@ import bs58 from 'bs58'
 import { MainNet, RegTest, TestNet } from '@defichain/jellyfish-network'
 import { OP_CODES } from '@defichain/jellyfish-transaction/src/script'
 import { RegTestContainer } from '@defichain/testcontainers'
-import * as DeFiAddress from '../src'
-import { P2SH } from '../src'
+import { DeFiAddress, P2SH } from '../src'
 
 describe('P2SH', () => {
   const container = new RegTestContainer()

--- a/packages/jellyfish-address/__tests__/p2wpkh.test.ts
+++ b/packages/jellyfish-address/__tests__/p2wpkh.test.ts
@@ -1,8 +1,7 @@
 import { MainNet, RegTest, TestNet } from '@defichain/jellyfish-network'
 import { OP_CODES } from '@defichain/jellyfish-transaction/src/script'
 import { RegTestContainer } from '@defichain/testcontainers'
-import * as DeFiAddress from '../src'
-import { P2WPKH } from '../src'
+import { DeFiAddress, P2WPKH } from '../src'
 
 describe('P2WPKH', () => {
   const container = new RegTestContainer()

--- a/packages/jellyfish-address/__tests__/p2wsh.test.ts
+++ b/packages/jellyfish-address/__tests__/p2wsh.test.ts
@@ -1,7 +1,6 @@
 import { MainNet, RegTest, TestNet } from '@defichain/jellyfish-network'
 import { OP_CODES } from '@defichain/jellyfish-transaction/src/script'
-import * as DeFiAddress from '../src'
-import { P2WSH } from '../src'
+import { DeFiAddress, P2WSH } from '../src'
 
 describe('P2WSH', () => {
   const p2wshFixture = {

--- a/packages/jellyfish-address/src/index.ts
+++ b/packages/jellyfish-address/src/index.ts
@@ -76,7 +76,7 @@ function from<T extends Address> (net: NetworkName, address: string): T {
   return (possible.get(highestKey) as T)
 }
 
-export {
+export const DeFiAddress = {
   guess,
   from
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Avoid ES6 default export at all cost, technical debt minter.