### PR TITLE
Vin.txid to be decoded in BE order

### DIFF
--- a/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
@@ -57,9 +57,7 @@ export class MockPrevoutProvider implements PrevoutProvider {
 
   static mapPrevout (utxo: any, pubKey: Buffer): Prevout {
     return {
-      // utxo.id from defid is reversed, we uses non reversed order in txid
-      // TODO(fuxingloh): we need consistency for this. https://github.com/DeFiCh/jellyfish/issues/231
-      txid: Buffer.from(utxo.txid, 'hex').reverse().toString('hex'),
+      txid: utxo.txid,
       vout: utxo.vout,
       value: new BigNumber(utxo.amount),
       script: {

--- a/packages/jellyfish-transaction-builder/__tests__/raw_crafting.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/raw_crafting.ts
@@ -59,7 +59,7 @@ it('should craft, sign and broadcast a txn from scratch', async () => {
         script: { stack: [] },
         sequence: 0xffffffff,
         // container.fundAddress returns in BE
-        txid: Buffer.from(txid, 'hex').reverse().toString('hex')
+        txid: txid
       }
     ],
     vout: [

--- a/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
+++ b/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
@@ -97,7 +97,7 @@ describe('ComposableBuffer deep implementation', () => {
       return [
         ComposableBuffer.uInt16(() => data.ver, v => data.ver = v),
         ComposableBuffer.uInt32(() => data.val, v => data.val = v),
-        ComposableBuffer.hexLE(8, () => data.hex, v => data.hex = v)
+        ComposableBuffer.hex(8, () => data.hex, v => data.hex = v)
       ]
     }
 
@@ -183,7 +183,7 @@ describe('ComposableBuffer.varUIntArray', () => {
     composers (data: VarItem): BufferComposer[] {
       return [
         ComposableBuffer.uInt16(() => data.val, v => data.val = v),
-        ComposableBuffer.hexLE(12, () => data.hex, v => data.hex = v)
+        ComposableBuffer.hex(12, () => data.hex, v => data.hex = v)
       ]
     }
   }
@@ -233,7 +233,7 @@ describe('ComposableBuffer.varUIntArray', () => {
 
       expect(() => {
         composer.toBuffer(new SmartBuffer())
-      }).toThrow('ComposableBuffer.hexLE.toBuffer invalid as length != getter().length')
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
     })
 
     it('should fail toBuffer deeply due to value out of range', () => {
@@ -263,7 +263,7 @@ describe('ComposableBuffer.array', () => {
     composers (data: Item): BufferComposer[] {
       return [
         ComposableBuffer.bigNumberUInt64(() => data.value, v => data.value = v),
-        ComposableBuffer.hexLE(32, () => data.txid, v => data.txid = v)
+        ComposableBuffer.hex(32, () => data.txid, v => data.txid = v)
       ]
     }
   }
@@ -312,7 +312,7 @@ describe('ComposableBuffer.array', () => {
 
       expect(() => {
         composer.toBuffer(new SmartBuffer())
-      }).toThrow('ComposableBuffer.hexLE.toBuffer invalid as length != getter().length')
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
     })
 
     it('should fail toBuffer deeply due to value out of range', () => {
@@ -344,7 +344,7 @@ describe('ComposableBuffer.single', () => {
   class CSingle extends ComposableBuffer<Single> {
     composers (data: Single): BufferComposer[] {
       return [
-        ComposableBuffer.hexLE(16, () => data.id, v => data.id = v),
+        ComposableBuffer.hex(16, () => data.id, v => data.id = v),
         ComposableBuffer.uInt16(() => data.value, v => data.value = v)
       ]
     }
@@ -385,7 +385,7 @@ describe('ComposableBuffer.single', () => {
 
       expect(() => {
         composer.toBuffer(new SmartBuffer())
-      }).toThrow('ComposableBuffer.hexLE.toBuffer invalid as length != getter().length')
+      }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
     })
 
     it('should fail toBuffer deeply due to value out of range', () => {
@@ -401,8 +401,8 @@ describe('ComposableBuffer.single', () => {
   })
 })
 
-describe('ComposableBuffer.hexLE', () => {
-  const composer = ComposableBuffer.hexLE(16, () => value, (v: string) => value = v)
+describe('ComposableBuffer.hex', () => {
+  const composer = ComposableBuffer.hex(16, () => value, (v: string) => value = v)
   const expectedBuffer = Buffer.from('9ea83a5c6579d282d189cc04b8e151ef', 'hex')
   let value = ''
 
@@ -435,12 +435,12 @@ describe('ComposableBuffer.hexLE', () => {
 
     expect(() => {
       composer.toBuffer(new SmartBuffer())
-    }).toThrow('ComposableBuffer.hexLE.toBuffer invalid as length != getter().length')
+    }).toThrow('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
   })
 })
 
 describe('ComposableBuffer.hexBE', () => {
-  const composer = ComposableBuffer.hexBE(16, () => value, (v: string) => value = v)
+  const composer = ComposableBuffer.hexBEBufferLE(16, () => value, (v: string) => value = v)
   const expectedBuffer = Buffer.from('9ea83a5c6579d282d189cc04b8e151ef', 'hex')
   let value = ''
 
@@ -473,7 +473,7 @@ describe('ComposableBuffer.hexBE', () => {
 
     expect(() => {
       composer.toBuffer(new SmartBuffer())
-    }).toThrow('ComposableBuffer.hexBE.toBuffer invalid as length != getter().length')
+    }).toThrow('ComposableBuffer.hexBEBufferLE.toBuffer invalid as length != getter().length')
   })
 })
 

--- a/packages/jellyfish-transaction/__tests__/index.test.ts
+++ b/packages/jellyfish-transaction/__tests__/index.test.ts
@@ -15,7 +15,7 @@ it('should be able to use DeFiTransactionConstants constants to craft Transactio
           stack: []
         },
         sequence: 0xffffffff,
-        txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+        txid: '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef'
       }
     ],
     vout: [

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CTransaction.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CTransaction.test.ts
@@ -61,7 +61,7 @@ describe('CTransaction', () => {
             stack: []
           },
           sequence: 4294967278,
-          txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+          txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff'
         },
         {
           index: 1,
@@ -69,7 +69,7 @@ describe('CTransaction', () => {
             stack: []
           },
           sequence: 4294967295,
-          txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+          txid: '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef'
         }
       ],
       vout: [
@@ -113,7 +113,7 @@ describe('CTransaction', () => {
   })
 
   describe('P2SH-P2WPKH (UNSIGNED)', () => {
-    const hex = '0400000001db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a54770100000000feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac000008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac0092040000'
+    const hex = '040000000177541aeb3c4dac9260b68f74f44c973081a9d4cb2ebe8038b2d70faa201b6bdb0100000000feffffff02b8b4eb0b000000001976a914a457b684d7f0d539a46a45bbc043f35b59d0d96388ac000008af2f000000001976a914fd270b1ee6abcaea97fea7ad0402e8bd8ad6d77c88ac0092040000'
     const data: Transaction = {
       version: 0x00000004,
       vin: [
@@ -167,7 +167,7 @@ describe('CTransaction', () => {
   })
 
   describe('P2WSH (UNSIGNED)', () => {
-    const hex = '0400000002fe3dc9208094f3ffd12645477b3dc56f60ec4fa8e6f5d67c565d1c6b9216b36e0000000000ffffffff0815cf020f013ed6cf91d29f4202e8a58726b1ac6c79da47c23d1bee0a6925f80000000000ffffffff0100f2052a010000001976a914a30741f8145e5acadf23f751864167f32e0963f788ac0000000000'
+    const hex = '04000000026eb316926b1c5d567cd6f5e6a84fec606fc53d7b474526d1fff3948020c93dfe0000000000fffffffff825690aee1b3dc247da796cacb12687a5e802429fd291cfd63e010f02cf15080000000000ffffffff0100f2052a010000001976a914a30741f8145e5acadf23f751864167f32e0963f788ac0000000000'
     const data: Transaction = {
       version: 0x00000004,
       vin: [
@@ -216,7 +216,7 @@ describe('CTransaction', () => {
   })
 
   describe('P2SH-P2WSH (UNSIGNED)', () => {
-    const hex = '040000000136641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e0100000000ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688ac00c0832f05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac0000000000'
+    const hex = '04000000016eb98797a21c6c10aa74edf29d618be109f48a8e94c694f3701e08ca691864360100000000ffffffff0200e9a435000000001976a914389ffce9cd9ae88dcc0631e88a821ffdbe9bfe2688ac00c0832f05000000001976a9147480a33f950689af511e6e84c138dbbd3c3ee41588ac0000000000'
     const data: Transaction = {
       version: 0x00000004,
       vin: [

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionSegWit.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CTransactionSegWit.test.ts
@@ -79,7 +79,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           sequence: 4294967278,
-          txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+          txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff'
         },
         {
           index: 1,
@@ -87,7 +87,7 @@ describe('CTransactionSegWit', () => {
             stack: []
           },
           sequence: 4294967295,
-          txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+          txid: '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef'
         }
       ],
       vout: [
@@ -166,7 +166,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           sequence: 4294967294,
-          txid: 'db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477'
+          txid: '77541aeb3c4dac9260b68f74f44c973081a9d4cb2ebe8038b2d70faa201b6bdb'
         }
       ],
       vout: [
@@ -236,7 +236,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           sequence: 4294967295,
-          txid: 'fe3dc9208094f3ffd12645477b3dc56f60ec4fa8e6f5d67c565d1c6b9216b36e'
+          txid: '6eb316926b1c5d567cd6f5e6a84fec606fc53d7b474526d1fff3948020c93dfe'
         },
         {
           index: 0,
@@ -244,7 +244,7 @@ describe('CTransactionSegWit', () => {
             stack: []
           },
           sequence: 4294967295,
-          txid: '0815cf020f013ed6cf91d29f4202e8a58726b1ac6c79da47c23d1bee0a6925f8'
+          txid: 'f825690aee1b3dc247da796cacb12687a5e802429fd291cfd63e010f02cf1508'
         }
       ],
       vout: [
@@ -307,7 +307,7 @@ describe('CTransactionSegWit', () => {
             ]
           },
           sequence: 4294967295,
-          txid: '36641869ca081e70f394c6948e8af409e18b619df2ed74aa106c1ca29787b96e'
+          txid: '6eb98797a21c6c10aa74edf29d618be109f48a8e94c694f3701e08ca69186436'
         }
       ],
       vout: [

--- a/packages/jellyfish-transaction/__tests__/tx_composer/CVin.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_composer/CVin.test.ts
@@ -5,7 +5,7 @@ describe('CVin', () => {
   describe('P2KH (UNSIGNED)', () => {
     const hex = 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f0000000000eeffffff'
     const data: Vin = {
-      txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f',
+      txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff',
       index: 0x00000000,
       script: {
         stack: []
@@ -25,7 +25,7 @@ describe('CVin', () => {
   describe('P2KH (SIGNED)', () => {
     const hex = 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f00000000494830450221008b9d1dc26ba6a9cb62127b02742fa9d754cd3bebf337f7a55d114c8e5cdd30be022040529b194ba3f9281a99f2b1c0a19c0489bc22ede944ccf4ecbab4cc618ef3ed01eeffffff'
     const data: Vin = {
-      txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f',
+      txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff',
       index: 0x00000000,
       script: {
         stack: [
@@ -47,7 +47,7 @@ describe('CVin', () => {
   describe('P2WPKH (SEGWIT)', () => {
     const hex = 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff'
     const data: Vin = {
-      txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a',
+      txid: '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef',
       index: 0x00000001,
       script: {
         stack: []
@@ -67,7 +67,7 @@ describe('CVin', () => {
   describe('P2SH-P2WPKH (UNSIGNED)', () => {
     const hex = 'db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a54770100000000feffffff'
     const data: Vin = {
-      txid: 'db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477',
+      txid: '77541aeb3c4dac9260b68f74f44c973081a9d4cb2ebe8038b2d70faa201b6bdb',
       index: 0x00000001,
       script: {
         stack: []
@@ -87,7 +87,7 @@ describe('CVin', () => {
   describe('P2SH-P2WPKH (SIGNED-SEGWIT)', () => {
     const hex = 'db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477010000001716001479091972186c449eb1ded22b78e40d009bdf0089feffffff'
     const data: Vin = {
-      txid: 'db6b1b20aa0fd7b23880be2ecbd4a98130974cf4748fb66092ac4d3ceb1a5477',
+      txid: '77541aeb3c4dac9260b68f74f44c973081a9d4cb2ebe8038b2d70faa201b6bdb',
       index: 0x00000001,
       script: {
         stack: [

--- a/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
+++ b/packages/jellyfish-transaction/__tests__/tx_signature/sign_input.test.ts
@@ -13,7 +13,7 @@ describe('sign single input', () => {
           stack: []
         },
         sequence: 4294967278,
-        txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+        txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff'
       },
       {
         index: 1,
@@ -21,7 +21,7 @@ describe('sign single input', () => {
           stack: []
         },
         sequence: 4294967295,
-        txid: 'ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a'
+        txid: '8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef'
       }
     ],
     vout: [

--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -177,14 +177,15 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
-   * LE ordered HEX String with length specified, encoded in LE order buffer.
+   * HEX String with length specified, encoded into Buffer as the same order of the Hex String.
+   * In short this read a hex and push it into the Buffer. It will not re-order the endian.
    *
    * @param length of the bytes to read/set
-   * @param getter to read LE ordered HEX String and write as LE ordered Buffer
-   * @param setter to read LE ordered Buffer and set as LE ordered HEX String
+   * @param getter to read HEX String and write as the same ordered Buffer
+   * @param setter to read ordered Buffer and set as the same ordered HEX String
    * @throws Error if length != getter().length in set
    */
-  static hexLE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
+  static hex (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
     return {
       fromBuffer: (buffer: SmartBuffer): void => {
         const buff = Buffer.from(buffer.readBuffer(length))
@@ -193,7 +194,7 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
       toBuffer: (buffer: SmartBuffer): void => {
         const hex = getter()
         if (hex.length !== length * 2) {
-          throw new Error('ComposableBuffer.hexLE.toBuffer invalid as length != getter().length')
+          throw new Error('ComposableBuffer.hex.toBuffer invalid as length != getter().length')
         }
         const buff: Buffer = Buffer.from(hex, 'hex')
         buffer.writeBuffer(buff)
@@ -203,13 +204,14 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
 
   /**
    * BE ordered HEX String with length specified, encoded in LE order buffer.
+   * Different from BufferComposer.hex, this will reorder the Buffer from LE to BE and BE to LE.
    *
    * @param length of the bytes to read/set
    * @param getter to read BE ordered HEX String and write as LE ordered Buffer
    * @param setter to read LE ordered Buffer and set as BE ordered HEX String
    * @throws Error if length != getter().length in set
    */
-  static hexBE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
+  static hexBEBufferLE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
     return {
       fromBuffer: (buffer: SmartBuffer): void => {
         const buff = Buffer.from(buffer.readBuffer(length)).reverse()
@@ -218,7 +220,7 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
       toBuffer: (buffer: SmartBuffer): void => {
         const hex = getter()
         if (hex.length !== length * 2) {
-          throw new Error('ComposableBuffer.hexBE.toBuffer invalid as length != getter().length')
+          throw new Error('ComposableBuffer.hexBEBufferLE.toBuffer invalid as length != getter().length')
         }
         const buff: Buffer = Buffer.from(hex, 'hex').reverse()
         buffer.writeBuffer(buff)
@@ -319,9 +321,6 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
       }
     }
   }
-
-  // TODO(jellyfish): with the introduction of hexLE, hexBE, utf8LE, utf8BE
-  //  might want to indicate LE for all unsigned integer
 
   /**
    * Unsigned Int8, 1 byte

--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -177,15 +177,14 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
-   * Read/write as little endian, set/get as little endian.
+   * LE ordered HEX String with length specified, encoded in LE order buffer.
    *
    * @param length of the bytes to read/set
-   * @param getter to read hex from to buffer
-   * @param setter to set to hex from buffer
+   * @param getter to read LE ordered HEX String and write as LE ordered Buffer
+   * @param setter to read LE ordered Buffer and set as LE ordered HEX String
    * @throws Error if length != getter().length in set
    */
   static hexLE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
-    // TODO(fuxingloh): this wrong, fix in another PR
     return {
       fromBuffer: (buffer: SmartBuffer): void => {
         const buff = Buffer.from(buffer.readBuffer(length))
@@ -203,15 +202,14 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
-   * Read/write as big endian, set/get as big endian.
+   * BE ordered HEX String with length specified, encoded in LE order buffer.
    *
    * @param length of the bytes to read/set
-   * @param getter to read hex from to buffer
-   * @param setter to set to hex from buffer
+   * @param getter to read BE ordered HEX String and write as LE ordered Buffer
+   * @param setter to read LE ordered Buffer and set as BE ordered HEX String
    * @throws Error if length != getter().length in set
    */
   static hexBE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
-    // TODO(fuxingloh): this wrong, fix in another PR
     return {
       fromBuffer: (buffer: SmartBuffer): void => {
         const buff = Buffer.from(buffer.readBuffer(length)).reverse()
@@ -233,8 +231,8 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
    * String is always BE, as Javascript is uses BE by default.
    *
    * @param length of the bytes to read/set
-   * @param getter to read BE ordered string and write as LE ordered Buffer
-   * @param setter to write LE ordered Buffer and set as BE ordered string
+   * @param getter to read BE ordered String and write as LE ordered Buffer
+   * @param setter to read LE ordered Buffer and set as BE ordered String
    * @throws Error if length != getter().length in set
    */
   static utf8LE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
@@ -258,8 +256,8 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
    * String is always BE, as Javascript is uses BE by default.
    *
    * @param length of the bytes to read/set
-   * @param getter to read BE ordered string and write as BE ordered Buffer
-   * @param setter to write BE ordered Buffer and set as BE ordered string
+   * @param getter to read BE ordered String and write as BE ordered Buffer
+   * @param setter to read BE ordered Buffer and set as BE ordered String
    * @throws Error if length != getter().length in set
    */
   static utf8BE (length: number, getter: () => string, setter: (data: string) => void): BufferComposer {
@@ -282,8 +280,8 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
    * VarUInt sized UTF-8 string, encoded in LE order buffer.
    * String is always BE, as Javascript is uses BE by default.
    *
-   * @param getter to read BE ordered string and write as LE ordered Buffer
-   * @param setter to write LE ordered Buffer and set as BE ordered string
+   * @param getter to read BE ordered String and write as LE ordered Buffer
+   * @param setter to read LE ordered Buffer and set as BE ordered String
    */
   static varUIntUtf8LE (getter: () => string, setter: (data: string) => void): BufferComposer {
     return {
@@ -304,8 +302,8 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
    * VarUInt sized UTF-8 string, encoded in BE order buffer.
    * String is always BE, as Javascript is uses BE by default.
    *
-   * @param getter to read BE ordered string and write as BE ordered Buffer
-   * @param setter to write BE ordered Buffer and set as BE ordered string
+   * @param getter to read BE ordered String and write as BE ordered Buffer
+   * @param setter to read BE ordered Buffer and set as BE ordered String
    */
   static varUIntUtf8BE (getter: () => string, setter: (data: string) => void): BufferComposer {
     return {

--- a/packages/jellyfish-transaction/src/script/mapping.ts
+++ b/packages/jellyfish-transaction/src/script/mapping.ts
@@ -74,7 +74,7 @@ export const OP_CODES = {
    *   OP_0
    *   OP_PUSHDATA<RIPEMD160(SHA256(pubkey))>
    *
-   * @param buffer {SmartBuffer} to read from
+   * @param {SmartBuffer} buffer to read from
    * @return {OPCode[]} read from buffer to OPCode
    */
   fromBuffer (buffer: SmartBuffer) {
@@ -105,8 +105,8 @@ export const OP_CODES = {
    *   0x88 (OP_EQUALVERIFY)
    *   0xac (OP_CHECKSIG)
    *
-   * @param stack {OPCode[]} to convert into raw buffer
-   * @param buffer {SmartBuffer} to write to
+   * @param {OPCode[]} stack to convert into raw buffer
+   * @param {SmartBuffer} buffer to write to
    */
   toBuffer (stack: OPCode[], buffer: SmartBuffer) {
     const buffs = toBuffer(stack)
@@ -189,9 +189,17 @@ export const OP_CODES = {
    * OP_PUSHDATA1 use OP_PUSHDATA
    * OP_PUSHDATA2 use OP_PUSHDATA
    * OP_PUSHDATA4 use OP_PUSHDATA
+   * @param {Buffer} buffer
+   * @param {'little' | 'big'} endian order
    */
   OP_PUSHDATA: (buffer: Buffer, endian: 'little' | 'big'): OP_PUSHDATA => {
     return new OP_PUSHDATA(buffer, endian)
+  },
+  /**
+   * @param {Buffer} buffer in little endian
+   */
+  OP_PUSHDATA_LE: (buffer: Buffer): OP_PUSHDATA => {
+    return new OP_PUSHDATA(buffer, 'little')
   },
   /**
    * @param {string} hex in little endian
@@ -199,6 +207,7 @@ export const OP_CODES = {
   OP_PUSHDATA_HEX_LE: (hex: string): OP_PUSHDATA => {
     return new OP_PUSHDATA(Buffer.from(hex, 'hex'), 'little')
   },
+
   // TODO: to map everything as class
   //  to be separated into concerns, stack, arithmetic, crypto, etc...
 

--- a/packages/jellyfish-transaction/src/tx_composer.ts
+++ b/packages/jellyfish-transaction/src/tx_composer.ts
@@ -83,7 +83,8 @@ export class CVin extends ComposableBuffer<Vin> implements Vin {
 
   composers (vin: Vin): BufferComposer[] {
     return [
-      ComposableBuffer.hexLE(32, () => vin.txid, v => vin.txid = v),
+      // defid returns txid in BE order hence we need to reverse it
+      ComposableBuffer.hexBE(32, () => vin.txid, v => vin.txid = v),
       ComposableBuffer.uInt32(() => vin.index, v => vin.index = v),
       ComposableBuffer.single<Script>(() => vin.script, v => vin.script = v, v => new CScript(v)),
       ComposableBuffer.uInt32(() => vin.sequence, v => vin.sequence = v)

--- a/packages/jellyfish-transaction/src/tx_composer.ts
+++ b/packages/jellyfish-transaction/src/tx_composer.ts
@@ -84,7 +84,7 @@ export class CVin extends ComposableBuffer<Vin> implements Vin {
   composers (vin: Vin): BufferComposer[] {
     return [
       // defid returns txid in BE order hence we need to reverse it
-      ComposableBuffer.hexBE(32, () => vin.txid, v => vin.txid = v),
+      ComposableBuffer.hexBEBufferLE(32, () => vin.txid, v => vin.txid = v),
       ComposableBuffer.uInt32(() => vin.index, v => vin.index = v),
       ComposableBuffer.single<Script>(() => vin.script, v => vin.script = v, v => new CScript(v)),
       ComposableBuffer.uInt32(() => vin.sequence, v => vin.sequence = v)

--- a/packages/jellyfish-transaction/src/tx_segwit.ts
+++ b/packages/jellyfish-transaction/src/tx_segwit.ts
@@ -39,14 +39,14 @@ export class CWitnessProgram extends ComposableBuffer<WitnessProgram> {
   composers (wp: WitnessProgram): BufferComposer[] {
     return [
       ComposableBuffer.uInt32(() => wp.version, v => wp.version = v),
-      ComposableBuffer.hexLE(32, () => wp.hashPrevouts, v => wp.hashPrevouts = v),
-      ComposableBuffer.hexLE(32, () => wp.hashSequence, v => wp.hashSequence = v),
-      ComposableBuffer.hexBE(32, () => wp.outpointTxId, v => wp.outpointTxId = v),
+      ComposableBuffer.hex(32, () => wp.hashPrevouts, v => wp.hashPrevouts = v),
+      ComposableBuffer.hex(32, () => wp.hashSequence, v => wp.hashSequence = v),
+      ComposableBuffer.hexBEBufferLE(32, () => wp.outpointTxId, v => wp.outpointTxId = v),
       ComposableBuffer.uInt32(() => wp.outpointIndex, v => wp.outpointIndex = v),
       ComposableBuffer.single<Script>(() => wp.scriptCode, v => wp.scriptCode = v, v => new CScript(v)),
       ComposableBuffer.satoshiAsBigNumber(() => wp.value, v => wp.value = v),
       ComposableBuffer.uInt32(() => wp.sequence, v => wp.sequence = v),
-      ComposableBuffer.hexLE(32, () => wp.hashOutputs, v => wp.hashOutputs = v),
+      ComposableBuffer.hex(32, () => wp.hashOutputs, v => wp.hashOutputs = v),
       ComposableBuffer.uInt32(() => wp.lockTime, v => wp.lockTime = v),
       ComposableBuffer.uInt32(() => wp.hashType, v => wp.hashType = v)
     ]

--- a/packages/jellyfish-transaction/src/tx_segwit.ts
+++ b/packages/jellyfish-transaction/src/tx_segwit.ts
@@ -41,7 +41,7 @@ export class CWitnessProgram extends ComposableBuffer<WitnessProgram> {
       ComposableBuffer.uInt32(() => wp.version, v => wp.version = v),
       ComposableBuffer.hexLE(32, () => wp.hashPrevouts, v => wp.hashPrevouts = v),
       ComposableBuffer.hexLE(32, () => wp.hashSequence, v => wp.hashSequence = v),
-      ComposableBuffer.hexLE(32, () => wp.outpointTxId, v => wp.outpointTxId = v),
+      ComposableBuffer.hexBE(32, () => wp.outpointTxId, v => wp.outpointTxId = v),
       ComposableBuffer.uInt32(() => wp.outpointIndex, v => wp.outpointIndex = v),
       ComposableBuffer.single<Script>(() => wp.scriptCode, v => wp.scriptCode = v, v => new CScript(v)),
       ComposableBuffer.satoshiAsBigNumber(() => wp.value, v => wp.value = v),

--- a/packages/jellyfish-transaction/src/tx_signature.ts
+++ b/packages/jellyfish-transaction/src/tx_signature.ts
@@ -48,7 +48,8 @@ function hashPrevouts (transaction: Transaction, sigHashType: SIGHASH): string {
 
   const buffer = new SmartBuffer()
   for (const vin of transaction.vin) {
-    buffer.writeBuffer(Buffer.from(vin.txid, 'hex'))
+    const txid = Buffer.from(vin.txid, 'hex').reverse()
+    buffer.writeBuffer(txid)
     buffer.writeUInt32LE(vin.index)
   }
   return dSHA256(buffer.toBuffer()).toString('hex')

--- a/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/mnemonic/bip32.test.ts
@@ -19,7 +19,7 @@ const transaction: Transaction = {
     index: 0,
     script: { stack: [] },
     sequence: 4294967278,
-    txid: 'fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4e4ad969f'
+    txid: '9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff'
   }],
   vout: [{
     script: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

`Vin.txid` to be decoded in BE order but re-encoded as LE. This is for consistency with defid, see #231 

#### Which issue(s) does this PR fixes?:
Fixes #231
