### PR TITLE
fix RpcApiError rpcMethod wrong param

### DIFF
--- a/packages/jellyfish-api-core/__tests__/container_adapter_client.ts
+++ b/packages/jellyfish-api-core/__tests__/container_adapter_client.ts
@@ -31,7 +31,7 @@ export class ContainerAdapterClient extends ApiClient {
     })
 
     if (error != null) {
-      throw new RpcApiError({ ...error, rpcMethod: method })
+      throw new RpcApiError({ ...error, method: method })
     }
 
     return result

--- a/packages/jellyfish-api-core/src/index.ts
+++ b/packages/jellyfish-api-core/src/index.ts
@@ -78,10 +78,10 @@ export class ClientApiError extends ApiError {
  * API RPC error, from upstream.
  */
 export class RpcApiError extends ApiError {
-  public readonly payload: { code: number, message: string, rpcMethod: string }
+  public readonly payload: { code: number, message: string, method: string }
 
-  constructor (error: { code: number, message: string, rpcMethod: string }) {
-    super(`RpcApiError: '${error.message}', code: ${error.code}, rpcMethod: ${error.rpcMethod}`)
+  constructor (error: { code: number, message: string, method: string }) {
+    super(`RpcApiError: '${error.message}', code: ${error.code}, method: ${error.method}`)
     this.payload = error
   }
 }

--- a/packages/jellyfish-api-jsonrpc/__tests__/index.test.ts
+++ b/packages/jellyfish-api-jsonrpc/__tests__/index.test.ts
@@ -83,7 +83,7 @@ describe('ApiError', () => {
 
     await expect(promise).rejects.toThrow(ApiError)
     await expect(promise).rejects.toThrow(RpcApiError)
-    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid private key encoding\', code: -5')
+    await expect(promise).rejects.toThrow(/^RpcApiError: 'Invalid private key encoding', code: -5, method: importprivkey$/)
   })
 
   it('should throw ClientApiError: 404 - Not Found', async () => {

--- a/packages/jellyfish-api-jsonrpc/src/index.ts
+++ b/packages/jellyfish-api-jsonrpc/src/index.ts
@@ -67,7 +67,7 @@ export class JsonRpcClient extends ApiClient {
     switch (response.status) {
       case 200:
       default:
-        return JsonRpcClient.parse(text, precision)
+        return JsonRpcClient.parse(method, text, precision)
 
       case 401:
       case 404:
@@ -84,13 +84,13 @@ export class JsonRpcClient extends ApiClient {
     })
   }
 
-  private static parse (text: string, precision: Precision | PrecisionPath): any {
+  private static parse (method: string, text: string, precision: Precision | PrecisionPath): any {
     const { result, error } = JellyfishJSON.parse(text, {
       result: precision
     })
 
     if (error != null) {
-      throw new RpcApiError({ ...error, rpcMethod: text })
+      throw new RpcApiError({ ...error, method: method })
     }
 
     return result


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

1. RpcApiError passed in wrong param
2. rename `rpcMethod` to just `method`, `Rpc` is already part of the class name.
3. Added stricter test to assert errors.

