### PR TITLE
Faster CI with --maxWorkers=4 + npm caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
         with:
           node-version: '15'
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - run: npm ci
       - run: npm run build
 
@@ -31,6 +38,13 @@ jobs:
         with:
           node-version: '15'
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - run: npm ci
       - run: npm run build
       - run: npx --no-install ts-standard
@@ -43,6 +57,13 @@ jobs:
       - uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
         with:
           node-version: '15'
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - uses: andresz1/size-limit-action@c53e18c847d5eb13f61754c45f3fbfc3aa5c17cc
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish:latest": "lerna exec -- npm publish --tag latest --access public",
     "standard": "ts-standard --fix",
     "test": "jest",
-    "test:ci": "jest --ci --coverage --forceExit --maxWorkers=5",
+    "test:ci": "jest --ci --coverage --forceExit --maxWorkers=4",
     "all": "npm run build && npm run standard && npm run test"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "publish:latest": "lerna exec -- npm publish --tag latest --access public",
     "standard": "ts-standard --fix",
     "test": "jest",
-    "test:ci": "jest --ci --coverage --forceExit",
+    "test:ci": "jest --ci --coverage --forceExit --maxWorkers=5",
     "all": "npm run build && npm run standard && npm run test"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

- Improved CI performance for running test by adding -maxWorkers=4 (CI uses 2 core, 2x2 = 4).
- Added caching for NPM for better CI performance

TLDR, reduce the longest workflow from 20++ minutes to under 10 minutes.