### PR TITLE
Able to specify image tag via ENV in `defid_container.ts`

### DIFF
--- a/packages/testcontainers/src/chains/defid_container.ts
+++ b/packages/testcontainers/src/chains/defid_container.ts
@@ -22,8 +22,7 @@ export interface StartOptions {
 export abstract class DeFiDContainer extends DockerContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
-  public static readonly image = (process && process.env.DEFICHAIN_DOCKER_IMAGE) ?
-    process.env.DEFICHAIN_DOCKER_IMAGE : 'defi/defichain:HEAD-643194e' // fast-tracked https://github.com/DeFiCh/ain/pull/464 >1.7.3
+  public static readonly image = process?.env?.DEFICHAIN_DOCKER_IMAGE ?? 'defi/defichain:HEAD-643194e' // fast-tracked https://github.com/DeFiCh/ain/pull/464 >1.7.3
 
   public static readonly DefaultStartOptions = {
     user: 'testcontainers-user',

--- a/packages/testcontainers/src/chains/defid_container.ts
+++ b/packages/testcontainers/src/chains/defid_container.ts
@@ -22,7 +22,13 @@ export interface StartOptions {
 export abstract class DeFiDContainer extends DockerContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
-  public static readonly image = process?.env?.DEFICHAIN_DOCKER_IMAGE ?? 'defi/defichain:HEAD-643194e' // fast-tracked https://github.com/DeFiCh/ain/pull/464 >1.7.3
+
+  public static get image (): string {
+    if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
+      return process.env.DEFICHAIN_DOCKER_IMAGE
+    }
+    return 'defi/defichain:1.7.9-rc.1'
+  }
 
   public static readonly DefaultStartOptions = {
     user: 'testcontainers-user',

--- a/packages/testcontainers/src/chains/defid_container.ts
+++ b/packages/testcontainers/src/chains/defid_container.ts
@@ -22,7 +22,8 @@ export interface StartOptions {
 export abstract class DeFiDContainer extends DockerContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
-  public static readonly image = 'defi/defichain:HEAD-643194e' // fast-tracked https://github.com/DeFiCh/ain/pull/464 >1.7.3
+  public static readonly image = (process && process.env.DEFICHAIN_DOCKER_IMAGE) ?
+    process.env.DEFICHAIN_DOCKER_IMAGE : 'defi/defichain:HEAD-643194e' // fast-tracked https://github.com/DeFiCh/ain/pull/464 >1.7.3
 
   public static readonly DefaultStartOptions = {
     user: 'testcontainers-user',

--- a/packages/testcontainers/src/chains/reg_test_container/index.ts
+++ b/packages/testcontainers/src/chains/reg_test_container/index.ts
@@ -16,6 +16,7 @@ export class RegTestContainer extends DeFiDContainer {
   protected getCmd (opts: StartOptions): string[] {
     return [...super.getCmd(opts),
       '-regtest=1',
+      '-jellyfish_regtest=1',
       '-txnotokens=0',
       '-logtimemicros',
       '-txindex=1',


### PR DESCRIPTION
Added ability to specify image as an env var

<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Update defid_container.ts to be able to use env var to specify image tag

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
