### PR TITLE
`jellyfish-transaction-builder`: utxos-to-account support multiple destination addresses

### DIFF
--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_utxos_to_account.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_utxos_to_account.test.ts
@@ -147,10 +147,7 @@ describe('account.utxosToAccount()', () => {
   it('should reject invalid utxosToAccount arg - less than 1 token in balance destination', async () => {
     const dest = await providers.elliptic.script()
     await expect(builder.account.utxosToAccount({
-      to: [{
-        balances: [],
-        script: dest
-      }]
+      to: []
     }, dest)).rejects.toThrow('Conversion output `utxosToAccount.to` array length must be greater than or equal to one')
   })
 

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder_account.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder_account.ts
@@ -10,30 +10,37 @@ export class TxnBuilderAccount extends P2WPKHTxnBuilder {
    *
    * @param {UtxosToAccount} utxosToAccount txn to create
    * @param {Script} changeScript to send unspent to after deducting the (converted + fees)
-   * @throws {TxnBuilderError} if 'utxosToAccount.to' and 'utxosToAccount.to[0].balances' length is not `1`
-   * @throws {TxnBuilderError} if 'utxosToAccount.to' and 'utxosToAccount.to[0].balances[0].token' is not `0`
+   * @throws {TxnBuilderError} if 'utxosToAccount.to' length is less than `1`
+   * @throws {TxnBuilderError} if 'utxosToAccount.to[any].balances' length is not `1`
+   * @throws {TxnBuilderError} if 'utxosToAccount.to[any].balances[0].token' is not `0`\
    * @returns {Promise<TransactionSegWit>}
    */
   async utxosToAccount (utxosToAccount: UtxosToAccount, changeScript: Script): Promise<TransactionSegWit> {
-    if (utxosToAccount.to.length !== 1) {
+    if (utxosToAccount.to.length < 1) {
       throw new TxnBuilderError(TxnBuilderErrorType.INVALID_UTXOS_TO_ACCOUNT_OUTPUT,
-        'Conversion output `utxosToAccount.to` array length must be one'
+        'Conversion output `utxosToAccount.to` array length must be greater than or equal to one'
       )
     }
 
-    if (utxosToAccount.to[0].balances.length !== 1) {
-      throw new TxnBuilderError(TxnBuilderErrorType.INVALID_UTXOS_TO_ACCOUNT_OUTPUT,
-        'Conversion output `utxosToAccount.to[0].balances` array length must be one'
-      )
+    for (let i = 0; i < utxosToAccount.to.length; i++) {
+      const sb = utxosToAccount.to[i]
+      if (sb.balances.length !== 1) {
+        throw new TxnBuilderError(TxnBuilderErrorType.INVALID_UTXOS_TO_ACCOUNT_OUTPUT,
+          'Each `utxosToAccount.to` array `balances` array length must be one'
+        )
+      }
+
+      if (sb.balances[0].token !== 0x00) {
+        throw new TxnBuilderError(TxnBuilderErrorType.INVALID_UTXOS_TO_ACCOUNT_OUTPUT,
+          'Each `utxosToAccount.to` array `balances[0].token` must be 0x00, only DFI supported'
+        )
+      }
     }
 
-    if (utxosToAccount.to[0].balances[0].token !== 0x00) {
-      throw new TxnBuilderError(TxnBuilderErrorType.INVALID_UTXOS_TO_ACCOUNT_OUTPUT,
-        '`utxosToAccount.to[0].balances[0].token` must be 0x00, only DFI support'
-      )
-    }
+    const amountToConvert = utxosToAccount.to.reduce((total, dest) => (
+      total.plus(dest.balances[0].amount)
+    ), new BigNumber(0))
 
-    const amountToConvert = utxosToAccount.to[0].balances[0].amount
     return await super.createDeFiTx(
       OP_CODES.OP_DEFI_TX_UTXOS_TO_ACCOUNT(utxosToAccount),
       changeScript,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
Allow split output tokens into multiple address (as DeFiChain supported)

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #270 

#### Additional comments?:
