### PR TITLE
fix oss-governance-project-pr to only run on pr target

### DIFF
--- a/.github/workflows/oss-governance-project-pr.yml
+++ b/.github/workflows/oss-governance-project-pr.yml
@@ -1,7 +1,7 @@
 name: Governance
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened ]
 
 jobs:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

If there a merge conflict, it will fail. Running on target won't.
