### PR TITLE
Fixed doc files from getMintingInfo to getMiningInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const client = new jellyfish.Client('http://localhost:8554', {
   timeout: 20000
 })
 
-client.mining.getMintingInfo().then((info) => {
+client.mining.getMiningInfo().then((info) => {
   console.log(info)
 })
 ```
@@ -47,7 +47,7 @@ client.mining.getMintingInfo().then((info) => {
 import {Client} from '@defichain/jellyfish'
 
 const client = new Client('http://localhost:8554')
-const info = await client.mining.getMintingInfo()
+const info = await client.mining.getMiningInfo()
 ```
 
 ### Providers

--- a/packages/jellyfish-api-core/README.md
+++ b/packages/jellyfish-api-core/README.md
@@ -16,9 +16,9 @@ category.
 ### Usage Example
 
 ```js
-const result = await client.mining.getMintingInfo()
+const result = await client.mining.getMiningInfo()
 // or
-client.mining.getMintingInfo().then((result) => {
+client.mining.getMiningInfo().then((result) => {
   console.log(result)
 }).catch((err) => {
   console.log('panic!')

--- a/website/docs/jellyfish/design.md
+++ b/website/docs/jellyfish/design.md
@@ -31,7 +31,7 @@ life to modern development.
 import {Client} from '@defichain/jellyfish'
 
 const client = new Client()
-const {blocks} = await client.mining.getMintingInfo()
+const {blocks} = await client.mining.getMiningInfo()
 ```
 
 ## IEEE-754 arbitrary precision
@@ -60,7 +60,7 @@ it('lost precision converting DFI 😥', () => {
   that path as 'bignumber'. Otherwise, it will default to number, This applies deeply.
 
 
-As not all number parsed are significant in all context, (e.g. `mining.getMintingInfo()`), this allows jellyfish library 
+As not all number parsed are significant in all context, (e.g. `mining.getMiningInfo()`), this allows jellyfish library 
 users to use the `number` for non precision sensitive operation (e.g. `networkhashps`) and BigNumber for precision 
 sensitive operations.
 
@@ -79,7 +79,7 @@ export class Wallet {
 ```
 
 ```ts {2-3,9,13}
-export interface MintingInfo {
+export interface MiningInfo {
   blocks: number
   currentblockweight?: number
   //...
@@ -90,8 +90,8 @@ export class Mining {
     return await this.client.call('getnetworkhashps', [nblocks, height], 'number')
   }
 
-  async getMintingInfo (): Promise<MintingInfo> {
-    return await this.client.call('getmintinginfo', [], 'number')
+  async getMiningInfo (): Promise<MiningInfo> {
+    return await this.client.call('getmininginfo', [], 'number')
   }
 }
 ```

--- a/website/docs/jellyfish/usage.md
+++ b/website/docs/jellyfish/usage.md
@@ -19,7 +19,7 @@ npm install @defichain/jellyfish
 import {Client, MiningInfo} from '@defichain/jellyfish'
 
 const client = new Client('http://localhost:8554')
-const info: MiningInfo  = await client.mining.getMintingInfo()
+const info: MiningInfo  = await client.mining.getMiningInfo()
 ```
 
 ### CommonJS for Node
@@ -30,7 +30,7 @@ const client = new jellyfish.Client('http://localhost:8554', {
   timeout: 20000
 })
 
-client.mining.getMintingInfo().then((info) => {
+client.mining.getMiningInfo().then((info) => {
   console.log(info)
 })
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:
Changed various `.md` files that uses `getMintingInfo()` in code examples.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #230 

#### Additional comments?:
This PR does not change the docs in `testcontainers` as the containers do not have `getMiningInfo()` as a shorthand method like they have with `getMintingInfo()`. An issue has been created to address this. #376 
