### PR TITLE
removed noUnusedLocals from tsconfig.base.json too strict during dev

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "strict": true,
-    "esModuleInterop": true,
-    "noUnusedLocals": true
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Removed noUnusedLocals from `tsconfig.base.json` too strict during dev making it hard to do dirty testing, by default lint will catch it during PR.
