### PR TITLE
updated icx and oracle codeowners responsibility

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,8 @@
 /packages/jellyfish-address/                    @fuxingloh @ivan-zynesis
 
 /packages/jellyfish-api-core/                               @fuxingloh @canonbrother @jingyi2811 @thedoublejay
-/packages/jellyfish-api-core/src/category/icxorderbook.ts   @fuxingloh @canonbrother @jingyi2811 @thedoublejay @monstrobishi @surangap
-/packages/jellyfish-api-core/src/category/oracle.ts         @fuxingloh @canonbrother @jingyi2811 @thedoublejay @monstrobishi @surangap
+/packages/jellyfish-api-core/src/category/icxorderbook.ts   @fuxingloh @surangap @monstrobishi @canonbrother @ivan-zynesis
+/packages/jellyfish-api-core/src/category/oracle.ts         @fuxingloh @jingyi2811 @surangap @canonbrother @monstrobishi
 
 /packages/jellyfish-api-jsonrpc/                @fuxingloh @thedoublejay
 /packages/jellyfish-crypto/                     @fuxingloh @ivan-zynesis


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Reduce `CODEOWNERS` responsibilities for ICX and Oracle. Added @ivan-zynesis to ICX for future `jellyfish-transaction` context.

To allow better code ownership experience for https://github.com/DeFiCh/jellyfish/pull/357