### PR TITLE
poolpair.customRewards is nullable

### DIFF
--- a/packages/jellyfish-api-core/src/category/poolpair.ts
+++ b/packages/jellyfish-api-core/src/category/poolpair.ts
@@ -56,7 +56,7 @@ export class PoolPair {
    * Returns information about pool
    *
    * @param {string} symbol token's symbol
-   * @param {boolean} verbose default = true, otherwise only symbol, name, status, idTokena, idTokenB
+   * @param {boolean} verbose default = true, otherwise only symbol, name, status, idTokenA, idTokenB
    * @return {Promise<PoolPairsResult>}
    */
   async getPoolPair (symbol: string, verbose = true): Promise<PoolPairsResult> {
@@ -142,7 +142,7 @@ export interface PoolPairInfo {
   blockCommissionA: BigNumber
   blockCommissionB: BigNumber
   rewardPct: BigNumber
-  customRewards: BigNumber
+  customRewards?: BigNumber
   creationTx: string
   creationHeight: BigNumber
 }

--- a/website/docs/jellyfish/api/poolpair.md
+++ b/website/docs/jellyfish/api/poolpair.md
@@ -49,7 +49,7 @@ interface PoolPairInfo {
   blockCommissionA: BigNumber
   blockCommissionB: BigNumber
   rewardPct: BigNumber
-  customRewards: BigNumber
+  customRewards?: BigNumber
   creationTx: string
   creationHeight: number
 }
@@ -91,7 +91,7 @@ interface PoolPairInfo {
   blockCommissionA: BigNumber
   blockCommissionB: BigNumber
   rewardPct: BigNumber
-  customRewards: BigNumber
+  customRewards?: BigNumber
   creationTx: string
   creationHeight: number
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
Update the status type of poolpair customRewards which is nullable

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #393

#### Additional comments?:
Ref:
https://github.com/DeFiCh/ain/blob/7a430185fd3029e9ee8974fde4e65c715fb9db04/src/masternodes/rpc_poolpair.cpp#L51-L59
