### PR TITLE
removed project references and internal dev deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,8 @@ Configurations required when introducing new package:
 
 1. root `tsconfig.json` - `compilerOptions.paths` - add to map absolute packages name back to the source code
 2. root `tsconfig.build.json` - `references` - add new created tsconfig.build.json here
-3. sub-package `tsconfig.build.json` - `references` - add package dependencies tsconfig.build.json location
-4. sub-package `package.json` - `scripts.build` - ensure each sub-package build script is configured "tsc -b ./tsconfig.build.json"
-5. root `jest.config.js` - `moduleNameMapper` - update accordingly for allowing test case to use same `import from <sub-package-name>` syntax
+3. root `jest.config.js` - `moduleNameMapper` - update accordingly for allowing test case to use same `import from <sub-package-name>` syntax
+4. sub-package `package.json` - `scripts.build` - ensure each sub-package build script is configured `tsc -b ./tsconfig.build.json`
 
 ### Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13207,7 +13207,6 @@
     },
     "node_modules/@types/lossless-json": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/minimatch": {
@@ -29326,7 +29325,6 @@
         "bignumber.js": "^9.0.1"
       },
       "devDependencies": {
-        "@defichain/testcontainers": "0.0.0",
         "@parcel/transformer-typescript-types": "2.0.0-beta.1",
         "parcel": "2.0.0-beta.1"
       },
@@ -29355,9 +29353,6 @@
       "license": "MIT",
       "dependencies": {
         "@defichain/jellyfish-json": "0.0.0"
-      },
-      "devDependencies": {
-        "@defichain/testcontainers": "0.0.0"
       }
     },
     "packages/jellyfish-api-jsonrpc": {
@@ -29370,7 +29365,6 @@
         "cross-fetch": "^3.1.2"
       },
       "devDependencies": {
-        "@defichain/testcontainers": "0.0.0",
         "nock": "^13.0.11"
       }
     },
@@ -29402,10 +29396,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/lossless-json": "^1.0.0",
         "lossless-json": "^1.0.4"
-      },
-      "devDependencies": {
-        "@types/lossless-json": "^1.0.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
@@ -29435,11 +29427,6 @@
         "@defichain/jellyfish-crypto": "0.0.0",
         "@defichain/jellyfish-transaction": "0.0.0",
         "@defichain/jellyfish-transaction-signature": "0.0.0"
-      },
-      "devDependencies": {
-        "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
-        "@defichain/testing": "0.0.0"
       },
       "peerDependencies": {
         "bignumber.js": "^9.0.1"
@@ -30658,7 +30645,6 @@
       "requires": {
         "@defichain/jellyfish-api-core": "0.0.0",
         "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
         "@parcel/transformer-typescript-types": "2.0.0-beta.1",
         "bignumber.js": "^9.0.1",
         "parcel": "2.0.0-beta.1"
@@ -30677,15 +30663,13 @@
     "@defichain/jellyfish-api-core": {
       "version": "file:packages/jellyfish-api-core",
       "requires": {
-        "@defichain/jellyfish-json": "0.0.0",
-        "@defichain/testcontainers": "0.0.0"
+        "@defichain/jellyfish-json": "0.0.0"
       }
     },
     "@defichain/jellyfish-api-jsonrpc": {
       "version": "file:packages/jellyfish-api-jsonrpc",
       "requires": {
         "@defichain/jellyfish-api-core": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.2",
         "nock": "^13.0.11"
@@ -30729,12 +30713,9 @@
     "@defichain/jellyfish-transaction-builder": {
       "version": "file:packages/jellyfish-transaction-builder",
       "requires": {
-        "@defichain/jellyfish-api-jsonrpc": "0.0.0",
         "@defichain/jellyfish-crypto": "0.0.0",
         "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-transaction-signature": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
-        "@defichain/testing": "0.0.0"
+        "@defichain/jellyfish-transaction-signature": "0.0.0"
       }
     },
     "@defichain/jellyfish-transaction-signature": {
@@ -40083,8 +40064,7 @@
       "dev": true
     },
     "@types/lossless-json": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "@types/minimatch": {
       "version": "3.0.3",

--- a/packages/jellyfish-address/tsconfig.build.json
+++ b/packages/jellyfish-address/tsconfig.build.json
@@ -6,10 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-crypto/tsconfig.build.json"},
-    {"path": "../jellyfish-network/tsconfig.build.json"},
-    {"path": "../jellyfish-transaction/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-api-core/package.json
+++ b/packages/jellyfish-api-core/package.json
@@ -36,8 +36,5 @@
   },
   "dependencies": {
     "@defichain/jellyfish-json": "0.0.0"
-  },
-  "devDependencies": {
-    "@defichain/testcontainers": "0.0.0"
   }
 }

--- a/packages/jellyfish-api-core/tsconfig.build.json
+++ b/packages/jellyfish-api-core/tsconfig.build.json
@@ -6,9 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-json/tsconfig.build.json"},
-    {"path": "../testcontainers/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-api-jsonrpc/package.json
+++ b/packages/jellyfish-api-jsonrpc/package.json
@@ -40,7 +40,6 @@
     "abort-controller": "^3.0.0"
   },
   "devDependencies": {
-    "@defichain/testcontainers": "0.0.0",
     "nock": "^13.0.11"
   }
 }

--- a/packages/jellyfish-api-jsonrpc/tsconfig.build.json
+++ b/packages/jellyfish-api-jsonrpc/tsconfig.build.json
@@ -6,9 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-api-core/tsconfig.build.json"},
-    {"path": "../testcontainers/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-json/package.json
+++ b/packages/jellyfish-json/package.json
@@ -38,9 +38,7 @@
     "bignumber.js": "^9.0.1"
   },
   "dependencies": {
+    "@types/lossless-json": "^1.0.0",
     "lossless-json": "^1.0.4"
-  },
-  "devDependencies": {
-    "@types/lossless-json": "^1.0.0"
   }
 }

--- a/packages/jellyfish-transaction-builder/package.json
+++ b/packages/jellyfish-transaction-builder/package.json
@@ -41,10 +41,5 @@
     "@defichain/jellyfish-crypto": "0.0.0",
     "@defichain/jellyfish-transaction": "0.0.0",
     "@defichain/jellyfish-transaction-signature": "0.0.0"
-  },
-  "devDependencies": {
-    "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-    "@defichain/testcontainers": "0.0.0",
-    "@defichain/testing": "0.0.0"
   }
 }

--- a/packages/jellyfish-transaction-builder/tsconfig.build.json
+++ b/packages/jellyfish-transaction-builder/tsconfig.build.json
@@ -6,10 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-api-jsonrpc/tsconfig.build.json"},
-    {"path": "../testcontainers/tsconfig.build.json"},
-    {"path": "../testing/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-transaction-signature/tsconfig.build.json
+++ b/packages/jellyfish-transaction-signature/tsconfig.build.json
@@ -6,8 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-transaction/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-wallet-mnemonic/tsconfig.build.json
+++ b/packages/jellyfish-wallet-mnemonic/tsconfig.build.json
@@ -6,9 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-wallet/tsconfig.build.json"},
-    {"path": "../jellyfish-transaction/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish-wallet/tsconfig.build.json
+++ b/packages/jellyfish-wallet/tsconfig.build.json
@@ -6,10 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-address/tsconfig.build.json"},
-    {"path": "../jellyfish-crypto/tsconfig.build.json"},
-    {"path": "../jellyfish-transaction/tsconfig.build.json"}
-  ]
+  }
 }

--- a/packages/jellyfish/package.json
+++ b/packages/jellyfish/package.json
@@ -57,7 +57,6 @@
     "bignumber.js": "^9.0.1"
   },
   "devDependencies": {
-    "@defichain/testcontainers": "0.0.0",
     "@parcel/transformer-typescript-types": "2.0.0-beta.1",
     "parcel": "2.0.0-beta.1"
   }

--- a/packages/jellyfish/tsconfig.json
+++ b/packages/jellyfish/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../../tsconfig.base.json"
 }

--- a/packages/testing/tsconfig.build.json
+++ b/packages/testing/tsconfig.build.json
@@ -6,11 +6,5 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-  },
-  "references": [
-    {"path": "../jellyfish-api-core/tsconfig.build.json"},
-    {"path": "../jellyfish-network/tsconfig.build.json"},
-    {"path": "../jellyfish-crypto/tsconfig.build.json"},
-    {"path": "../testcontainers/tsconfig.build.json"}
-  ]
+  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

- Removed internal `devDependencies` as it can be resolved via module mapper in jest, hence not required anymore for testing.
- Removed individual project references to just use a global reference table, easier to maintain.
- Moved `@types/lossless-json` to be part of `dependencies` in `jellyfish-json`
- Fixed invalid `@defichain/jellyfish` tsconfig.json extend reference that didn't exist