### PR TITLE
implements WalletHdNode on WalletAccount

### DIFF
--- a/packages/jellyfish-wallet-mnemonic/package.json
+++ b/packages/jellyfish-wallet-mnemonic/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@defichain/jellyfish-wallet": "0.0.0",
     "@defichain/jellyfish-transaction": "0.0.0",
-    "@defichain/jellyfish-transaction-signature": "0.0.0",
     "bip32": "^2.0.6",
     "bip39": "^3.0.3"
   }

--- a/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
@@ -83,3 +83,46 @@ it('address to script', () => {
     ]
   })
 })
+
+describe("WalletAccount: 44'/1129'/0'", () => {
+  const nodeProvider = new TestNodeProvider()
+  const accountProvider = new TestAccountProvider([])
+  let account: WalletAccount
+
+  beforeAll(() => {
+    const node = nodeProvider.derive("44'/1129'/0'")
+    account = accountProvider.provide(node)
+  })
+
+  it('should derive public key for account', async () => {
+    const pubKey = await account.publicKey()
+    expect(pubKey.length).toStrictEqual(33)
+    expect(pubKey.toString('hex')).toStrictEqual('03331bde25ae763c3872effa39a7b104dfd072d43a956d1c40c0aff7ede5fb1578')
+  })
+
+  it('should derive private key for account', async () => {
+    const privKey = await account.privateKey()
+    expect(privKey.length).toStrictEqual(32)
+    expect(privKey.toString('hex')).toStrictEqual('3434272f31313239272f30273434272f31313239272f30273434272f31313239')
+  })
+
+  it('should derive sign and verify for account', async () => {
+    const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
+
+    const signature = await account.sign(hash)
+    expect(signature.toString('hex')).toStrictEqual('3044022015707827c1bdfabfdbabb8d82f35c2cbe7b8d2fc1388a692469fe04879e4938802202eaf2033fb1b2cd69b5039457c283b9c80f082a6732f5460b983eb6947ca21bd')
+
+    const valid = await account.verify(hash, signature)
+    expect(valid).toStrictEqual(true)
+  })
+
+  it('should signed transaction and fail because invalid for account', async () => {
+    return await expect(async () => await account.signTx({
+      version: 0,
+      vin: [],
+      vout: [],
+      lockTime: 0
+    }, [])
+    ).rejects.toThrow()
+  })
+})

--- a/packages/jellyfish-wallet/package.json
+++ b/packages/jellyfish-wallet/package.json
@@ -40,8 +40,7 @@
   "dependencies": {
     "@defichain/jellyfish-address": "0.0.0",
     "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0",
-    "@defichain/jellyfish-transaction-builder": "0.0.0",
-    "@defichain/jellyfish-transaction-signature": "0.0.0"
+    "@defichain/jellyfish-network": "0.0.0",
+    "@defichain/jellyfish-transaction": "0.0.0"
   }
 }

--- a/packages/jellyfish-wallet/package.json
+++ b/packages/jellyfish-wallet/package.json
@@ -41,6 +41,7 @@
     "@defichain/jellyfish-address": "0.0.0",
     "@defichain/jellyfish-crypto": "0.0.0",
     "@defichain/jellyfish-transaction": "0.0.0",
+    "@defichain/jellyfish-transaction-builder": "0.0.0",
     "@defichain/jellyfish-transaction-signature": "0.0.0"
   }
 }

--- a/packages/jellyfish-wallet/src/wallet_account.ts
+++ b/packages/jellyfish-wallet/src/wallet_account.ts
@@ -1,4 +1,4 @@
-import { Script, OP_CODES } from '@defichain/jellyfish-transaction'
+import { Script, OP_CODES, Transaction, Vout, TransactionSegWit } from '@defichain/jellyfish-transaction'
 import { WalletHdNode } from './wallet_hd_node'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
 import { Network } from '@defichain/jellyfish-network'
@@ -11,7 +11,7 @@ import { DeFiAddress } from '@defichain/jellyfish-address'
  *
  * WalletAccount implementation uses NATIVE SEGWIT redeem script exclusively.
  */
-export abstract class WalletAccount {
+export abstract class WalletAccount implements WalletHdNode {
   protected constructor (
     private readonly hdNode: WalletHdNode,
     private readonly network: Network
@@ -56,6 +56,26 @@ export abstract class WalletAccount {
    * @return Promise<boolean>
    */
   abstract isActive (): Promise<boolean>
+
+  async publicKey (): Promise<Buffer> {
+    return await this.hdNode.publicKey()
+  }
+
+  async privateKey (): Promise<Buffer> {
+    return await this.hdNode.privateKey()
+  }
+
+  async sign (hash: Buffer): Promise<Buffer> {
+    return await this.hdNode.sign(hash)
+  }
+
+  async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
+    return await this.hdNode.signTx(transaction, prevouts)
+  }
+
+  async verify (hash: Buffer, derSignature: Buffer): Promise<boolean> {
+    return await this.hdNode.verify(hash, derSignature)
+  }
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Implements `WalletHdNode` on `WalletAccount` to use the `EllipticPair` interface on the `WalletAccount` without exposing WalletHdNode directly for ease of use.
