### PR TITLE
Fixed bad test in oracle RPC and cleaned up docs for consistency

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/oracle/removeOracle.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/oracle/removeOracle.test.ts
@@ -1,7 +1,6 @@
-import { MasterNodeRegTestContainer, DeFiDRpcError } from '@defichain/testcontainers'
+import { DeFiDRpcError, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '../../../src'
-import { UTXO } from '../../../src/category/oracle'
 
 describe('Oracle', () => {
   const container = new MasterNodeRegTestContainer()
@@ -46,39 +45,6 @@ describe('Oracle', () => {
 
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toThrow(`RpcApiError: 'Test RemoveOracleAppointTx execution failed:\noracle <${oracleid as string}> not found', code: -32600, method: removeoracle`)
-  })
-
-  it('should removeOracle with utxos', async () => {
-    const address = await container.getNewAddress()
-
-    const priceFeeds = [
-      { token: 'APPLE', currency: 'EUR' },
-      { token: 'TESLA', currency: 'USD' }
-    ]
-
-    const oracleid = await container.call('appointoracle', [address, priceFeeds, 1])
-
-    await container.generate(1)
-
-    const utxos = await container.call('listunspent', [1, 9999999, [address], true])
-    const inputs: UTXO[] = utxos.map((utxo: UTXO) => {
-      return {
-        txid: utxo.txid,
-        vout: utxo.vout
-      }
-    })
-
-    const data = await client.oracle.removeOracle(oracleid, inputs)
-
-    expect(typeof data).toStrictEqual('string')
-    expect(data.length).toStrictEqual(64)
-
-    await container.generate(1)
-
-    const promise = container.call('getoracledata', [oracleid])
-
-    await expect(promise).rejects.toThrow(DeFiDRpcError)
-    await expect(promise).rejects.toThrow(`DeFiDRpcError: 'oracle <${oracleid as string}> not found', code: -20`) // Removed
   })
 
   it('should not removeOracle with arbitrary utxos', async () => {

--- a/packages/jellyfish-api-core/__tests__/category/oracle/setOracleData.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/oracle/setOracleData.test.ts
@@ -1,7 +1,6 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '../../../src'
-import { UTXO } from '../../../src/category/oracle'
 
 describe('Oracle', () => {
   const container = new MasterNodeRegTestContainer()
@@ -111,15 +110,9 @@ describe('Oracle', () => {
     const timestamp = new Date().getTime()
     const prices = [{ tokenAmount: '0.5@APPLE', currency: 'EUR' }]
 
-    const utxos = await container.call('listunspent', [1, 9999999, [address], true])
-    const inputs: UTXO[] = utxos.map((utxo: UTXO) => {
-      return {
-        txid: utxo.txid,
-        vout: utxo.vout
-      }
-    })
+    const input = await container.fundAddress(address, 10)
 
-    await client.oracle.setOracleData(oracleid, timestamp, { prices, utxos: inputs })
+    await client.oracle.setOracleData(oracleid, timestamp, { prices, utxos: [input] })
 
     await container.generate(1)
 
@@ -143,7 +136,7 @@ describe('Oracle', () => {
     )
   })
 
-  it('should not setOracleData with arbritary UTXOs', async () => {
+  it('should not setOracleData with arbitrary UTXOs', async () => {
     const priceFeeds = [
       { token: 'APPLE', currency: 'EUR' }
     ]

--- a/packages/jellyfish-api-core/__tests__/category/oracle/updateOracle.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/oracle/updateOracle.test.ts
@@ -1,7 +1,6 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '../../../src'
-import { UTXO } from '../../../src/category/oracle'
 
 describe('Oracle', () => {
   const container = new MasterNodeRegTestContainer()
@@ -154,52 +153,6 @@ describe('Oracle', () => {
       { token: '12345678', currency: '12345678' },
       { token: 'ABCDEFGH', currency: 'ABCDEFGH' }
     ])
-  })
-
-  it('should updateOracle with utxos', async () => {
-    // Appoint oracle
-    const address = await container.getNewAddress()
-
-    const appointOraclePriceFeeds = [
-      { token: 'APPLE', currency: 'EUR' },
-      { token: 'TESLA', currency: 'USD' }
-    ]
-
-    const oracleid = await container.call('appointoracle', [address, appointOraclePriceFeeds, 1])
-
-    await container.generate(1)
-
-    // Update oracle
-    const updateOraclePriceFeeds = [
-      { token: 'FB', currency: 'CNY' },
-      { token: 'MSFT', currency: 'SGD' }
-    ]
-
-    const utxos = await container.call('listunspent', [1, 9999999, [address], true])
-    const inputs: UTXO[] = utxos.map((utxo: UTXO) => {
-      return {
-        txid: utxo.txid,
-        vout: utxo.vout
-      }
-    })
-
-    await client.oracle.updateOracle(oracleid, await container.getNewAddress(), {
-      priceFeeds: updateOraclePriceFeeds,
-      weightage: 2,
-      utxos: inputs
-    })
-
-    await container.generate(1)
-
-    const data = await container.call('getoracledata', [oracleid])
-
-    expect(data).toStrictEqual({
-      weightage: 2,
-      oracleid,
-      address: expect.any(String),
-      priceFeeds: updateOraclePriceFeeds,
-      tokenPrices: []
-    })
   })
 
   it('should not updateOracle with arbitrary utxos', async () => {

--- a/packages/jellyfish-api-core/src/category/oracle.ts
+++ b/packages/jellyfish-api-core/src/category/oracle.ts
@@ -26,7 +26,7 @@ export class Oracle {
    * @param {UTXO[]} [options.utxos = []]
    * @param {string} [options.utxos.txid]
    * @param {number} [options.utxos.vout]
-   * @return {Promise<string>} oracleId, also the txn id for txn created to appoint oracle
+   * @return {Promise<string>} oracleid, also the txn id for txn created to appoint oracle
    */
   async appointOracle (address: string, priceFeeds: OraclePriceFeed[], options: AppointOracleOptions = {}): Promise<string> {
     const { utxos = [] } = options
@@ -36,20 +36,20 @@ export class Oracle {
   /**
    * Removes oracle.
    *
-   * @param {string} oracleId
+   * @param {string} oracleid
    * @param {UTXO[]} [utxos = []]
    * @param {string} [utxos.txid]
    * @param {number} [utxos.vout]
    * @return {Promise<string>} txid
    */
-  async removeOracle (oracleId: string, utxos: UTXO[] = []): Promise<string> {
-    return await this.client.call('removeoracle', [oracleId, utxos], 'number')
+  async removeOracle (oracleid: string, utxos: UTXO[] = []): Promise<string> {
+    return await this.client.call('removeoracle', [oracleid, utxos], 'number')
   }
 
   /**
    * Update a price oracle for rely of real time price data.
    *
-   * @param {string} oracleId
+   * @param {string} oracleid
    * @param {string} address
    * @param {UpdateOracleOptions} [options]
    * @param {OraclePriceFeed[]} options.priceFeeds
@@ -59,15 +59,15 @@ export class Oracle {
    * @param {number} [options.utxos.vout]
    * @return {Promise<string>} txid
    */
-  async updateOracle (oracleId: string, address: string, options: UpdateOracleOptions = {}): Promise<string> {
+  async updateOracle (oracleid: string, address: string, options: UpdateOracleOptions = {}): Promise<string> {
     const { utxos = [] } = options
-    return await this.client.call('updateoracle', [oracleId, address, options.priceFeeds, options.weightage, utxos], 'number')
+    return await this.client.call('updateoracle', [oracleid, address, options.priceFeeds, options.weightage, utxos], 'number')
   }
 
   /**
    * Set oracle data transaction.
    *
-   * @param {string} oracleId
+   * @param {string} oracleid
    * @param {number} timestamp
    * @param {SetOracleDataOptions} [options]
    * @param {OraclePrice[]} options.prices
@@ -76,19 +76,19 @@ export class Oracle {
    * @param {number} [options.utxos.vout]
    * @return {Promise<string>} txid
    */
-  async setOracleData (oracleId: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string> {
+  async setOracleData (oracleid: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string> {
     const { utxos = [] } = options
-    return await this.client.call('setoracledata', [oracleId, timestamp, options.prices, utxos], 'number')
+    return await this.client.call('setoracledata', [oracleid, timestamp, options.prices, utxos], 'number')
   }
 
   /**
    * Returns oracle data.
    *
-   * @param {string} oracleId
+   * @param {string} oracleid
    * @return {Promise<OracleData>}
    */
-  async getOracleData (oracleId: string): Promise<OracleData> {
-    return await this.client.call('getoracledata', [oracleId], 'number')
+  async getOracleData (oracleid: string): Promise<OracleData> {
+    return await this.client.call('getoracledata', [oracleid], 'number')
   }
 
   /**

--- a/packages/jellyfish-api-core/src/category/oracle.ts
+++ b/packages/jellyfish-api-core/src/category/oracle.ts
@@ -26,7 +26,7 @@ export class Oracle {
    * @param {UTXO[]} [options.utxos = []]
    * @param {string} [options.utxos.txid]
    * @param {number} [options.utxos.vout]
-   * @return {Promise<string>} oracleid, also the txn id for txn created to appoint oracle
+   * @return {Promise<string>} oracleId, also the txn id for txn created to appoint oracle
    */
   async appointOracle (address: string, priceFeeds: OraclePriceFeed[], options: AppointOracleOptions = {}): Promise<string> {
     const { utxos = [] } = options
@@ -36,20 +36,20 @@ export class Oracle {
   /**
    * Removes oracle.
    *
-   * @param {string} oracleid
+   * @param {string} oracleId
    * @param {UTXO[]} [utxos = []]
    * @param {string} [utxos.txid]
    * @param {number} [utxos.vout]
    * @return {Promise<string>} txid
    */
-  async removeOracle (oracleid: string, utxos: UTXO[] = []): Promise<string> {
-    return await this.client.call('removeoracle', [oracleid, utxos], 'number')
+  async removeOracle (oracleId: string, utxos: UTXO[] = []): Promise<string> {
+    return await this.client.call('removeoracle', [oracleId, utxos], 'number')
   }
 
   /**
    * Update a price oracle for rely of real time price data.
    *
-   * @param {string} oracleid
+   * @param {string} oracleId
    * @param {string} address
    * @param {UpdateOracleOptions} [options]
    * @param {OraclePriceFeed[]} options.priceFeeds
@@ -59,15 +59,15 @@ export class Oracle {
    * @param {number} [options.utxos.vout]
    * @return {Promise<string>} txid
    */
-  async updateOracle (oracleid: string, address: string, options: UpdateOracleOptions = {}): Promise<string> {
+  async updateOracle (oracleId: string, address: string, options: UpdateOracleOptions = {}): Promise<string> {
     const { utxos = [] } = options
-    return await this.client.call('updateoracle', [oracleid, address, options.priceFeeds, options.weightage, utxos], 'number')
+    return await this.client.call('updateoracle', [oracleId, address, options.priceFeeds, options.weightage, utxos], 'number')
   }
 
   /**
    * Set oracle data transaction.
    *
-   * @param {string} oracleid
+   * @param {string} oracleId
    * @param {number} timestamp
    * @param {SetOracleDataOptions} [options]
    * @param {OraclePrice[]} options.prices
@@ -76,19 +76,19 @@ export class Oracle {
    * @param {number} [options.utxos.vout]
    * @return {Promise<string>} txid
    */
-  async setOracleData (oracleid: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string> {
+  async setOracleData (oracleId: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string> {
     const { utxos = [] } = options
-    return await this.client.call('setoracledata', [oracleid, timestamp, options.prices, utxos], 'number')
+    return await this.client.call('setoracledata', [oracleId, timestamp, options.prices, utxos], 'number')
   }
 
   /**
    * Returns oracle data.
    *
-   * @param {string} oracleid
+   * @param {string} oracleId
    * @return {Promise<OracleData>}
    */
-  async getOracleData (oracleid: string): Promise<OracleData> {
-    return await this.client.call('getoracledata', [oracleid], 'number')
+  async getOracleData (oracleId: string): Promise<OracleData> {
+    return await this.client.call('getoracledata', [oracleId], 'number')
   }
 
   /**

--- a/website/docs/jellyfish/api/oracle.md
+++ b/website/docs/jellyfish/api/oracle.md
@@ -15,7 +15,7 @@ const something = await client.oracle.method()
 
 ## appointOracle
 
-Creates a price oracle for rely of real time price data.
+Creates a price oracle for relay of real time price data.
 
 ```ts title="client.oracle.appointOracle()"
 interface oracle {
@@ -44,7 +44,7 @@ Removes oracle.
 
 ```ts title="client.oracle.removeOracle()"
 interface oracle {
-  removeOracle (oracleid: string, utxos: UTXO[] = []): Promise<string>
+  removeOracle (oracleId: string, utxos: UTXO[] = []): Promise<string>
 }
 
 interface UTXO {
@@ -55,11 +55,11 @@ interface UTXO {
 
 ## updateOracle
 
-Update a price oracle for rely of real time price data.
+Update a price oracle for relay of real time price data.
 
 ```ts title="client.oracle.updateOracle()"
 interface oracle {
-  updateOracle (oracleid: string, address: string, options: UpdateOracleOptions = {}): Promise<string>
+  updateOracle (oracleId: string, address: string, options: UpdateOracleOptions = {}): Promise<string>
 }
 
 interface UpdateOracleOptions {
@@ -85,7 +85,7 @@ Set oracle data transaction.
 
 ```ts title="client.oracle.setOracleData()"
 interface oracle {
-  setOracleData (oracleid: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string>
+  setOracleData (oracleId: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string>
 }
 
 interface SetOracleDataOptions {
@@ -110,7 +110,7 @@ Returns oracle data.
 
 ```ts title="client.oracle.getOracleData()"
 interface oracle {
-  getOracleData (oracleid: string): Promise<OracleData>
+  getOracleData (oracleId: string): Promise<OracleData>
 }
 
 interface OracleData {

--- a/website/docs/jellyfish/api/oracle.md
+++ b/website/docs/jellyfish/api/oracle.md
@@ -44,7 +44,7 @@ Removes oracle.
 
 ```ts title="client.oracle.removeOracle()"
 interface oracle {
-  removeOracle (oracleId: string, utxos: UTXO[] = []): Promise<string>
+  removeOracle (oracleid: string, utxos: UTXO[] = []): Promise<string>
 }
 
 interface UTXO {
@@ -59,7 +59,7 @@ Update a price oracle for relay of real time price data.
 
 ```ts title="client.oracle.updateOracle()"
 interface oracle {
-  updateOracle (oracleId: string, address: string, options: UpdateOracleOptions = {}): Promise<string>
+  updateOracle (oracleid: string, address: string, options: UpdateOracleOptions = {}): Promise<string>
 }
 
 interface UpdateOracleOptions {
@@ -85,7 +85,7 @@ Set oracle data transaction.
 
 ```ts title="client.oracle.setOracleData()"
 interface oracle {
-  setOracleData (oracleId: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string>
+  setOracleData (oracleid: string, timestamp: number, options: SetOracleDataOptions = {}): Promise<string>
 }
 
 interface SetOracleDataOptions {
@@ -110,7 +110,7 @@ Returns oracle data.
 
 ```ts title="client.oracle.getOracleData()"
 interface oracle {
-  getOracleData (oracleId: string): Promise<OracleData>
+  getOracleData (oracleid: string): Promise<OracleData>
 }
 
 interface OracleData {


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

```ts
const utxos = await container.call('listunspent', [1, 9999999, [address], true])
```

When `utxos.length === 0`, it will pick a foundation auth, as you pass in an empty UTXO. And since addresses are new without having a UTXO, it will succeed silently. This is not the expected case. UTXO test must use `fundAddress` for consistent test behavior.

~~Also renamed `oracleid` to `oracleId` for the parameter to keep camelCase consistency for params. `oracleid` is still used for data objects since ain uses that but we should use `oracleId` on params.~~