### PR TITLE
Remove typecheck for OP_PUSHDATA

### DIFF
--- a/packages/jellyfish-transaction-signature/src/tx_signature.ts
+++ b/packages/jellyfish-transaction-signature/src/tx_signature.ts
@@ -87,7 +87,7 @@ function hashOutputs (transaction: Transaction, sigHashType: SIGHASH): string {
 async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
   const stack = signInputOption.prevout.script.stack
 
-  if (stack.length === 2 && stack[1] instanceof OP_PUSHDATA && (stack[1] as OP_PUSHDATA).length() === 20) {
+  if (stack.length === 2 && (stack[1] as OP_PUSHDATA).length() === 20) {
     const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
     const pubkeyHashHex = HASH160(pubkey).toString('hex')
     const pushDataHex = (stack[1] as OP_PUSHDATA).hex

--- a/packages/jellyfish-transaction-signature/src/tx_signature.ts
+++ b/packages/jellyfish-transaction-signature/src/tx_signature.ts
@@ -87,19 +87,20 @@ function hashOutputs (transaction: Transaction, sigHashType: SIGHASH): string {
 async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
   const stack = signInputOption.prevout.script.stack
 
-  if (stack.length === 2 && (stack[1] as OP_PUSHDATA).length() === 20) {
-    const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
-    const pubkeyHashHex = HASH160(pubkey).toString('hex')
-    const pushDataHex = (stack[1] as OP_PUSHDATA).hex
+  if (stack.length !== 2) return false
+  if (stack[0].type !== 'OP_0') return false
+  if (stack[1].type !== 'OP_PUSHDATA') return false
+  if ((stack[1] as OP_PUSHDATA).length() !== 20) return false
 
-    if (pubkeyHashHex === pushDataHex) {
-      return true
-    }
+  const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+  const pubkeyHashHex = HASH160(pubkey).toString('hex')
+  const pushDataHex = (stack[1] as OP_PUSHDATA).hex
 
-    throw new Error('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+  if (pubkeyHashHex === pushDataHex) {
+    return true
   }
 
-  return false
+  throw new Error('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Remove typecheck for OP_PUSHDATA. This fixes an issue where the typecheck denies signing a private key due to the instance type of OP_PUSHDATA not being correctly interpreted.

See: https://github.com/DeFiCh/salmon/pull/60#issuecomment-874717109

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
