### PR TITLE
Make prevout optional in elliptic pair

### DIFF
--- a/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/provider.mock.ts
@@ -86,7 +86,7 @@ export class MockEllipticPairProvider implements EllipticPairProvider {
     }
   }
 
-  get (prevout: Prevout): EllipticPair {
+  get (prevout?: Prevout): EllipticPair {
     return this.ellipticPair
   }
 }

--- a/packages/jellyfish-transaction-builder/src/provider.ts
+++ b/packages/jellyfish-transaction-builder/src/provider.ts
@@ -40,5 +40,5 @@ export interface EllipticPairProvider {
    * @param {Prevout} prevout for the EllipticPair
    * @return {EllipticPair}
    */
-  get: (prevout: Prevout) => EllipticPair
+  get: (prevout?: Prevout) => EllipticPair
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Most practical implementations don't want to pass in a prevout to obtain an elliptic pair, the existing interface makes it awkward for end users. E.g. have to pass in an empty prevout, etc 

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
