### PR TITLE
Allow access to network from WalletAccount

### DIFF
--- a/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
@@ -2,6 +2,7 @@ import { TestAccountProvider } from './account.mock'
 import { TestNodeProvider } from './node.mock'
 import { WalletAccount } from '../src'
 import { OP_CODES } from '@defichain/jellyfish-transaction'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('provide different account', () => {
   const nodeProvider = new TestNodeProvider()
@@ -40,6 +41,11 @@ describe('WalletAccount: 0/0/0', () => {
   it('isActive should be active', async () => {
     const active = await account.isActive()
     expect(active).toStrictEqual(true)
+  })
+
+  it('should be able to access network', async () => {
+    const network = account.network
+    expect(network.name).toStrictEqual(RegTest)
   })
 })
 
@@ -124,5 +130,15 @@ describe("WalletAccount: 44'/1129'/0'", () => {
       lockTime: 0
     }, [])
     ).rejects.toThrow()
+  })
+
+  it('should derive sign and verify for account', async () => {
+    const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
+
+    const signature = await account.sign(hash)
+    expect(signature.toString('hex')).toStrictEqual('3044022015707827c1bdfabfdbabb8d82f35c2cbe7b8d2fc1388a692469fe04879e4938802202eaf2033fb1b2cd69b5039457c283b9c80f082a6732f5460b983eb6947ca21bd')
+
+    const valid = await account.verify(hash, signature)
+    expect(valid).toStrictEqual(true)
   })
 })

--- a/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet_account.test.ts
@@ -45,7 +45,7 @@ describe('WalletAccount: 0/0/0', () => {
 
   it('should be able to access network', async () => {
     const network = account.network
-    expect(network.name).toStrictEqual(RegTest)
+    expect(network.name).toStrictEqual(RegTest.name)
   })
 })
 

--- a/packages/jellyfish-wallet/src/wallet_account.ts
+++ b/packages/jellyfish-wallet/src/wallet_account.ts
@@ -14,7 +14,7 @@ import { DeFiAddress } from '@defichain/jellyfish-address'
 export abstract class WalletAccount implements WalletEllipticPair {
   protected constructor (
     private readonly walletEllipticPair: WalletEllipticPair,
-    private readonly network: Network
+    public readonly network: Network
   ) {
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

For many implementations it's useful to know what network the wallet function belongs to. Can refactor into a getter function if needed.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
