### PR TITLE
SignInputOption should not require EllipticPair

### DIFF
--- a/packages/jellyfish-transaction-builder/__tests__/raw_crafting.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/raw_crafting.test.ts
@@ -1,14 +1,9 @@
 import BigNumber from 'bignumber.js'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import {
-  CTransactionSegWit,
-  DeFiTransactionConstants,
-  Transaction,
-  OP_CODES
-} from '@defichain/jellyfish-transaction'
+import { CTransactionSegWit, DeFiTransactionConstants, OP_CODES, Transaction } from '@defichain/jellyfish-transaction'
 import { TransactionSigner } from '@defichain/jellyfish-transaction-signature'
-import { WIF, HASH160 } from '@defichain/jellyfish-crypto'
+import { HASH160, WIF } from '@defichain/jellyfish-crypto'
 import { SmartBuffer } from 'smart-buffer'
 
 const container = new MasterNodeRegTestContainer()
@@ -95,7 +90,8 @@ it('should craft, sign and broadcast a txn from scratch', async () => {
       },
       tokenId: 0x00
     },
-    ellipticPair: inputPair
+    publicKey: async () => await inputPair.publicKey(),
+    sign: async (hash) => await inputPair.sign(hash)
   }])
 
   // Get it as a buffer and send to container

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_error.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_error.test.ts
@@ -93,6 +93,6 @@ describe('EllipticPairProvider', () => {
     providers.elliptic.ellipticPair = randomEllipticPair()
 
     await expect(builder.utxo.sendAll(script))
-      .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+      .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and publicKey is not allowed')
   })
 })

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_p2wpkh.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_p2wpkh.test.ts
@@ -3,7 +3,7 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTxnBuilder } from '../../src'
 import { fundEllipticPair } from '../test.utils'
-import { DeFiOpUnmapped, OP_CODES, OP_DEFI_TX, CDfTx } from '@defichain/jellyfish-transaction'
+import { CDfTx, DeFiOpUnmapped, OP_CODES, OP_DEFI_TX } from '@defichain/jellyfish-transaction'
 
 // P2WPKHTxnBuilder is abstract and not instantiable
 class TestBuilder extends P2WPKHTxnBuilder {}
@@ -51,7 +51,7 @@ beforeEach(async () => {
 })
 
 describe('createDeFiTx()', () => {
-  it('should creat DfTx stack correctly and return change as vout', async () => {
+  it('should create DfTx stack correctly and return change as vout', async () => {
     const change = await providers.elliptic.script()
     const result = await builder.createDeFiTx(dummyDfTx, change)
 

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
@@ -1,11 +1,14 @@
 import {
-  DeFiTransactionConstants, OP_CODES,
+  DeFiTransactionConstants,
+  OP_CODES,
+  OP_DEFI_TX,
   Script,
   Transaction,
   TransactionSegWit,
-  Vin, Vout, OP_DEFI_TX
+  Vin,
+  Vout
 } from '@defichain/jellyfish-transaction'
-import { TransactionSigner, SignInputOption } from '@defichain/jellyfish-transaction-signature'
+import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 import BigNumber from 'bignumber.js'
 import { EllipticPairProvider, FeeRateProvider, Prevout, PrevoutProvider } from '../provider'
 import { calculateFeeP2WPKH } from './txn_fee'
@@ -134,10 +137,8 @@ export abstract class P2WPKHTxnBuilder {
    */
   protected async sign (transaction: Transaction, prevouts: Prevout[]): Promise<TransactionSegWit> {
     const signInputOptions = prevouts.map((prevout: Prevout): SignInputOption => {
-      return {
-        prevout: prevout,
-        ellipticPair: this.ellipticPairProvider.get(prevout)
-      }
+      const node = this.ellipticPairProvider.get(prevout)
+      return { prevout: prevout, publicKey: node.publicKey, sign: node.sign }
     })
 
     try {

--- a/packages/jellyfish-transaction-signature/__tests__/tx/p2wpkh_1_to_1.test.ts
+++ b/packages/jellyfish-transaction-signature/__tests__/tx/p2wpkh_1_to_1.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { SmartBuffer } from 'smart-buffer'
 import { Bech32, WIF } from '@defichain/jellyfish-crypto'
-import { OP_CODES, CTransaction, CTransactionSegWit } from '@defichain/jellyfish-transaction'
+import { CTransaction, CTransactionSegWit, OP_CODES } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '../../src'
 
 // From Address P2WPKH
@@ -18,6 +18,7 @@ it('sign transaction', async () => {
     SmartBuffer.fromBuffer(Buffer.from(unsigned, 'hex'))
   )
 
+  const wep = WIF.asEllipticPair(input.privKey)
   const inputs: SignInputOption[] = [{
     prevout: {
       script: {
@@ -29,7 +30,8 @@ it('sign transaction', async () => {
       value: new BigNumber('10'),
       tokenId: 0
     },
-    ellipticPair: WIF.asEllipticPair(input.privKey)
+    publicKey: async () => await wep.publicKey(),
+    sign: async (hash) => await wep.sign(hash)
   }]
   const txSigned = new CTransactionSegWit(await TransactionSigner.sign(txUnsigned, inputs))
 

--- a/packages/jellyfish-transaction-signature/__tests__/tx/p2wpkh_1_to_2.test.ts
+++ b/packages/jellyfish-transaction-signature/__tests__/tx/p2wpkh_1_to_2.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { SmartBuffer } from 'smart-buffer'
 import { Bech32, WIF } from '@defichain/jellyfish-crypto'
-import { OP_CODES, CTransaction, CTransactionSegWit } from '@defichain/jellyfish-transaction'
+import { CTransaction, CTransactionSegWit, OP_CODES } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '../../src'
 
 // From Address P2WPKH
@@ -18,6 +18,7 @@ it('sign transaction', async () => {
     SmartBuffer.fromBuffer(Buffer.from(unsigned, 'hex'))
   )
 
+  const wep = WIF.asEllipticPair(input.privKey)
   const inputs: SignInputOption[] = [{
     prevout: {
       script: {
@@ -29,7 +30,8 @@ it('sign transaction', async () => {
       value: new BigNumber('10'),
       tokenId: 0
     },
-    ellipticPair: WIF.asEllipticPair(input.privKey)
+    publicKey: async () => await wep.publicKey(),
+    sign: async (hash) => await wep.sign(hash)
   }]
   const txSigned = new CTransactionSegWit(await TransactionSigner.sign(txUnsigned, inputs))
 

--- a/packages/jellyfish-transaction-signature/__tests__/tx_signature/sign_input.test.ts
+++ b/packages/jellyfish-transaction-signature/__tests__/tx_signature/sign_input.test.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { OP_CODES, OP_PUSHDATA, SIGHASH, Transaction, Vout } from '@defichain/jellyfish-transaction'
-import { SHA256, HASH160, Elliptic } from '@defichain/jellyfish-crypto'
+import { Elliptic, HASH160, SHA256 } from '@defichain/jellyfish-crypto'
 import { TransactionSigner } from '../../src'
 
 describe('sign single input', () => {
@@ -72,7 +72,8 @@ describe('sign single input', () => {
   it('should sign single input', async () => {
     const witness = await TransactionSigner.signInput(transaction, 1, {
       prevout: prevout,
-      ellipticPair: keyPair
+      publicKey: async () => await keyPair.publicKey(),
+      sign: async (hash) => await keyPair.sign(hash)
     }, SIGHASH.ALL)
 
     expect(witness.scripts.length).toStrictEqual(2)
@@ -87,7 +88,8 @@ describe('sign single input', () => {
   it('should sign with same witnessScript getting the same signature', async () => {
     const witness = await TransactionSigner.signInput(transaction, 1, {
       prevout: prevout,
-      ellipticPair: keyPair,
+      publicKey: async () => await keyPair.publicKey(),
+      sign: async (hash) => await keyPair.sign(hash),
       witnessScript: {
         stack: [
           OP_CODES.OP_DUP,
@@ -111,7 +113,8 @@ describe('sign single input', () => {
   it('should sign with different witness script getting different signature', async () => {
     const witness = await TransactionSigner.signInput(transaction, 1, {
       prevout: prevout,
-      ellipticPair: keyPair,
+      publicKey: async () => await keyPair.publicKey(),
+      sign: async (hash) => await keyPair.sign(hash),
       witnessScript: {
         stack: [
           OP_CODES.OP_DUP,
@@ -144,7 +147,8 @@ describe('sign single input', () => {
         value: new BigNumber('6'),
         tokenId: 0x00
       },
-      ellipticPair: keyPair
+      publicKey: async () => await keyPair.publicKey(),
+      sign: async (hash) => await keyPair.sign(hash)
     }, SIGHASH.ALL))
       .rejects.toThrow('witnessScript required, only P2WPKH can be guessed')
   })
@@ -162,51 +166,58 @@ describe('sign single input', () => {
         value: new BigNumber('6'),
         tokenId: 0x00
       },
-      ellipticPair: keyPair
+      publicKey: async () => await keyPair.publicKey(),
+      sign: async (hash) => await keyPair.sign(hash)
     }, SIGHASH.ALL))
-      .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+      .rejects.toThrow('invalid input option - attempting to sign a mismatch vout and publicKey is not allowed')
   })
 
   describe('SIGHASH for consistency should err-out as they are not implemented', () => {
     it('should err SIGHASH.NONE', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.NONE)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.SINGLE', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.SINGLE)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.ANYONECANPAY', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.ALL_ANYONECANPAY', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.ALL_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.NONE_ANYONECANPAY', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.NONE_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
 
     it('should err SIGHASH.SINGLE_ANYONECANPAY', async () => {
       return await expect(TransactionSigner.signInput(transaction, 1, {
         prevout: prevout,
-        ellipticPair: keyPair
+        publicKey: async () => await keyPair.publicKey(),
+        sign: async (hash) => await keyPair.sign(hash)
       }, SIGHASH.SINGLE_ANYONECANPAY)).rejects.toThrow('currently only SIGHASH.ALL is supported')
     })
   })

--- a/packages/jellyfish-transaction-signature/src/tx_signature.ts
+++ b/packages/jellyfish-transaction-signature/src/tx_signature.ts
@@ -1,4 +1,4 @@
-import { dSHA256, HASH160 } from '@defichain/jellyfish-crypto'
+import { dSHA256, EllipticPair, HASH160 } from '@defichain/jellyfish-crypto'
 import { SmartBuffer } from 'smart-buffer'
 import {
   CVoutV4,
@@ -215,6 +215,19 @@ export const TransactionSigner = {
       witness: witnesses,
       lockTime: transaction.lockTime
     }
+  },
+
+  async signPrevoutsWithEllipticPairs (transaction: Transaction, prevouts: Vout[], ellipticPairs: EllipticPair[], option: SignOption = {}): Promise<TransactionSegWit> {
+    const inputs: SignInputOption[] = prevouts.map((prevout, index) => {
+      const ellipticPair = ellipticPairs[index]
+      return {
+        prevout: prevout,
+        publicKey: async () => await ellipticPair.publicKey(),
+        sign: async (hash) => await ellipticPair.sign(hash)
+      }
+    })
+
+    return await TransactionSigner.sign(transaction, inputs, option)
   },
 
   validate (transaction: Transaction, inputOptions: SignInputOption[], option: SignOption) {

--- a/packages/jellyfish-transaction-signature/src/tx_signature.ts
+++ b/packages/jellyfish-transaction-signature/src/tx_signature.ts
@@ -1,19 +1,19 @@
-import { EllipticPair, dSHA256, HASH160 } from '@defichain/jellyfish-crypto'
+import { dSHA256, HASH160 } from '@defichain/jellyfish-crypto'
 import { SmartBuffer } from 'smart-buffer'
 import {
+  CVoutV4,
+  CWitnessProgram,
+  DeFiTransactionConstants,
+  OP_CODES,
+  OP_PUSHDATA,
   Script,
+  SIGHASH,
   Transaction,
   TransactionSegWit,
   Vin,
   Vout,
   Witness,
-  OP_CODES,
-  OP_PUSHDATA,
-  CWitnessProgram,
-  WitnessProgram,
-  DeFiTransactionConstants,
-  SIGHASH,
-  CVoutV4
+  WitnessProgram
 } from '@defichain/jellyfish-transaction'
 
 export interface SignInputOption {
@@ -22,9 +22,16 @@ export interface SignInputOption {
    */
   prevout: Vout
   /**
-   * EllipticPair to generate a signature with
+   * @return {Promise<Buffer>} compressed public key
    */
-  ellipticPair: EllipticPair
+  publicKey: () => Promise<Buffer>
+  /**
+   * @param {Buffer} hash to sign
+   * @return {Buffer} signature in DER format, SIGHASHTYPE not included
+   * @see https://tools.ietf.org/html/rfc6979
+   * @see https://github.com/bitcoin/bitcoin/pull/13666
+   */
+  sign: (hash: Buffer) => Promise<Buffer>
   /**
    * Optionally provide a witness script,
    * or it will be guessed if it can be guessed.
@@ -92,7 +99,7 @@ async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
   if (stack[1].type !== 'OP_PUSHDATA') return false
   if ((stack[1] as OP_PUSHDATA).length() !== 20) return false
 
-  const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+  const pubkey: Buffer = await signInputOption.publicKey()
   const pubkeyHashHex = HASH160(pubkey).toString('hex')
   const pushDataHex = (stack[1] as OP_PUSHDATA).hex
 
@@ -100,7 +107,7 @@ async function isV0P2WPKH (signInputOption: SignInputOption): Promise<boolean> {
     return true
   }
 
-  throw new Error('invalid input option - attempting to sign a mismatch vout and elliptic pair is not allowed')
+  throw new Error('invalid input option - attempting to sign a mismatch vout and publicKey is not allowed')
 }
 
 /**
@@ -115,7 +122,7 @@ async function getScriptCode (vin: Vin, signInputOption: SignInputOption): Promi
   }
 
   if (await isV0P2WPKH(signInputOption)) {
-    const pubkey: Buffer = await signInputOption.ellipticPair.publicKey()
+    const pubkey: Buffer = await signInputOption.publicKey()
     const pubkeyHash = HASH160(pubkey)
 
     return {
@@ -170,12 +177,12 @@ export const TransactionSigner = {
     const program = await asWitnessProgram(transaction, vin, option, sigHashType)
     const preimage = new CWitnessProgram(program).asBuffer()
     const sigHash = dSHA256(preimage)
-    const derSignature = await option.ellipticPair.sign(sigHash)
+    const derSignature = await option.sign(sigHash)
     const sigHashBuffer = Buffer.alloc(1, sigHashType)
 
     // signature + pubKey
     const signature = Buffer.concat([derSignature, Buffer.alloc(1, sigHashBuffer)])
-    const pubkey: Buffer = await option.ellipticPair.publicKey()
+    const pubkey: Buffer = await option.publicKey()
     return {
       scripts: [
         {

--- a/packages/jellyfish-wallet-classic/src/classic.ts
+++ b/packages/jellyfish-wallet-classic/src/classic.ts
@@ -54,9 +54,9 @@ export class WalletClassic implements WalletEllipticPair {
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
+      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
     })
-    return TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.sign(transaction, inputs, {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet-classic/src/classic.ts
+++ b/packages/jellyfish-wallet-classic/src/classic.ts
@@ -1,7 +1,7 @@
 import { WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
 import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
-import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
+import { TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 
 /**
  * WalletClassic extends WalletEllipticPair with a simple classic implementation.
@@ -53,10 +53,7 @@ export class WalletClassic implements WalletEllipticPair {
    * @return {TransactionSegWit} a signed transaction
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
-    const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
-    })
-    return await TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.signPrevoutsWithEllipticPairs(transaction, prevouts, prevouts.map(() => this), {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet-classic/src/classic.ts
+++ b/packages/jellyfish-wallet-classic/src/classic.ts
@@ -1,6 +1,6 @@
 import { WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
-import { Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
+import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 
 /**
@@ -56,6 +56,8 @@ export class WalletClassic implements WalletEllipticPair {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
       return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
     })
-    return TransactionSigner.sign(transaction, inputs)
+    return TransactionSigner.sign(transaction, inputs, {
+      sigHashType: SIGHASH.ALL
+    })
   }
 }

--- a/packages/jellyfish-wallet-classic/src/classic.ts
+++ b/packages/jellyfish-wallet-classic/src/classic.ts
@@ -1,10 +1,6 @@
 import { WalletEllipticPair } from '@defichain/jellyfish-wallet'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
-import {
-  Transaction,
-  Vout,
-  TransactionSegWit
-} from '@defichain/jellyfish-transaction'
+import { Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 
 /**
@@ -58,7 +54,7 @@ export class WalletClassic implements WalletEllipticPair {
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, ellipticPair: this }
+      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
     })
     return TransactionSigner.sign(transaction, inputs)
   }

--- a/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
@@ -125,9 +125,9 @@ export class MnemonicHdNode implements WalletHdNode {
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
+      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
     })
-    return TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.sign(transaction, inputs, {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
@@ -1,11 +1,6 @@
 import { WalletHdNode, WalletHdNodeProvider } from '@defichain/jellyfish-wallet'
 import { DERSignature } from '@defichain/jellyfish-crypto'
-import {
-  Transaction,
-  Vout,
-  TransactionSegWit,
-  SIGHASH
-} from '@defichain/jellyfish-transaction'
+import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 import * as bip32 from 'bip32'
 import * as bip39 from 'bip39'
@@ -130,7 +125,7 @@ export class MnemonicHdNode implements WalletHdNode {
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, ellipticPair: this }
+      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
     })
     return TransactionSigner.sign(transaction, inputs, {
       sigHashType: SIGHASH.ALL

--- a/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
@@ -1,7 +1,7 @@
 import { WalletHdNode, WalletHdNodeProvider } from '@defichain/jellyfish-wallet'
 import { DERSignature } from '@defichain/jellyfish-crypto'
 import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
-import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
+import { TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 import * as bip32 from 'bip32'
 import * as bip39 from 'bip39'
 
@@ -124,10 +124,7 @@ export class MnemonicHdNode implements WalletHdNode {
    * @return TransactionSegWit signed transaction ready to broadcast
    */
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
-    const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
-    })
-    return await TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.signPrevoutsWithEllipticPairs(transaction, prevouts, prevouts.map(() => this), {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet/__tests__/node.mock.ts
+++ b/packages/jellyfish-wallet/__tests__/node.mock.ts
@@ -1,6 +1,6 @@
 import { WalletHdNode, WalletHdNodeProvider } from '../src'
 import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
-import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
+import { TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 import { Elliptic, EllipticPair } from '@defichain/jellyfish-crypto'
 
 /**
@@ -34,10 +34,7 @@ export class TestNode implements WalletHdNode {
   }
 
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
-    const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
-    })
-    return await TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.signPrevoutsWithEllipticPairs(transaction, prevouts, prevouts.map(() => this), {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet/__tests__/node.mock.ts
+++ b/packages/jellyfish-wallet/__tests__/node.mock.ts
@@ -1,5 +1,5 @@
 import { WalletHdNode, WalletHdNodeProvider } from '../src'
-import { Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
+import { SIGHASH, Transaction, TransactionSegWit, Vout } from '@defichain/jellyfish-transaction'
 import { SignInputOption, TransactionSigner } from '@defichain/jellyfish-transaction-signature'
 import { Elliptic, EllipticPair } from '@defichain/jellyfish-crypto'
 
@@ -37,7 +37,9 @@ export class TestNode implements WalletHdNode {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
       return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
     })
-    return TransactionSigner.sign(transaction, inputs)
+    return TransactionSigner.sign(transaction, inputs, {
+      sigHashType: SIGHASH.ALL
+    })
   }
 }
 

--- a/packages/jellyfish-wallet/__tests__/node.mock.ts
+++ b/packages/jellyfish-wallet/__tests__/node.mock.ts
@@ -35,9 +35,9 @@ export class TestNode implements WalletHdNode {
 
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
+      return { prevout: prevout, publicKey: async () => await this.publicKey(), sign: async (hash) => await this.sign(hash) }
     })
-    return TransactionSigner.sign(transaction, inputs, {
+    return await TransactionSigner.sign(transaction, inputs, {
       sigHashType: SIGHASH.ALL
     })
   }

--- a/packages/jellyfish-wallet/__tests__/node.mock.ts
+++ b/packages/jellyfish-wallet/__tests__/node.mock.ts
@@ -35,7 +35,7 @@ export class TestNode implements WalletHdNode {
 
   async signTx (transaction: Transaction, prevouts: Vout[]): Promise<TransactionSegWit> {
     const inputs: SignInputOption[] = prevouts.map(prevout => {
-      return { prevout: prevout, ellipticPair: this }
+      return { prevout: prevout, publicKey: this.publicKey, sign: this.sign }
     })
     return TransactionSigner.sign(transaction, inputs)
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

SignInputOption should not require EllipticPair to prevent the wrong use of the EllipticPair interface. E.g. accessing privKey.

Also added `TransactionSigner.signPrevoutsWithEllipticPairs` to keep EllipticPair implementation dry.