### PR TITLE
Replace `npx run codecov` with GH Actions `codecov/codecov-action`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
       - run: npm run build
 
       - run: npm run test:ci
-      - run: npx codecov
+
+      - uses: codecov/codecov-action@c585afe366f940d214dc09df2664c06d7fe07052
+        with:
+          fail_ci_if_error: true
 
   lint:
     name: Lint


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

As bash uploader `v1` is deprecated, it's using verified `v2` now
