### PR TITLE
removed npm@next badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ DeFi Jellyfish follows a monorepo methodology, all maintained packages are in th
 version tag.
 
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish/next)](https://www.npmjs.com/package/@defichain/jellyfish/v/next)
 
 Package                                            | Description
 ---------------------------------------------------|-------------

--- a/packages/jellyfish-address/README.md
+++ b/packages/jellyfish-address/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-address)](https://www.npmjs.com/package/@defichain/jellyfish-address/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-address/next)](https://www.npmjs.com/package/@defichain/jellyfish-address/v/next)
 
 # @defichain/jellyfish-address
 

--- a/packages/jellyfish-api-core/README.md
+++ b/packages/jellyfish-api-core/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-api-core)](https://www.npmjs.com/package/@defichain/jellyfish-api-core/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-api-core/next)](https://www.npmjs.com/package/@defichain/jellyfish-api-core/v/next)
 
 # @defichain/jellyfish-api-core
 

--- a/packages/jellyfish-api-jsonrpc/README.md
+++ b/packages/jellyfish-api-jsonrpc/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-api-jsonrpc)](https://www.npmjs.com/package/@defichain/jellyfish-api-jsonrpc/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-api-jsonrpc/next)](https://www.npmjs.com/package/@defichain/jellyfish-api-jsonrpc/v/next)
 
 # @defichain/jellyfish-api-jsonrpc
 

--- a/packages/jellyfish-crypto/README.md
+++ b/packages/jellyfish-crypto/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-crypto)](https://www.npmjs.com/package/@defichain/jellyfish-crypto/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-crypto/next)](https://www.npmjs.com/package/@defichain/jellyfish-crypto/v/next)
 
 # @defichain/jellyfish-crypto
 

--- a/packages/jellyfish-json/README.md
+++ b/packages/jellyfish-json/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-json)](https://www.npmjs.com/package/@defichain/jellyfish-json/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-json/next)](https://www.npmjs.com/package/@defichain/jellyfish-json/v/next)
 
 # @defichain/jellyfish-json
 

--- a/packages/jellyfish-network/README.md
+++ b/packages/jellyfish-network/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-network)](https://www.npmjs.com/package/@defichain/jellyfish-network/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-network/next)](https://www.npmjs.com/package/@defichain/jellyfish-network/v/next)
 
 # @defichain/jellyfish-network
 

--- a/packages/jellyfish-transaction-builder/README.md
+++ b/packages/jellyfish-transaction-builder/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-builder)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-builder/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-builder/next)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-builder/v/next)
 
 # @defichain/jellyfish-transaction-builder
 

--- a/packages/jellyfish-transaction-signature/README.md
+++ b/packages/jellyfish-transaction-signature/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-signature)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-signature/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-transaction-signature/next)](https://www.npmjs.com/package/@defichain/jellyfish-transaction-signature/v/next)
 
 # @defichain/jellyfish-transaction-signature
 

--- a/packages/jellyfish-transaction/README.md
+++ b/packages/jellyfish-transaction/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-transaction)](https://www.npmjs.com/package/@defichain/jellyfish-transaction/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-transaction/next)](https://www.npmjs.com/package/@defichain/jellyfish-transaction/v/next)
 
 # @defichain/jellyfish-transaction
 

--- a/packages/jellyfish-wallet-classic/README.md
+++ b/packages/jellyfish-wallet-classic/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-classic)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-classic/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-classic/next)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-classic/v/next)
 
 # @defichain/jellyfish-wallet-classic
 

--- a/packages/jellyfish-wallet-encrypted/README.md
+++ b/packages/jellyfish-wallet-encrypted/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-encrypted)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-encrypted/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-encrypted/next)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-encrypted/v/next)
 
 # @defichain/jellyfish-wallet-encrypted
 

--- a/packages/jellyfish-wallet-mnemonic/README.md
+++ b/packages/jellyfish-wallet-mnemonic/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-mnemonic)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-mnemonic/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-wallet-mnemonic/next)](https://www.npmjs.com/package/@defichain/jellyfish-wallet-mnemonic/v/next)
 
 # @defichain/jellyfish-wallet-mnemonic
 

--- a/packages/jellyfish-wallet/README.md
+++ b/packages/jellyfish-wallet/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish-wallet)](https://www.npmjs.com/package/@defichain/jellyfish-wallet/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish-wallet/next)](https://www.npmjs.com/package/@defichain/jellyfish-wallet/v/next)
 
 # @defichain/jellyfish-wallet
 

--- a/packages/jellyfish/README.md
+++ b/packages/jellyfish/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish/next)](https://www.npmjs.com/package/@defichain/jellyfish/v/next)
 
 # @defichain/jellyfish
 

--- a/packages/testcontainers/README.md
+++ b/packages/testcontainers/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/testcontainers)](https://www.npmjs.com/package/@defichain/testcontainers/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/testcontainers/next)](https://www.npmjs.com/package/@defichain/testcontainers/v/next)
 
 # @defichain/testcontainers
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,5 +1,4 @@
 [![npm](https://img.shields.io/npm/v/@defichain/testing)](https://www.npmjs.com/package/@defichain/testing/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/testing/next)](https://www.npmjs.com/package/@defichain/testing/v/next)
 
 # @defichain/testing
 

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -23,7 +23,6 @@ As with all modern JavaScript projects, jellyfish follows a monorepo structure w
 maintained in this repo are published with the same version tag and follows the `DeFiCh/ain` releases.
 
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
-[![npm@next](https://img.shields.io/npm/v/@defichain/jellyfish/next)](https://www.npmjs.com/package/@defichain/jellyfish/v/next)
 
 Package                                            | Description 
 ---------------------------------------------------|-------------


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind docs

#### What this PR does / why we need it:

All release are released into `npm@latest` by default now, hence deprecating the `npm@next` badge.