### PR TITLE
EncryptedProviderData encrypt mnemonic words instead of privKey

### DIFF
--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -44,6 +44,22 @@ const prevout: Vout = {
   tokenId: 0x00
 }
 
+it('should be able to access provider.data and provider.options', async () => {
+  const scrypt = new Scrypt(new SimpleScryptsy({ N: 16384, r: 8, p: 1 }))
+  const words = MnemonicHdNodeProvider.generateWords(24)
+  const passphrase = 'random'
+  const data = await EncryptedHdNodeProvider.wordsToEncryptedData(
+    words,
+    regTestBip32Options,
+    scrypt,
+    passphrase
+  )
+  const provider = EncryptedHdNodeProvider.init(data, regTestBip32Options, scrypt, async () => passphrase)
+
+  expect(provider.data).toBeDefined()
+  expect(provider.options).toBeDefined()
+})
+
 describe('24 words: random with passphrase "random" (exact same test in jellyfish-wallet-mnemonic)', () => {
   const scrypt = new Scrypt(new SimpleScryptsy({ N: 16384, r: 8, p: 1 }))
   let provider: EncryptedHdNodeProvider

--- a/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
@@ -43,6 +43,14 @@ const prevout: Vout = {
   tokenId: 0x00
 }
 
+it('should be able to access provider.data and provider.options', async () => {
+  const words = MnemonicHdNodeProvider.generateWords(24)
+  const provider = MnemonicHdNodeProvider.fromWords(words, regTestBip32Options)
+
+  expect(provider.data).toBeDefined()
+  expect(provider.options).toBeDefined()
+})
+
 describe('24 words: random', () => {
   let provider: MnemonicHdNodeProvider
 

--- a/packages/jellyfish-wallet-mnemonic/src/hd_node.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/hd_node.ts
@@ -112,8 +112,8 @@ export interface MnemonicProviderData {
  */
 export class MnemonicHdNodeProvider implements WalletHdNodeProvider<MnemonicHdNode> {
   private constructor (
-    private readonly data: MnemonicProviderData,
-    private readonly options: Bip32Options
+    public readonly data: MnemonicProviderData,
+    public readonly options: Bip32Options
   ) {
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

- `HdNodeProvider.data` and `HdNodeProvider.options` should be `public readonly` for external read
- EncryptedProviderData should encode encrypted words instead of private key for mnemonic recovery

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #503

#### Additional comments?:

- [ ] @ivan-zynesis how do to encrypt even buffer length properly?
