### PR TITLE
AppointOracle and UpdateOracle rpcs should allow weightage value from 0 to 255

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/oracle/appointOracle.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/oracle/appointOracle.test.ts
@@ -91,6 +91,58 @@ describe('Oracle', () => {
     ])
   })
 
+  it('should appointOracle if weightage is 0', async () => {
+    const priceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const oracleid = await client.oracle.appointOracle(await container.getNewAddress(), priceFeeds, { weightage: 0 })
+
+    expect(typeof oracleid).toStrictEqual('string')
+    expect(oracleid.length).toStrictEqual(64)
+
+    await container.generate(1)
+  })
+
+  it('should appointOracle if weightage is 255', async () => {
+    const priceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const oracleid = await client.oracle.appointOracle(await container.getNewAddress(), priceFeeds, { weightage: 255 })
+
+    expect(typeof oracleid).toStrictEqual('string')
+    expect(oracleid.length).toStrictEqual(64)
+
+    await container.generate(1)
+  })
+
+  it('should not appointOracle if weightage is -1', async () => {
+    const priceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const promise = client.oracle.appointOracle(await container.getNewAddress(), priceFeeds, { weightage: -1 })
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'the weightage value is out of bounds\', code: -25, method: appointoracle')
+  })
+
+  it('should not appointOracle if weightage is 256', async () => {
+    const priceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const promise = client.oracle.appointOracle(await container.getNewAddress(), priceFeeds, { weightage: 256 })
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'the weightage value is out of bounds\', code: -25, method: appointoracle')
+  })
+
   it('should appointOracle with utxos', async () => {
     const address = await container.getNewAddress()
 

--- a/packages/jellyfish-api-core/__tests__/category/oracle/updateOracle.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/oracle/updateOracle.test.ts
@@ -155,6 +155,114 @@ describe('Oracle', () => {
     ])
   })
 
+  it('should updateOracle if weightage is 0', async () => {
+    // Appoint oracle
+    const appointOraclePriceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    let oracleid = await container.call('appointoracle', [await container.getNewAddress(), appointOraclePriceFeeds, 1])
+
+    await container.generate(1)
+
+    // Update oracle
+    const updateOraclePriceFeeds = [
+      { token: 'FB', currency: 'CNY' },
+      { token: 'MSFT', currency: 'SGD' }
+    ]
+
+    oracleid = await client.oracle.updateOracle(oracleid, await container.getNewAddress(), {
+      priceFeeds: updateOraclePriceFeeds,
+      weightage: 0
+    })
+
+    await container.generate(1)
+
+    expect(typeof oracleid).toStrictEqual('string')
+    expect(oracleid.length).toStrictEqual(64)
+  })
+
+  it('should updateOracle if weightage is 255', async () => {
+    // Appoint oracle
+    const appointOraclePriceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    let oracleid = await container.call('appointoracle', [await container.getNewAddress(), appointOraclePriceFeeds, 1])
+
+    await container.generate(1)
+
+    // Update oracle
+    const updateOraclePriceFeeds = [
+      { token: 'FB', currency: 'CNY' },
+      { token: 'MSFT', currency: 'SGD' }
+    ]
+
+    oracleid = await client.oracle.updateOracle(oracleid, await container.getNewAddress(), {
+      priceFeeds: updateOraclePriceFeeds,
+      weightage: 255
+    })
+
+    await container.generate(1)
+
+    expect(typeof oracleid).toStrictEqual('string')
+    expect(oracleid.length).toStrictEqual(64)
+  })
+
+  it('should not updateOracle if weightage is -1', async () => {
+    // Appoint oracle
+    const appointOraclePriceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const oracleid = await container.call('appointoracle', [await container.getNewAddress(), appointOraclePriceFeeds, 1])
+
+    await container.generate(1)
+
+    // Update oracle
+    const updateOraclePriceFeeds = [
+      { token: 'FB', currency: 'CNY' },
+      { token: 'MSFT', currency: 'SGD' }
+    ]
+
+    const promise = client.oracle.updateOracle(oracleid, await container.getNewAddress(), {
+      priceFeeds: updateOraclePriceFeeds,
+      weightage: -1
+    })
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'the weightage value is out of bounds\', code: -25, method: updateoracle')
+  })
+
+  it('should not updateOracle if weightage is 256', async () => {
+    // Appoint oracle
+    const appointOraclePriceFeeds = [
+      { token: 'APPLE', currency: 'EUR' },
+      { token: 'TESLA', currency: 'USD' }
+    ]
+
+    const oracleid = await container.call('appointoracle', [await container.getNewAddress(), appointOraclePriceFeeds, 1])
+
+    await container.generate(1)
+
+    // Update oracle
+    const updateOraclePriceFeeds = [
+      { token: 'FB', currency: 'CNY' },
+      { token: 'MSFT', currency: 'SGD' }
+    ]
+
+    const promise = client.oracle.updateOracle(oracleid, await container.getNewAddress(), {
+      priceFeeds: updateOraclePriceFeeds,
+      weightage: 256
+    })
+
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('RpcApiError: \'the weightage value is out of bounds\', code: -25, method: updateoracle')
+  })
+
   it('should not updateOracle with arbitrary utxos', async () => {
     // Appoint oracle
     const appointOraclePriceFeeds = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

These 2 Oracle rpcs should allow weightage value from 0 to 255,  not 1 to 100.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #509 

#### Additional comments?:
