### PR TITLE
`@defichain/jellyfish-wallet` derivation refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13290,6 +13290,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/create-hmac": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/create-hmac/-/create-hmac-1.1.0.tgz",
+      "integrity": "sha512-BNYNdzdhOZZQWCOpwvIll3FSvgo3e55Y2M6s/jOY6TuOCwqt3cLmQsK4tSmJ5fayDot8EG4k3+hcZagfww9JlQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/docker-modem": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.1.tgz",
@@ -30428,7 +30437,11 @@
         "@defichain/jellyfish-transaction": "0.0.0",
         "@defichain/jellyfish-wallet": "0.0.0",
         "bip32": "^2.0.6",
-        "bip39": "^3.0.4"
+        "bip39": "^3.0.4",
+        "create-hmac": "^1.1.7"
+      },
+      "devDependencies": {
+        "@types/create-hmac": "^1.1.0"
       }
     },
     "packages/testcontainers": {
@@ -31714,8 +31727,10 @@
       "requires": {
         "@defichain/jellyfish-transaction": "0.0.0",
         "@defichain/jellyfish-wallet": "0.0.0",
+        "@types/create-hmac": "^1.1.0",
         "bip32": "^2.0.6",
-        "bip39": "^3.0.4"
+        "bip39": "^3.0.4",
+        "create-hmac": "^1.1.7"
       }
     },
     "@defichain/testcontainers": {
@@ -41152,6 +41167,15 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/create-hash/-/create-hash-1.2.2.tgz",
       "integrity": "sha512-Fg8/kfMJObbETFU/Tn+Y0jieYewryLrbKwLCEIwPyklZZVY2qB+64KFjhplGSw+cseZosfFXctXO+PyIYD8iZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/create-hmac": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/create-hmac/-/create-hmac-1.1.0.tgz",
+      "integrity": "sha512-BNYNdzdhOZZQWCOpwvIll3FSvgo3e55Y2M6s/jOY6TuOCwqt3cLmQsK4tSmJ5fayDot8EG4k3+hcZagfww9JlQ==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-encrypted/__tests__/bip32.test.ts
@@ -168,14 +168,14 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('3e1f9339b4685c35d590fd1a6801967a9f95dbedf3e5733efa6451dc771a2d18')
+      expect(privKey.toString('hex')).toStrictEqual('b5b25c4628c5bb31a673ee8d1ab4c378ae50df2b173cf99d26cfe7848d834628')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022070454813f8ff8e7a13f2ef9be18c89a3768d846647559798c147cd2ae284d1b1022058584df9e77efd620c7657f8d63eb7a2cd8c5753e3d29bc50bcb4c8c5c95ce49')
+      expect(signature.toString('hex')).toStrictEqual('304402203d6b4db36c211f41c4fe38295cf73e8872719a38d88b54e0aa3968cf075c162f02200989c4e66f1ec8dfb3d612ded1892bb026ff6c40aeb81c1c36aea7b64622eec7')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -196,14 +196,14 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('be7b3f86469900fc9302cea6bcf3b05c165a6461f8a0e7796305c350fc1f7357')
+      expect(privKey.toString('hex')).toStrictEqual('93ec40698d0819e6f9cb9cdd56c0f17c4c9165cb46a691680c6062976458f97c')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('304402201866354d84fb7b576c3a3248adb55582aa9a1c61b8d27dc355c4d9d07aa16b480220311133b0a69ab54a63406b1fce001c91d8a65ef665016d9792850edbe34a7598')
+      expect(signature.toString('hex')).toStrictEqual('3044022017fd6b15966223f557b4808b143e2333e8100dae1162aa70404043f640c6d87e02207aead802d1fe8bef1f01320234fc827a5bb74950f03717273b80ff7a8b3d13f8')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -219,19 +219,19 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
 
     it('should derive pub key', async () => {
       const derivedPubKey = await node.publicKey()
-      expect(derivedPubKey.toString('hex')).toStrictEqual('03d0d24a126c861c02622cb4ee75b860d6e65d1d6ffee20bf5793c1a00ade37db5')
+      expect(derivedPubKey.toString('hex')).toStrictEqual('0357e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db96')
     })
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('209fab36379401ac23960f0890ac1cc880e9c6e351a8525dac59a3ea6bb4ebb7')
+      expect(privKey.toString('hex')).toStrictEqual('c168700046e2cdfab52f5da5d5975ecaaaffa45c5b174100a0dab260a252cd43')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022007340e6a1052ca16acb180f33dd6781c60e2aa1acd27f4b50c13c6f370c9c8a802206fca4fd8263eb84d6e2c8d6111a5663b5da59eec843aab5cbfcbb273d497917c')
+      expect(signature.toString('hex')).toStrictEqual('30440220467af7ace148ad6cc0d16b1197ac497b0d8abee2262484026ebe8263711d1f4f02203e598cb442b480d8579c14efb8bee28acf0bfbd45a563115804cc4b96f7f56a3')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -251,8 +251,8 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402202c7ba3ded9cb503e8afb8a14ddb16ef4ea66043157e2a76e40d5d534fa80114302202aa1ea35654e2cd59a9f2e325037b38ef3d3939b47041782f05c819b1090dbd201')
-      expect(signed.witness[0].scripts[1].hex).toStrictEqual('03d0d24a126c861c02622cb4ee75b860d6e65d1d6ffee20bf5793c1a00ade37db5')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('30440220185e6303835b2031806ffc3bead6c2979bbfb8cb76cce7eaabd0455c247fb74402203eb29b1ce28c3095fbd061fe304c2a14cae23f7b6be518c8f6d531e5648df4ab01')
+      expect(signed.witness[0].scripts[1].hex).toStrictEqual('0357e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db96')
     })
   })
 
@@ -265,19 +265,19 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
 
     it('should derive pub key', async () => {
       const derivedPubKey = await node.publicKey()
-      expect(derivedPubKey.toString('hex')).toStrictEqual('0332b504dca50e2f9f369ac3bdc1a29fc5a082c9a35cc60f54d4c115518bb7a824')
+      expect(derivedPubKey.toString('hex')).toStrictEqual('02dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd')
     })
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('12137509a9c70bc0ac55f0897577ba55cd1c222a209096f7b27f3de4c1eef30d')
+      expect(privKey.toString('hex')).toStrictEqual('aca9b40bb55657e8f5e61298357edda0fa9ac88fbce8f60a3eb2b3d3d32dd20d')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022036a7d5ad851541745fa4081327ef846c262d46640cbb1f5d989c07db3400fe4a0220384de187749c731ea47036d4f4bb77db69961359b8c70a1da5750b9acec2e573')
+      expect(signature.toString('hex')).toStrictEqual('304402201a2cd2dd58ce73f2e68bf394db9543b357d4ad9c05a69ccf764a057cb445238c022012557da02591c6e9c5951b9fd339eade10e604146c547a5e5468f7ecaabc563c')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -297,8 +297,8 @@ describe('24 words: abandon x23 art with passphrase "jellyfish-wallet-encrypted"
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('30440220729650b5ab2e325e13da49e474fa5f434f7c68f2d62a734e48c982a921b38830022069c02966ede1db87ac726326da7d5467775de23ec56516f151b31abbb90ec7e701')
-      expect(signed.witness[0].scripts[1].hex).toStrictEqual('0332b504dca50e2f9f369ac3bdc1a29fc5a082c9a35cc60f54d4c115518bb7a824')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402207e9550e32dc22dda8ec2766aeb2644558ec96e1ae15844aa8cefca1dd18516c8022071b0086ea1219fbd9fa0fa4fa8b807203fc8ce206ecd2be048bb3f99c69a84d301')
+      expect(signed.witness[0].scripts[1].hex).toStrictEqual('02dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd')
     })
   })
 })

--- a/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
@@ -158,7 +158,7 @@ describe('24 words: abandon x23 art', () => {
 
   describe("44'/1129'/0'/0/0", () => {
     let node: MnemonicHdNode
-    const pubKey = '037cf033b3c773dae3ce704e85fabef1702b25ad897533fe65b5c3f85912adebc1'
+    const pubKey = '034849fafd49b531a2b8a101993c34ea5c70bdc094fd4fc45d2fca2068d2143553'
 
     beforeEach(() => {
       node = provider.derive("44'/1129'/0'/0/0")
@@ -171,14 +171,14 @@ describe('24 words: abandon x23 art', () => {
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('3e1f9339b4685c35d590fd1a6801967a9f95dbedf3e5733efa6451dc771a2d18')
+      expect(privKey.toString('hex')).toStrictEqual('b5b25c4628c5bb31a673ee8d1ab4c378ae50df2b173cf99d26cfe7848d834628')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022070454813f8ff8e7a13f2ef9be18c89a3768d846647559798c147cd2ae284d1b1022058584df9e77efd620c7657f8d63eb7a2cd8c5753e3d29bc50bcb4c8c5c95ce49')
+      expect(signature.toString('hex')).toStrictEqual('304402203d6b4db36c211f41c4fe38295cf73e8872719a38d88b54e0aa3968cf075c162f02200989c4e66f1ec8dfb3d612ded1892bb026ff6c40aeb81c1c36aea7b64622eec7')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -198,14 +198,14 @@ describe('24 words: abandon x23 art', () => {
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('3044022039c1dd0ccc95e188bd997f955221f37d97eb135d3060d79aa584f0d6361e4083022012481d8505adecea60cd02b4a2c381c0323a5ff0eb780bea1a9d11485c2d6e6f01')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402204d8c2fe002b537d0b04d0ace2b11d308bed62328ae36f9a540ab6e870af64abf022058b9a9eb3c2aa5e09b8dedbce93ca6751fb3725aa0fc7cab37540153941eaf7001')
       expect(signed.witness[0].scripts[1].hex).toStrictEqual(pubKey)
     })
   })
 
   describe("44'/1129'/1'/0/0", () => {
     let node: MnemonicHdNode
-    const pubKey = '03548dfc620bcd01f774ba24512b594040693898b49ca08ec4ea9fc99f319be34f'
+    const pubKey = '032a530c06df4a2b4e50863da169733d57ec07c598f8188e5a0341952fa2580075'
 
     beforeEach(() => {
       node = provider.derive("44'/1129'/1'/0/0")
@@ -218,14 +218,14 @@ describe('24 words: abandon x23 art', () => {
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('be7b3f86469900fc9302cea6bcf3b05c165a6461f8a0e7796305c350fc1f7357')
+      expect(privKey.toString('hex')).toStrictEqual('93ec40698d0819e6f9cb9cdd56c0f17c4c9165cb46a691680c6062976458f97c')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('304402201866354d84fb7b576c3a3248adb55582aa9a1c61b8d27dc355c4d9d07aa16b480220311133b0a69ab54a63406b1fce001c91d8a65ef665016d9792850edbe34a7598')
+      expect(signature.toString('hex')).toStrictEqual('3044022017fd6b15966223f557b4808b143e2333e8100dae1162aa70404043f640c6d87e02207aead802d1fe8bef1f01320234fc827a5bb74950f03717273b80ff7a8b3d13f8')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -245,7 +245,7 @@ describe('24 words: abandon x23 art', () => {
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('30440220403d4733c626866ba4117cbf725cc7f6d547cc8bc012786345cb1e58a2693426022039597dd1c39c1a528b884b97a246dd24b6fc7a103ce29a15ef8402ca691b5b0901')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402200a5da4731e6221afe5706d97c0f537668e7eadb8d86ad11fe35b10888d2d63f502201eba3eb749f129a0ee40626c455ed21f041317294ef0dc0de5362fb2162d54a101')
       expect(signed.witness[0].scripts[1].hex).toStrictEqual(pubKey)
     })
   })
@@ -259,19 +259,19 @@ describe('24 words: abandon x23 art', () => {
 
     it('should derive pub key', async () => {
       const derivedPubKey = await node.publicKey()
-      expect(derivedPubKey.toString('hex')).toStrictEqual('03d0d24a126c861c02622cb4ee75b860d6e65d1d6ffee20bf5793c1a00ade37db5')
+      expect(derivedPubKey.toString('hex')).toStrictEqual('0357e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db96')
     })
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('209fab36379401ac23960f0890ac1cc880e9c6e351a8525dac59a3ea6bb4ebb7')
+      expect(privKey.toString('hex')).toStrictEqual('c168700046e2cdfab52f5da5d5975ecaaaffa45c5b174100a0dab260a252cd43')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022007340e6a1052ca16acb180f33dd6781c60e2aa1acd27f4b50c13c6f370c9c8a802206fca4fd8263eb84d6e2c8d6111a5663b5da59eec843aab5cbfcbb273d497917c')
+      expect(signature.toString('hex')).toStrictEqual('30440220467af7ace148ad6cc0d16b1197ac497b0d8abee2262484026ebe8263711d1f4f02203e598cb442b480d8579c14efb8bee28acf0bfbd45a563115804cc4b96f7f56a3')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -291,8 +291,8 @@ describe('24 words: abandon x23 art', () => {
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402202c7ba3ded9cb503e8afb8a14ddb16ef4ea66043157e2a76e40d5d534fa80114302202aa1ea35654e2cd59a9f2e325037b38ef3d3939b47041782f05c819b1090dbd201')
-      expect(signed.witness[0].scripts[1].hex).toStrictEqual('03d0d24a126c861c02622cb4ee75b860d6e65d1d6ffee20bf5793c1a00ade37db5')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('30440220185e6303835b2031806ffc3bead6c2979bbfb8cb76cce7eaabd0455c247fb74402203eb29b1ce28c3095fbd061fe304c2a14cae23f7b6be518c8f6d531e5648df4ab01')
+      expect(signed.witness[0].scripts[1].hex).toStrictEqual('0357e2eb9dee0792a24c7a9047bd05e28acd7a9275bc2b33916b1e434993f5db96')
     })
   })
 
@@ -305,19 +305,19 @@ describe('24 words: abandon x23 art', () => {
 
     it('should derive pub key', async () => {
       const derivedPubKey = await node.publicKey()
-      expect(derivedPubKey.toString('hex')).toStrictEqual('0332b504dca50e2f9f369ac3bdc1a29fc5a082c9a35cc60f54d4c115518bb7a824')
+      expect(derivedPubKey.toString('hex')).toStrictEqual('02dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd')
     })
 
     it('should derive priv key', async () => {
       const privKey = await node.privateKey()
-      expect(privKey.toString('hex')).toStrictEqual('12137509a9c70bc0ac55f0897577ba55cd1c222a209096f7b27f3de4c1eef30d')
+      expect(privKey.toString('hex')).toStrictEqual('aca9b40bb55657e8f5e61298357edda0fa9ac88fbce8f60a3eb2b3d3d32dd20d')
     })
 
     it('should sign and verify', async () => {
       const hash = Buffer.from('e9071e75e25b8a1e298a72f0d2e9f4f95a0f5cdf86a533cda597eb402ed13b3a', 'hex')
 
       const signature = await node.sign(hash)
-      expect(signature.toString('hex')).toStrictEqual('3044022036a7d5ad851541745fa4081327ef846c262d46640cbb1f5d989c07db3400fe4a0220384de187749c731ea47036d4f4bb77db69961359b8c70a1da5750b9acec2e573')
+      expect(signature.toString('hex')).toStrictEqual('304402201a2cd2dd58ce73f2e68bf394db9543b357d4ad9c05a69ccf764a057cb445238c022012557da02591c6e9c5951b9fd339eade10e604146c547a5e5468f7ecaabc563c')
 
       const valid = await node.verify(hash, signature)
       expect(valid).toStrictEqual(true)
@@ -337,8 +337,8 @@ describe('24 words: abandon x23 art', () => {
       expect(signed.witness.length).toStrictEqual(1)
       expect(signed.witness[0].scripts.length).toStrictEqual(2)
 
-      expect(signed.witness[0].scripts[0].hex).toStrictEqual('30440220729650b5ab2e325e13da49e474fa5f434f7c68f2d62a734e48c982a921b38830022069c02966ede1db87ac726326da7d5467775de23ec56516f151b31abbb90ec7e701')
-      expect(signed.witness[0].scripts[1].hex).toStrictEqual('0332b504dca50e2f9f369ac3bdc1a29fc5a082c9a35cc60f54d4c115518bb7a824')
+      expect(signed.witness[0].scripts[0].hex).toStrictEqual('304402207e9550e32dc22dda8ec2766aeb2644558ec96e1ae15844aa8cefca1dd18516c8022071b0086ea1219fbd9fa0fa4fa8b807203fc8ce206ecd2be048bb3f99c69a84d301')
+      expect(signed.witness[0].scripts[1].hex).toStrictEqual('02dc83dda8b4e068d45fe63eaa12f2abbe4391569ffd25b031229275f9eb1f2efd')
     })
   })
 })

--- a/packages/jellyfish-wallet-mnemonic/package.json
+++ b/packages/jellyfish-wallet-mnemonic/package.json
@@ -38,6 +38,10 @@
     "@defichain/jellyfish-wallet": "0.0.0",
     "@defichain/jellyfish-transaction": "0.0.0",
     "bip32": "^2.0.6",
-    "bip39": "^3.0.4"
+    "bip39": "^3.0.4",
+    "create-hmac": "^1.1.7"
+  },
+  "devDependencies": {
+    "@types/create-hmac": "^1.1.0"
   }
 }

--- a/packages/jellyfish-wallet/__tests__/wallet.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet.test.ts
@@ -15,7 +15,7 @@ describe('discover accounts', () => {
 
   it('should discover [0] when [0] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -25,7 +25,7 @@ describe('discover accounts', () => {
 
   it('should discover [] when [1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38'
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -35,8 +35,8 @@ describe('discover accounts', () => {
 
   it('should discover [0,1] when [0,1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8',
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -46,9 +46,9 @@ describe('discover accounts', () => {
 
   it('should discover [0,1,2] when [0,1,2] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8',
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38',
-      'bcrt1q2v5wa73qe0ychdheppaeae5s594u3up2d0tha8'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp',
+      'bcrt1qhu2pkzfx4gc8r5nry89ma9xvvt6rz0r4xe5yyw'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -58,10 +58,10 @@ describe('discover accounts', () => {
 
   it('should discover [0,1] when [0,1,3,4] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8',
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38',
-      'bcrt1q9a2mrm2sp4xpu5k33jakr4jk9zqcwtf3ns3h7j',
-      'bcrt1qh7safzu8d2p02vlnhsm2995t3der3qk75wl8y6'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp',
+      'bcrt1q5kn8n6wne38q84z86ukghluh4d0seqp2rcfw5g',
+      'bcrt1qwtjj8kjc92zcya6jjprjvdn3h2vw9uh003q4c3'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -71,8 +71,8 @@ describe('discover accounts', () => {
 
   it('should discover [0] when [0,1] has activity as max account is set to 1', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8',
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -91,7 +91,7 @@ describe('is usable', () => {
 
   it('[0,1] should be usable when [0] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
     expect(await wallet.isUsable(0)).toStrictEqual(true)
@@ -100,8 +100,8 @@ describe('is usable', () => {
 
   it('[0,1,2] should be usable when [0,1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8',
-      'bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38'
+      'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
+      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
     expect(await wallet.isUsable(0)).toStrictEqual(true)
@@ -123,54 +123,54 @@ describe('get accounts', () => {
   it('should get account 0', async () => {
     const account = wallet.get(0)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1qtxqjthltev9zqzfqkgt3t758zmdq2twhf2hkj8')
+    expect(address).toStrictEqual('bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2')
   })
 
   it('should get account 1', async () => {
     const account = wallet.get(1)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1qncjrhlntyyrv6dk5xjn0ep6sjfrqv478365v38')
+    expect(address).toStrictEqual('bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp')
   })
 
   it('should get account 2', async () => {
     const account = wallet.get(2)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1q2v5wa73qe0ychdheppaeae5s594u3up2d0tha8')
+    expect(address).toStrictEqual('bcrt1qhu2pkzfx4gc8r5nry89ma9xvvt6rz0r4xe5yyw')
   })
 
   it('should get account 3', async () => {
     const account = wallet.get(3)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1q9a2mrm2sp4xpu5k33jakr4jk9zqcwtf3ns3h7j')
+    expect(address).toStrictEqual('bcrt1q5kn8n6wne38q84z86ukghluh4d0seqp2rcfw5g')
   })
 
   it('should get account 4', async () => {
     const address = await wallet.get(4).getAddress()
-    expect(address).toStrictEqual('bcrt1qh7safzu8d2p02vlnhsm2995t3der3qk75wl8y6')
+    expect(address).toStrictEqual('bcrt1qwtjj8kjc92zcya6jjprjvdn3h2vw9uh003q4c3')
   })
 
   it('should get account 5', async () => {
     const address = await wallet.get(5).getAddress()
-    expect(address).toStrictEqual('bcrt1qep3yprgx6q0pwuwat3hqj4fnkd3rfkd6cqev6j')
+    expect(address).toStrictEqual('bcrt1qcs3ny98wsfpch99mhp24gthzy0scz0l2ej43y0')
   })
 
   it('should get account 6', async () => {
     const address = await wallet.get(6).getAddress()
-    expect(address).toStrictEqual('bcrt1qqgwks52gufe3e2jplg6k40cat5prgtlr6f2p36')
+    expect(address).toStrictEqual('bcrt1qrl6m7payyuuwgqv6zmx5yk09l4najqphgljcpp')
   })
 
   it('should get account 7', async () => {
     const address = await wallet.get(7).getAddress()
-    expect(address).toStrictEqual('bcrt1q65yacygafrchwxv90wfc2jzdw6c4sl8ejn0mdf')
+    expect(address).toStrictEqual('bcrt1qm8y3cvv6g3az6k5lj3435d79wnepspx6j8hqqj')
   })
 
   it('should get account 8', async () => {
     const address = await wallet.get(8).getAddress()
-    expect(address).toStrictEqual('bcrt1qkt7rvkzk8qs7rk54vghrtzcdxfqazscmmp30hk')
+    expect(address).toStrictEqual('bcrt1qfm27gdjmr739est3jgv84cnxnavdp6y0zgm3wv')
   })
 
   it('should get account 9', async () => {
     const address = await wallet.get(9).getAddress()
-    expect(address).toStrictEqual('bcrt1qgpu5k3v66qjf8lc4p4lny0uwdxv6vf94axnjkf')
+    expect(address).toStrictEqual('bcrt1q4pj4gfe73x4ww58a42ysdktpj98fn64pjeh47d')
   })
 })

--- a/packages/jellyfish-wallet/src/wallet.ts
+++ b/packages/jellyfish-wallet/src/wallet.ts
@@ -24,7 +24,7 @@ export class JellyfishWallet<Account extends WalletAccount, HdNode extends Walle
    * @return Promise<WalletAccount>
    */
   get (account: number): Account {
-    const path = `${account}/0/0`
+    const path = `1129/${account}/0/0`
     const node = this.nodeProvider.derive(path)
     return this.accountProvider.provide(node)
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->
 
/kind feature

#### What this PR does / why we need it:

`@defichain/jellyfish-wallet-mnemonic` to use a unique seed of `"@defichain/jellyfish-wallet-mnemonic"` different from the default of `"Bitcoin seed"`.
- This will ultimately lock our implementation to be only usable with our library. This means the `24 phrases` will only work with the jellyfish libraries. This prevents users from attempting to export/import phrases from other libraries and creating a compatibility nightmare for us due to incompatible derivation techniques. We could intervene in UX but better if done and dealt with at the implementation core.
- With our own unique seed, a stolen 24 phrase will not be as easy to crack since the stealer will need to know what type of wallet this mnemonic phrase belongs to. (Not the main purpose of this refactor)



`@defichain/jellyfish-wallet` to include `COINTYPE` via `1129/{account}/0/0`
- To allow `jellyfish-wallet` to be agnostic from coin-type for ICX adoption.