### PR TITLE
inconsistent `maxPrice` should parse from buffer into consistent variant regardless

### DIFF
--- a/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
+++ b/packages/jellyfish-transaction/src/buffer/buffer_composer.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js'
 import { SmartBuffer } from 'smart-buffer'
 import { readVarUInt, writeVarUInt } from './buffer_varuint'
 import { getBitsFrom } from './buffer_bitmask'
-import { ONE_HUNDRED_MILLION, MAX_INT64, readBigNumberUInt64, writeBigNumberUInt64 } from './buffer_bignumber'
+import { MAX_INT64, ONE_HUNDRED_MILLION, readBigNumberUInt64, writeBigNumberUInt64 } from './buffer_bignumber'
 
 export interface BufferComposer {
   fromBuffer: (buffer: SmartBuffer) => void
@@ -553,29 +553,30 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
         const integer = readBigNumberUInt64(buffer)
         const fraction = readBigNumberUInt64(buffer)
 
+        // Disabled as it's not enforced
         // NOTE(canonbrother): max price default value is max int64 (9223372036854775807)
         // https://github.com/DeFiCh/ain/blob/aed00d09075094a3a0cedebde5248c006216ba09/src/masternodes/rpc_poolpair.cpp#L115-L123
-        if (fraction.gt(new BigNumber('99999999')) && !fraction.eq(MAX_INT64)) {
-          throw new Error('Too many decimals read from buffer. Will lose precision with more than 8 decimals')
-        }
+        // if (fraction.gt(new BigNumber('99999999')) && !fraction.eq(MAX_INT64)) {
+        //   throw new Error('Too many decimals read from buffer. Will lose precision with more than 8 decimals')
+        // }
 
         if (integer.eq(MAX_INT64) && fraction.eq(MAX_INT64)) {
-          setter(integer)
-          setter(fraction)
+          setter(MAX_INT64)
         } else {
           setter(integer.plus(fraction.dividedBy(ONE_HUNDRED_MILLION)))
         }
       },
       toBuffer: (buffer: SmartBuffer): void => {
-        if (getter().decimalPlaces() > 8) {
+        const maxPrice = getter()
+        if (maxPrice.decimalPlaces() > 8) {
           throw new Error('Too many decimals to be correctly represented. Will lose precision with more than 8 decimals')
         }
 
-        if (getter().eq(MAX_INT64)) {
-          writeBigNumberUInt64(getter(), buffer)
-          writeBigNumberUInt64(getter(), buffer)
+        if (maxPrice.eq(MAX_INT64)) {
+          writeBigNumberUInt64(MAX_INT64, buffer)
+          writeBigNumberUInt64(MAX_INT64, buffer)
         } else {
-          const n = getter().multipliedBy(ONE_HUNDRED_MILLION)
+          const n = maxPrice.multipliedBy(ONE_HUNDRED_MILLION)
           const fraction = n.mod(ONE_HUNDRED_MILLION)
           const integer = n.minus(fraction).dividedBy(ONE_HUNDRED_MILLION)
           writeBigNumberUInt64(integer, buffer)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Because maxPrice consistency structure is not enforced at the transaction level, `jellyfish-transaction` must be able to parse without erroring out. This PR will convert inconsistent maxPrice representation into the consistent variant.