### PR TITLE
increase `-rpcworkqueue` to 512 for testcontainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,6 @@
 
 /.github/                                       @fuxingloh
 /.husky/                                        @fuxingloh
-/.idea/                                         @fuxingloh @jingyi2811 @thedoublejay
 
 /packages/jellyfish/                            @fuxingloh @canonbrother
 /packages/jellyfish-address/                    @fuxingloh @ivan-zynesis

--- a/packages/testcontainers/src/chains/defid_container.ts
+++ b/packages/testcontainers/src/chains/defid_container.ts
@@ -62,6 +62,7 @@ export abstract class DeFiDContainer extends DockerContainer {
       '-printtoconsole',
       '-rpcallowip=0.0.0.0/0',
       '-rpcbind=0.0.0.0',
+      '-rpcworkqueue=512',
       `-rpcuser=${opts.user!}`,
       `-rpcpassword=${opts.password!}`
     ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

To allow more concurrent connections for testing.