### PR TITLE
Use BigNumber for Governance ProposalInfo amount property

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/governance/getProposal.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/getProposal.test.ts
@@ -9,7 +9,6 @@ describe('Governance', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
   })
 

--- a/packages/jellyfish-api-core/__tests__/category/governance/getProposal.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/getProposal.test.ts
@@ -2,6 +2,7 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '../../../src'
 import { ProposalStatus, ProposalType } from '../../../src/category/governance'
 import { GovernanceMasterNodeRegTestContainer } from './governance_container'
+import BigNumber from 'bignumber.js'
 
 describe('Governance', () => {
   const container = new GovernanceMasterNodeRegTestContainer()
@@ -35,7 +36,7 @@ describe('Governance', () => {
     expect(proposal.title).toStrictEqual(data.title)
     expect(proposal.type).toStrictEqual(ProposalType.COMMUNITY_FUND_REQUEST)
     expect(proposal.status).toStrictEqual(ProposalStatus.VOTING)
-    expect(proposal.amount).toStrictEqual(data.amount)
+    expect(proposal.amount).toStrictEqual(new BigNumber(data.amount))
     expect(proposal.totalCycles).toStrictEqual(data.cycles)
     expect(proposal.payoutAddress).toStrictEqual(data.payoutAddress)
   })

--- a/packages/jellyfish-api-core/__tests__/category/governance/listProposals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/listProposals.test.ts
@@ -8,7 +8,6 @@ describe('Governance', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
 
     await setup()

--- a/packages/jellyfish-api-core/__tests__/category/governance/listProposals.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/listProposals.test.ts
@@ -1,6 +1,7 @@
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { ListProposalsStatus, ListProposalsType, ProposalStatus, ProposalType } from '../../../src/category/governance'
 import { GovernanceMasterNodeRegTestContainer } from './governance_container'
+import BigNumber from 'bignumber.js'
 
 describe('Governance', () => {
   const container = new GovernanceMasterNodeRegTestContainer()
@@ -44,7 +45,7 @@ describe('Governance', () => {
       expect(typeof proposal.title).toStrictEqual('string')
       expect(typeof proposal.type).toStrictEqual('string')
       expect(typeof proposal.status).toStrictEqual('string')
-      expect(typeof proposal.amount).toStrictEqual('number')
+      expect(proposal.amount instanceof BigNumber).toStrictEqual(true)
       expect(typeof proposal.totalCycles).toStrictEqual('number')
       expect(typeof proposal.cyclesPaid).toStrictEqual('number')
       expect(typeof proposal.finalizeAfter).toStrictEqual('number')

--- a/packages/jellyfish-api-core/src/category/governance.ts
+++ b/packages/jellyfish-api-core/src/category/governance.ts
@@ -70,7 +70,7 @@ export class Governance {
    * @return {Promise<ProposalInfo>} Information about the proposal
    */
   async getProposal (proposalId: string): Promise<ProposalInfo> {
-    return await this.client.call('getproposal', [proposalId], 'number')
+    return await this.client.call('getproposal', [proposalId], { amount: 'bignumber' })
   }
 
   /**
@@ -98,7 +98,7 @@ export class Governance {
     type = ListProposalsType.ALL,
     status = ListProposalsStatus.ALL
   } = {}): Promise<ProposalInfo[]> {
-    return await this.client.call('listproposals', [type, status], 'number')
+    return await this.client.call('listproposals', [type, status], { amount: 'bignumber' })
   }
 
   /**
@@ -138,7 +138,7 @@ export interface ProposalInfo {
   title: string
   type: ProposalType
   status: ProposalStatus
-  amount: number
+  amount: BigNumber
   cyclesPaid: number
   totalCycles: number
   finalizeAfter: number

--- a/website/docs/jellyfish/api/governance.md
+++ b/website/docs/jellyfish/api/governance.md
@@ -61,7 +61,7 @@ interface ProposalInfo {
   title: string
   type: ProposalType
   status: ProposalStatus
-  amount: number
+  amount: BigNumber
   cyclesPaid: number
   totalCycles: number
   finalizeAfter: number
@@ -127,7 +127,7 @@ interface ProposalInfo {
   title: string
   type: ProposalType
   status: ProposalStatus
-  amount: number
+  amount: BigNumber
   cyclesPaid: number
   totalCycles: number
   finalizeAfter: number


### PR DESCRIPTION
#### What kind of PR is this?:

/kind fix

#### What this PR does / why we need it:

Type BigNumber instead of number in interface ProposalInfo amount property