### PR TITLE
add mnemonicAsEntropy and entropyAsMnemonic for storing mnemonic as 32 byte buffer

### DIFF
--- a/packages/jellyfish-wallet-mnemonic/__tests__/bip39.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/bip39.test.ts
@@ -1,4 +1,11 @@
-import { generateMnemonicWords, mnemonicToSeed, validateMnemonicSentence, validateMnemonicWord } from '../src'
+import {
+  entropyAsMnemonic,
+  generateMnemonicWords,
+  mnemonicAsEntropy,
+  mnemonicToSeed,
+  validateMnemonicSentence,
+  validateMnemonicWord
+} from '../src'
 
 it('should generate 12-15-18-21-24 and validate', () => {
   function shouldGenerateAndValidate (length: 12 | 15 | 18 | 21 | 24): void {
@@ -79,5 +86,46 @@ describe('single word mnemonic validation', () => {
     expect(validateMnemonicWord('一')).toStrictEqual(false)
     expect(validateMnemonicWord('あつい')).toStrictEqual(false)
     expect(validateMnemonicWord('가격')).toStrictEqual(false)
+  })
+})
+
+describe('mnemonicAsEntropy and entropyAsMnemonic', () => {
+  it('should mnemonicAsEntropy == entropyAsMnemonic', () => {
+    const generated = generateMnemonicWords()
+
+    const entropy = mnemonicAsEntropy(generated)
+    const words = entropyAsMnemonic(entropy)
+
+    expect(entropy.length).toStrictEqual(32)
+    expect(generated).toStrictEqual(words)
+
+    expect(generated.length).toStrictEqual(24)
+    expect(generated[0]).toStrictEqual(words[0])
+    expect(generated[23]).toStrictEqual(words[23])
+  })
+
+  it('should get 0000 for abandon x23 + art cs', () => {
+    const buffer = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+
+    const words = generateMnemonicWords(24, () => buffer)
+
+    const entropy = mnemonicAsEntropy(words)
+    expect(entropy).toStrictEqual(buffer)
+  })
+
+  it('should get abandon x23 + art cs for 0000', () => {
+    const buffer = Buffer.from('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
+    const words = entropyAsMnemonic(buffer)
+    expect(words.join(' ')).toStrictEqual(
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'
+    )
+  })
+
+  it('should fail if not 32 byte long', () => {
+    const buffer31 = Buffer.from('00000000000000000000000000000000000000000000000000000000000000', 'hex')
+
+    expect(() => {
+      entropyAsMnemonic(buffer31)
+    }).toThrow('expected entropy to be 32 byte long')
   })
 })

--- a/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
+++ b/packages/jellyfish-wallet-mnemonic/src/mnemonic.ts
@@ -50,3 +50,25 @@ export function generateMnemonicWords (length: 12 | 15 | 18 | 21 | 24 = 24, rng:
 export function mnemonicToSeed (mnemonic: string[]): Buffer {
   return bip39.mnemonicToSeedSync(mnemonic.join(' '))
 }
+
+/**
+ * @param {string[]} mnemonic words, (COLD)
+ * @return {Buffer} 32 byte
+ */
+export function mnemonicAsEntropy (mnemonic: string[]): Buffer {
+  const hex = bip39.mnemonicToEntropy(mnemonic.join(' '))
+  return Buffer.from(hex, 'hex')
+}
+
+/**
+ * @param {Buffer} entropy 32 bytes buffer
+ * @return {string[]} mnemonic words, (COLD)
+ */
+export function entropyAsMnemonic (entropy: Buffer): string[] {
+  if (entropy.length !== 32) {
+    throw new Error('expected entropy to be 32 byte long')
+  }
+
+  const sentence = bip39.entropyToMnemonic(entropy)
+  return sentence.split(' ')
+}


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Add mnemonicAsEntropy and entropyAsMnemonic for storing mnemonic as 32-byte buffer.

For `DeFiCh/wallet` to store mnemonic as 32-byte entropy without any even/odd hacks.