### PR TITLE
lint to run eslint directly instead of through standard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+{
+  "parserOptions": {
+    "project": "./tsconfig.json"
+  },
+  "extends": [
+    "standard-with-typescript",
+    "standard-jsx"
+  ],
+  "ignorePatterns": [
+    "dist",
+    "*.json",
+    "website"
+  ],
+  "rules": {
+    "func-style": [2, "declaration"],
+    "import/no-default-export": "error"
+  }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -14,5 +14,17 @@
   "rules": {
     "func-style": [2, "declaration"],
     "import/no-default-export": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/jellyfish-transaction/__tests__/**/*.test.ts",
+        "**/jellyfish-transaction/src/script/dftx/**/*.ts",
+        "**/jellyfish-transaction/src/*.ts"
+      ],
+      "rules": {
+        "no-return-assign": "off"
+      }
+    }
+  ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: npm ci
       - run: npm run build
-      - run: npx --no-install ts-standard
+      - run: npx --no-install eslint .
 
   size:
     name: Size Limit

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -192,6 +192,7 @@
       <w>testcontainers</w>
       <w>testmempoolaccept</w>
       <w>thedoublejay</w>
+      <w>timelock</w>
       <w>toaltstack</w>
       <w>tradeable</w>
       <w>txcount</w>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@size-limit/preset-app": "^5.0.2",
         "@types/jest": "^27.0.0",
+        "eslint": "^7.32.0",
         "husky": "^7.0.1",
         "jest": "^27.0.6",
         "lerna": "^4.0.0",
@@ -1538,15 +1539,15 @@
       "link": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
@@ -1558,12 +1559,12 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+      "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.8.1"
+        "type-fest": "^0.20.2"
       },
       "engines": {
         "node": ">=8"
@@ -1582,13 +1583,36 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
@@ -13761,9 +13785,9 @@
       }
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -17084,28 +17108,31 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
+        "glob-parent": "^5.1.2",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
@@ -17114,7 +17141,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -17123,7 +17150,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -17771,6 +17798,18 @@
       "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint/node_modules/globals": {
@@ -22676,6 +22715,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/lodash.set": {
@@ -31838,15 +31883,15 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+      "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.1.1",
         "espree": "^7.3.0",
-        "globals": "^12.1.0",
+        "globals": "^13.9.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
@@ -31855,12 +31900,12 @@
       },
       "dependencies": {
         "globals": {
-          "version": "12.4.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "version": "13.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+          "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.8.1"
+            "type-fest": "^0.20.2"
           }
         },
         "ignore": {
@@ -31870,12 +31915,29 @@
           "dev": true
         },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
         }
       }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
     },
     "@iarna/toml": {
       "version": "2.2.5",
@@ -41619,9 +41681,9 @@
       }
     },
     "acorn-jsx": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
     },
@@ -44120,28 +44182,31 @@
       }
     },
     "eslint": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.24.0.tgz",
-      "integrity": "sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.3",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^5.0.0",
+        "glob-parent": "^5.1.2",
         "globals": "^13.6.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
@@ -44150,7 +44215,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.21",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -44159,7 +44224,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^6.0.4",
+        "table": "^6.0.9",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -44172,6 +44237,12 @@
           "requires": {
             "@babel/highlight": "^7.10.4"
           }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
         },
         "globals": {
           "version": "13.8.0",
@@ -48227,6 +48298,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "lodash.set": {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,15 @@
     "version": "lerna version $1 --yes --no-push --no-git-tag-version",
     "publish:next": "lerna exec -- npm publish --tag next --access public",
     "publish:latest": "lerna exec -- npm publish --tag latest --access public",
-    "standard": "ts-standard --fix",
+    "lint": "eslint . --fix",
     "test": "jest --maxWorkers=100%",
     "test:ci": "jest --ci --coverage --forceExit --maxWorkers=4",
-    "all": "npm run clean && npm run build && npm run standard && npm run test"
+    "all": "npm run clean && npm run build && npm run lint && npm run test"
   },
   "devDependencies": {
     "@size-limit/preset-app": "^5.0.2",
     "@types/jest": "^27.0.0",
+    "eslint": "^7.32.0",
     "husky": "^7.0.1",
     "jest": "^27.0.6",
     "lerna": "^4.0.0",
@@ -48,7 +49,7 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "npm run standard"
+      "npm run lint"
     ]
   },
   "size-limit": [

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/poolSwapMaxPrice.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/poolSwapMaxPrice.test.ts
@@ -26,7 +26,7 @@ describe('Poolpair', () => {
     await setup()
   })
 
-  const setup = async (): Promise<void> => {
+  async function setup (): Promise<void> {
     await createToken(container, 'ELF', { collateralAddress: tokenAddress })
     await mintTokens(container, 'ELF', { address: dfiAddress })
     await createPoolPair(container, 'ELF', 'DFI')

--- a/packages/jellyfish-api-core/__tests__/category/spv/decodeHtlcScript.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/decodeHtlcScript.test.ts
@@ -16,7 +16,9 @@ describe('Spv', () => {
   })
 
   /** Util function to replace a char at index in string */
-  const replaceAt = (s: string, index: number, replacement: string): string => s.substr(0, index) + replacement + s.substr(index + replacement.length)
+  function replaceAt (s: string, index: number, replacement: string): string {
+    return s.substr(0, index) + replacement + s.substr(index + replacement.length)
+  }
 
   it('should decodeHtlc', async () => {
     const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])

--- a/packages/jellyfish-api-core/__tests__/category/wallet/sendMany.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/sendMany.test.ts
@@ -1,12 +1,7 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import BigNumber from 'bignumber.js'
-import {
-  UTXO,
-  ListUnspentOptions,
-  Mode,
-  SendManyOptions
-} from '../../../src/category/wallet'
+import { ListUnspentOptions, Mode, SendManyOptions, UTXO } from '../../../src/category/wallet'
 
 describe('Send many', () => {
   const container = new MasterNodeRegTestContainer()
@@ -22,8 +17,10 @@ describe('Send many', () => {
     await container.stop()
   })
 
-  // Returns matching utxos for given transaction id and address.
-  const getMatchingUTXO = async (txId: string, address: string): Promise<UTXO[]> => {
+  /**
+   * Returns matching utxos for given transaction id and address.
+   */
+  async function getMatchingUTXO (txId: string, address: string): Promise<UTXO[]> {
     const options: ListUnspentOptions = {
       addresses: [address]
     }

--- a/packages/jellyfish-api-core/__tests__/category/wallet/wallet.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/wallet/wallet.test.ts
@@ -258,8 +258,10 @@ describe('sendMany', () => {
     await container.stop()
   })
 
-  // Returns matching utxos for given transaction id and address.
-  const getMatchingUTXO = async (txId: string, address: string): Promise<UTXO[]> => {
+  /**
+   * Returns matching utxos for given transaction id and address.
+   */
+  async function getMatchingUTXO (txId: string, address: string): Promise<UTXO[]> {
     const options: ListUnspentOptions = {
       addresses: [address]
     }

--- a/packages/jellyfish-crypto/__tests__/aes256.test.ts
+++ b/packages/jellyfish-crypto/__tests__/aes256.test.ts
@@ -14,13 +14,19 @@ describe('Aes256', () => {
   })
 
   it('encrypt - should be able to overwrite cipher iv for better security measure', () => {
-    const iv = (): Buffer => Buffer.from('0102030405060708090a0b0c0d0e0f10', 'hex')
+    function iv (): Buffer {
+      return Buffer.from('0102030405060708090a0b0c0d0e0f10', 'hex')
+    }
+
     encrypted = AES256.encrypt(passphrase, privateKey, iv)
     expect(encrypted.length).toStrictEqual(48) // [16 bytes salt, 32 bytes cipher]
   })
 
   it('encrypt - should reject non 16 bytes long iv', () => {
-    const iv = (): Buffer => Buffer.from('0102030405060708090a0b0c0d0e0f', 'hex')
+    function iv (): Buffer {
+      return Buffer.from('0102030405060708090a0b0c0d0e0f', 'hex')
+    }
+
     expect(() => AES256.encrypt(passphrase, privateKey, iv)).toThrow('Initialization vector must be 16 bytes long')
   })
 

--- a/packages/jellyfish-json/src/index.ts
+++ b/packages/jellyfish-json/src/index.ts
@@ -1,5 +1,5 @@
 import BigNumber from 'bignumber.js'
-import { parse, stringify, LosslessNumber } from 'lossless-json'
+import { LosslessNumber, parse, stringify } from 'lossless-json'
 import { PrecisionPath, remap } from './remap'
 
 export { BigNumber, LosslessNumber, PrecisionPath }
@@ -19,7 +19,7 @@ export type Precision = 'lossless' | 'bignumber' | 'number'
 /**
  * Revive lossless as a type
  */
-const reviveLosslessAs = (transformer: (string: string) => any) => {
+function reviveLosslessAs (transformer: (string: string) => any) {
   return (key: string, value: any) => {
     if (value instanceof LosslessNumber) {
       return transformer(value.toString())
@@ -67,7 +67,7 @@ export const JellyfishJSON = {
    * @param {any} value object to stringify, with no risk of losing precision.
    */
   stringify (value: any): string {
-    const replacer = (key: string, value: any): any => {
+    function replacer (key: string, value: any): any {
       if (value instanceof BigNumber) {
         return new LosslessNumber(value.toString())
       }

--- a/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
+++ b/packages/jellyfish-transaction/__tests__/buffer/buffer_composer.test.ts
@@ -16,8 +16,6 @@ function hexAsBuffer (hex: string | string[]): SmartBuffer {
   return buffer
 }
 
-/* eslint-disable no-return-assign */
-
 it('should format (4 bytes, 32 bytes, 8 bytes) hex with hexAsBufferLE', () => {
   // assert hexAsBufferLE conditions is as expected.
 

--- a/packages/jellyfish-transaction/src/script/dftx/dftx.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx.ts
@@ -47,9 +47,6 @@ import {
 import { CDeFiOpUnmapped, DeFiOpUnmapped } from './dftx_unmapped'
 import { CSetGovernance, SetGovernance } from './dftx_governance'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * DeFi Transaction
  * [OP_RETURN, OP_PUSHDATA] Custom Transaction

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_account.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_account.ts
@@ -3,9 +3,6 @@ import { Script } from '../../tx'
 import { CScript } from '../../tx_composer'
 import { CScriptBalances, CTokenBalance, ScriptBalances, TokenBalance } from './dftx_balance'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * UtxosToAccount DeFi Transaction
  */

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_balance.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_balance.ts
@@ -3,9 +3,6 @@ import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 import { Script } from '../../tx'
 import { CScript } from '../../tx_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 export interface TokenBalance {
   token: number // ---------------------| 4 bytes unsigned
   amount: BigNumber // -----------------| 8 bytes unsigned

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_governance.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_governance.ts
@@ -3,9 +3,6 @@ import { SmartBuffer } from 'smart-buffer'
 import { readBigNumberUInt64, writeBigNumberUInt64 } from '../../buffer/buffer_bignumber'
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 export interface LiqPoolSplit {
   tokenId: number // -------------------| 4 bytes unsigned
   value: BigNumber // ------------------| 8 bytes unsigned

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_masternode.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_masternode.ts
@@ -1,9 +1,6 @@
 import { SmartBuffer } from 'smart-buffer'
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * CreateMasternode DeFi Transaction
  */

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_misc.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_misc.ts
@@ -1,8 +1,5 @@
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * Composable UtxosToAccount, C stands for Composable.
  * Immutable by design, bi-directional fromBuffer, toBuffer deep composer.

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_oracles.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_oracles.ts
@@ -1,11 +1,8 @@
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
-import { CurrencyPair, CCurrencyPair, CTokenPrice, TokenPrice } from './dftx_price'
+import { CCurrencyPair, CTokenPrice, CurrencyPair, TokenPrice } from './dftx_price'
 import { Script } from '../../tx'
 import { CScript } from '../../tx_composer'
 import BigNumber from 'bignumber.js'
-
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
 
 /**
  * AppointOracle DeFi Transaction

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_pool.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_pool.ts
@@ -3,11 +3,8 @@ import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 import { Script } from '../../tx'
 import { CScript } from '../../tx_composer'
 import { SmartBuffer } from 'smart-buffer'
-import { CScriptBalances, ScriptBalances, CTokenBalance, TokenBalance } from './dftx_balance'
-import { writeVarUInt, readVarUInt } from '../../buffer/buffer_varuint'
-
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
+import { CScriptBalances, CTokenBalance, ScriptBalances, TokenBalance } from './dftx_balance'
+import { readVarUInt, writeVarUInt } from '../../buffer/buffer_varuint'
 
 /**
  * PoolSwap DeFi Transaction

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_price.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_price.ts
@@ -1,9 +1,6 @@
 import BigNumber from 'bignumber.js'
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 export interface CurrencyPair {
   token: string // --------------------| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string
   currency: string // -----------------| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_token.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_token.ts
@@ -1,9 +1,6 @@
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
-import { TokenBalance, CTokenBalance } from './dftx_balance'
+import { CTokenBalance, TokenBalance } from './dftx_balance'
 import BigNumber from 'bignumber.js'
-
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
 
 /**
  * TokenMint DeFi Transaction

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_unmapped.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_unmapped.ts
@@ -1,9 +1,6 @@
 import { SmartBuffer } from 'smart-buffer'
 import { BufferComposer, ComposableBuffer } from '../../buffer/buffer_composer'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * Unmapped DeFi OP that is valid but don't have a composer for it yet.
  */

--- a/packages/jellyfish-transaction/src/tx_composer.ts
+++ b/packages/jellyfish-transaction/src/tx_composer.ts
@@ -6,9 +6,6 @@ import { OP_CODES, OPCode } from './script'
 import { readVarUInt, writeVarUInt } from './buffer/buffer_varuint'
 import { dSHA256 } from '@defichain/jellyfish-crypto'
 
-// Disabling no-return-assign makes the code cleaner with the setter and getter */
-/* eslint-disable no-return-assign */
-
 /**
  * USE CTransaction AT YOUR OWN RISK.
  * The TransactionBuilder has safety logic built-in to prevent overspent, CTransaction is its raw counter part.

--- a/packages/jellyfish-transaction/src/tx_segwit.ts
+++ b/packages/jellyfish-transaction/src/tx_segwit.ts
@@ -33,8 +33,6 @@ export interface WitnessProgram {
  * Composable WitnessProgram
  */
 export class CWitnessProgram extends ComposableBuffer<WitnessProgram> {
-  /* eslint-disable no-return-assign */
-
   composers (wp: WitnessProgram): BufferComposer[] {
     return [
       ComposableBuffer.uInt32(() => wp.version, v => wp.version = v),

--- a/packages/jellyfish/src/index.ts
+++ b/packages/jellyfish/src/index.ts
@@ -1,11 +1,7 @@
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { ApiClient } from '@defichain/jellyfish-api-core'
 
-import {
-  Provider,
-  HttpProvider,
-  HttpProviderConstructor
-} from './provider'
+import { HttpProvider, HttpProviderConstructor, Provider } from './provider'
 
 /**
  * Client options for Jellyfish
@@ -108,4 +104,5 @@ export const Jellyfish: {
   HttpProvider
 }
 
+/* eslint-disable import/no-default-export */
 export default Jellyfish

--- a/packages/testcontainers/src/chains/defid_container.ts
+++ b/packages/testcontainers/src/chains/defid_container.ts
@@ -257,7 +257,7 @@ async function cleanUpStale (prefix: string, docker: Dockerode): Promise<void> {
   /**
    * Same prefix and created more than 1 hour ago
    */
-  const isStale = (containerInfo: ContainerInfo): boolean => {
+  function isStale (containerInfo: ContainerInfo): boolean {
     if (containerInfo.Names.filter((value) => value.startsWith(prefix)).length > 0) {
       return containerInfo.Created + 60 * 60 < Date.now() / 1000
     }
@@ -268,7 +268,7 @@ async function cleanUpStale (prefix: string, docker: Dockerode): Promise<void> {
   /**
    * Stop container that are running, remove them after and their associated volumes
    */
-  const tryStopRemove = async (containerInfo: ContainerInfo): Promise<void> => {
+  async function tryStopRemove (containerInfo: ContainerInfo): Promise<void> {
     const container = docker.getContainer(containerInfo.Id)
     if (containerInfo.State === 'running') {
       await container.stop()

--- a/packages/testcontainers/src/wait_for_condition.ts
+++ b/packages/testcontainers/src/wait_for_condition.ts
@@ -10,7 +10,7 @@ export async function waitForCondition (condition: () => Promise<boolean>, timeo
   const expiredAt = Date.now() + timeout
 
   return await new Promise((resolve, reject) => {
-    const checkCondition = async (): Promise<void> => {
+    async function checkCondition (): Promise<void> {
       const isReady = await condition().catch(() => false)
       if (isReady) {
         resolve()


### PR DESCRIPTION
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

Instead of running ts-standard, we run eslint configured to use ts-standard to allow better IDE and GitHub integration.