### PR TITLE
refactor toBe/toEqual -> toStrictEqual

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/account/accountHistoryCount.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/accountHistoryCount.test.ts
@@ -58,7 +58,7 @@ describe('Account', () => {
     await waitForExpect(async () => {
       const count = await client.account.historyCount()
 
-      expect(typeof count).toBe('number')
+      expect(typeof count).toStrictEqual('number')
       expect(count).toBeGreaterThanOrEqual(0)
     })
   })
@@ -67,7 +67,7 @@ describe('Account', () => {
     await waitForExpect(async () => {
       const count = await client.account.historyCount('all')
 
-      expect(typeof count).toBe('number')
+      expect(typeof count).toStrictEqual('number')
       expect(count).toBeGreaterThanOrEqual(0)
     })
   })
@@ -79,7 +79,7 @@ describe('Account', () => {
       }
       const count = await client.account.historyCount('mine', options)
 
-      expect(typeof count).toBe('number')
+      expect(typeof count).toStrictEqual('number')
       expect(count).toBeGreaterThanOrEqual(0)
     })
   })
@@ -95,8 +95,8 @@ describe('Account', () => {
       const countWithDBTC = await client.account.historyCount('mine', options1)
       const countWithDETH = await client.account.historyCount('mine', options2)
 
-      expect(typeof countWithDBTC).toBe('number')
-      expect(typeof countWithDETH).toBe('number')
+      expect(typeof countWithDBTC).toStrictEqual('number')
+      expect(typeof countWithDETH).toStrictEqual('number')
       expect(countWithDBTC).toBeGreaterThanOrEqual(1)
       expect(countWithDETH).toBeGreaterThanOrEqual(1)
     })
@@ -109,7 +109,7 @@ describe('Account', () => {
       }
       const count = await client.account.historyCount('mine', options)
 
-      expect(typeof count).toBe('number')
+      expect(typeof count).toStrictEqual('number')
       expect(count).toBeGreaterThanOrEqual(0)
     })
   })

--- a/packages/jellyfish-api-core/__tests__/category/account/listAccountHistory.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/listAccountHistory.test.ts
@@ -228,7 +228,7 @@ describe('listAccountHistory', () => {
 
     const history = await client.account.listAccountHistory('mine', { limit: 100, no_rewards: true })
 
-    expect(history).toEqual(
+    expect(history).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'AccountToAccount',
@@ -251,7 +251,7 @@ describe('listAccountHistory', () => {
 
     const history = await client.account.listAccountHistory('mine', { limit: 100, no_rewards: true })
 
-    expect(history).toEqual(
+    expect(history).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'UtxosToAccount',
@@ -279,7 +279,7 @@ describe('listAccountHistory', () => {
     await container.generate(1)
     const history = await client.account.listAccountHistory('mine', { limit: 100, no_rewards: true })
 
-    expect(history).toEqual(
+    expect(history).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'UtxosToAccount',
@@ -289,7 +289,7 @@ describe('listAccountHistory', () => {
         })
       ])
     )
-    expect(history).toEqual(
+    expect(history).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'AccountToUtxos',
@@ -342,7 +342,7 @@ describe('listAccountHistory for poolpair', () => {
 
     expect(records.length).toStrictEqual(2)
 
-    expect(records).toEqual(expect.arrayContaining([
+    expect(records).toStrictEqual(expect.arrayContaining([
       expect.objectContaining({
         amounts: expect.arrayContaining([
           expect.stringContaining('DFI-DDAI')
@@ -368,7 +368,7 @@ describe('listAccountHistory for poolpair', () => {
 
     const histories = await client.account.listAccountHistory('mine', { limit: 100, no_rewards: true })
 
-    expect(histories).toEqual(expect.arrayContaining([
+    expect(histories).toStrictEqual(expect.arrayContaining([
       expect.objectContaining({
         type: 'RemovePoolLiquidity',
         amounts: expect.arrayContaining(['-20.00000000@DFI-DDAI'])
@@ -397,7 +397,7 @@ describe('listAccountHistory for poolpair', () => {
 
     const histories = await client.account.listAccountHistory('mine', { limit: 100, no_rewards: true })
 
-    expect(histories).toEqual(expect.arrayContaining([
+    expect(histories).toStrictEqual(expect.arrayContaining([
       expect.objectContaining({
         type: 'PoolSwap',
         amounts: expect.arrayContaining(['-5.00000000@DFI'])

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/claimDFCHTLC.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/claimDFCHTLC.test.ts
@@ -58,7 +58,7 @@ describe('ICXOrderBook.claimDFCHTLC', () => {
       closed: true
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCs[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
@@ -108,7 +108,7 @@ describe('ICXOrderBook.claimDFCHTLC', () => {
       closed: true
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCs[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
@@ -188,7 +188,7 @@ describe('ICXOrderBook.claimDFCHTLC', () => {
       closed: true
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCs[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/closeOffer.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/closeOffer.test.ts
@@ -76,7 +76,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     // close offer makeOfferTxId - taker
@@ -85,7 +85,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check no more offers
     const ordersAfterCloseOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await await container.call('icx_listorders', [{ orderTx: createOrderTxId }])
-    expect(Object.keys(ordersAfterCloseOffer).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterCloseOffer).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     // check accountBTC balance, should be the same as accountBTCBeforeOffer
     const accountBTCAfterOfferClose: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
@@ -128,7 +128,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     // close offer makeOfferTxId - taker
@@ -137,7 +137,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check no more offers
     const ordersAfterCloseOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await await container.call('icx_listorders', [{ orderTx: createOrderTxId }])
-    expect(Object.keys(ordersAfterCloseOffer).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterCloseOffer).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     // check accountBTC balance, should be the same as accountBTCBeforeOffer
     const accountBTCAfterOfferClose: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
@@ -181,7 +181,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     // input utxos
@@ -193,7 +193,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check no more offers
     const ordersAfterCloseOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterCloseOffer).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterCloseOffer).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     // check accountBTC balance, should be the same as accountBTCBeforeOffer
     const accountBTCAfterOfferClose: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
@@ -237,7 +237,7 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     // close offer "INVALID_OFFER_TX_ID" - taker
@@ -248,6 +248,6 @@ describe('ICXOrderBook.closeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterCloseOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterCloseOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterCloseOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/closeOrder.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/closeOrder.test.ts
@@ -194,7 +194,7 @@ describe('ICXOrderBook.closeOrder', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeDFCHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -216,7 +216,7 @@ describe('ICXOrderBook.closeOrder', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).type).toStrictEqual(ICXHTLCType.DFC)
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).status).toStrictEqual(ICXOrderStatus.OPEN)
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).offerTx).toStrictEqual(makeOfferTxId)
@@ -238,7 +238,7 @@ describe('ICXOrderBook.closeOrder', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExtHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterExtHTLC)
-    expect(Object.keys(HTLCsAfterExtHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterExtHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect((HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).type).toStrictEqual(ICXHTLCType.EXTERNAL)
     expect((HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).status).toStrictEqual(ICXOrderStatus.OPEN)
     expect((HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).offerTx).toStrictEqual(makeOfferTxId)
@@ -260,7 +260,7 @@ describe('ICXOrderBook.closeOrder', () => {
       closed: true
     }
     const HTLCsAfterClaim: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterClaim)
-    expect(Object.keys(HTLCsAfterClaim).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterClaim).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCsAfterClaim[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
@@ -285,7 +285,7 @@ describe('ICXOrderBook.closeOrder', () => {
 
     // offer should be close by now
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     // check partial order remaining
     const ordersAfterClaim: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders()

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/complexTests.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/complexTests.test.ts
@@ -92,7 +92,7 @@ describe('ICX Complex test scenarios', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -149,7 +149,7 @@ describe('ICX Complex test scenarios', () => {
       closed: true
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCs[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/icx_setup.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/icx_setup.ts
@@ -95,8 +95,8 @@ export class ICXSetup {
     const pool = await this.container.call('getpoolpair', ['BTC-DFI'])
     const combToken = await this.container.call('gettoken', ['BTC-DFI'])
     const idDFIBTC = Object.keys(combToken)[0]
-    expect(pool[idDFIBTC].idTokenA).toBe(idBTC)
-    expect(pool[idDFIBTC].idTokenB).toBe(idDFI)
+    expect(pool[idDFIBTC].idTokenA).toStrictEqual(idBTC)
+    expect(pool[idDFIBTC].idTokenB).toStrictEqual(idDFI)
   }
 
   async addLiquidityToBTCDFIPool (amountInBTC: number, amountInDFI: number): Promise<void> {
@@ -176,7 +176,7 @@ export class ICXSetup {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await this.client.icxorderbook.listOrders({ orderTx: orderTx })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     return {
@@ -207,7 +207,7 @@ export class ICXSetup {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await this.client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).type).toStrictEqual(ICXHTLCType.DFC)
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).status).toStrictEqual(ICXHTLCStatus.OPEN)
 
@@ -237,7 +237,7 @@ export class ICXSetup {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo| ICXClaimDFCHTLCInfo> = await this.client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect((HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).type).toStrictEqual(ICXHTLCType.EXTERNAL)
     expect((HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).status).toStrictEqual(ICXHTLCStatus.OPEN)
 

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/listHTLCs.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/listHTLCs.test.ts
@@ -83,7 +83,7 @@ describe('ICXOrderBook.listHTLCs', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeDFCHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -105,7 +105,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -137,7 +137,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExtHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterExtHTLC)
-    expect(Object.keys(HTLCsAfterExtHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterExtHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -190,7 +190,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -222,7 +222,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExtHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterExtHTLC)
-    expect(Object.keys(HTLCsAfterExtHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterExtHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -257,7 +257,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       limit: 1
     }
     const HTLCsWithLimit1: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsWithLimit1)
-    expect(Object.keys(HTLCsWithLimit1).length).toBe(2)
+    expect(Object.keys(HTLCsWithLimit1).length).toStrictEqual(2)
   })
 
   it.skip('should list closed HTLCs with ICXListHTLCOptions.closed parameter after HTLCs are expired', async () => {
@@ -297,7 +297,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -336,7 +336,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExpiry: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterExpiry)
-    expect(Object.keys(HTLCsAfterExpiry).length).toBe(2) // NOTE(surangap): EXT HTLC will still be in OPEN state
+    expect(Object.keys(HTLCsAfterExpiry).length).toStrictEqual(2) // NOTE(surangap): EXT HTLC will still be in OPEN state
 
     // List refended htlcs also and check
     const listHTLCOptionsWithRefunded = {
@@ -344,7 +344,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       closed: true
     }
     const HTLCsWithRefunded: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsWithRefunded)
-    expect(Object.keys(HTLCsWithRefunded).length).toBe(3)
+    expect(Object.keys(HTLCsWithRefunded).length).toStrictEqual(3)
   })
 
   it('should list closed HTLCs with ICXListHTLCOptions.closed parameter after DFC HTLC claim', async () => {
@@ -370,7 +370,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -402,7 +402,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExtHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterExtHTLC)
-    expect(Object.keys(HTLCsAfterExtHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterExtHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -440,7 +440,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterClaim: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsAfterClaim)
-    expect(Object.keys(HTLCsAfterClaim).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterClaim).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCsAfterClaim[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
@@ -455,7 +455,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       closed: true
     }
     const HTLCsWithClosed: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsWithClosed)
-    expect(Object.keys(HTLCsWithClosed).length).toBe(4) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsWithClosed).length).toStrictEqual(4) // extra entry for the warning text returned by the RPC atm.
     // we have a common field "type", use that to narrow down the record
     if (HTLCsWithClosed[claimTxId].type === ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
@@ -502,7 +502,7 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -522,13 +522,13 @@ describe('ICXOrderBook.listHTLCs', () => {
       offerTx: '123'
     }
     const HTLCsForIncorrectOfferTx: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsIncorrectOfferTx)
-    expect(Object.keys(HTLCsForIncorrectOfferTx).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsForIncorrectOfferTx).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     // List htlcs with invalid offer tx "INVALID_OFFER_TX" and check
     const listHTLCOptionsIncorrectOfferTx2 = {
       offerTx: 'INVALID_OFFER_TX'
     }
     const HTLCsForIncorrectOfferTx2: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.icxorderbook.listHTLCs(listHTLCOptionsIncorrectOfferTx2)
-    expect(Object.keys(HTLCsForIncorrectOfferTx2).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsForIncorrectOfferTx2).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/listOrders.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/listOrders.test.ts
@@ -271,7 +271,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // now list orders with ICXListOrderOptions.limit=1
     const ordersWithLimit1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ limit: 1 })
-    expect(Object.keys(ordersWithLimit1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersWithLimit1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCBeforeOffer: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // make offer to partial amount 10 DFI - taker
@@ -302,7 +302,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offesForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offesForOrder1).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offesForOrder1).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect((offesForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -328,7 +328,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // now list offers for orderTx = createOrderTxId with ICXListOrderOptions.limit=1
     const offesForOrder1WithLimit1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId, limit: 1 })
-    expect(Object.keys(offesForOrder1WithLimit1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offesForOrder1WithLimit1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
   })
 
   it('should test ICXListOrderOptions.closed parameter', async () => {
@@ -466,7 +466,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -496,7 +496,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1AfterCloseOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1AfterCloseOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1AfterCloseOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1AfterCloseOffer as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -511,7 +511,7 @@ describe('ICXOrderBook.listOrders', () => {
 
     // now list the ICX offers for orderTx = createOrderTxId with ICXListOrderOptions.closed=true and check
     const offersForOrder1AfterCloseOfferWithClosedTrue: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId, closed: true })
-    expect(Object.keys(offersForOrder1AfterCloseOfferWithClosedTrue).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1AfterCloseOfferWithClosedTrue).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     const offerInfoRetrived = offersForOrder1AfterCloseOfferWithClosedTrue as Record<string, ICXOfferInfo>
     expect(offerInfoRetrived[makeOffer2TxId].orderTx).toStrictEqual(offer2.orderTx)
     expect(offerInfoRetrived[makeOffer2TxId].status).toStrictEqual(ICXOrderStatus.CLOSED)

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/makeOffer.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/makeOffer.test.ts
@@ -102,7 +102,7 @@ describe('ICXOrderBook.makeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -171,7 +171,7 @@ describe('ICXOrderBook.makeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -241,7 +241,7 @@ describe('ICXOrderBook.makeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,
@@ -313,7 +313,7 @@ describe('ICXOrderBook.makeOffer', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const ordersAfterMakeOffer: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.call('icx_listorders', [{ orderTx: createOrderTxId }], 'bignumber')
-    expect(Object.keys(ordersAfterMakeOffer).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(ordersAfterMakeOffer).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((ordersAfterMakeOffer as Record<string, ICXOfferInfo>)[makeOfferTxId]).toStrictEqual(
       {
         orderTx: createOrderTxId,

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/submitDFCHTLC.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/submitDFCHTLC.test.ts
@@ -87,7 +87,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeDFCHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -110,7 +110,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -166,7 +166,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeDFCHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -189,7 +189,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -241,7 +241,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeExtHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -262,7 +262,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -300,7 +300,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterDFCHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptionsAfterDFCHTLC], 'bignumber')
-    expect(Object.keys(HTLCsAfterDFCHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterDFCHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCsAfterDFCHTLC[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -347,7 +347,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.DFC,
@@ -401,7 +401,7 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
   })
 
   it('should return an error when submiting DFC HTLC with incorrect HTLC.amount from the amount in the relavant offer', async () => {
@@ -430,6 +430,6 @@ describe('ICXOrderBook.submitDFCHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/icxorderbook/submitExtHTLC.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/icxorderbook/submitExtHTLC.test.ts
@@ -86,7 +86,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeDFCHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -109,7 +109,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).type).toStrictEqual(ICXHTLCType.DFC)
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).status).toStrictEqual(ICXOrderStatus.OPEN)
     expect((HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).offerTx).toStrictEqual(makeOfferTxId)
@@ -132,7 +132,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCsAfterExtHTLC: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptionsAfterExtHTLC], 'bignumber')
-    expect(Object.keys(HTLCsAfterExtHTLC).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCsAfterExtHTLC).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCsAfterExtHTLC[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -189,7 +189,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     const accountDFIBeforeExtHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountDFI, {}, true], 'bignumber')
@@ -210,7 +210,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -261,7 +261,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await client.call('icx_listhtlcs', [listHTLCOptions], 'bignumber')
-    expect(Object.keys(HTLCs).length).toBe(3) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     expect(HTLCs[ExtHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
       {
         type: ICXHTLCType.EXTERNAL,
@@ -319,7 +319,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCBeforeEXTHTLC
@@ -363,7 +363,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCBeforeEXTHTLC
@@ -394,7 +394,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCAfterDFCHTLC
@@ -425,7 +425,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCBeforeEXTHTLC
@@ -462,7 +462,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCAfterDFCHTLC
@@ -506,7 +506,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
 
     // List the ICX offers for orderTx = createOrderTxId and check
     const offersForOrder1: Record<string, ICXOrderInfo | ICXOfferInfo> = await client.icxorderbook.listOrders({ orderTx: createOrderTxId })
-    expect(Object.keys(offersForOrder1).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(offersForOrder1).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     expect((offersForOrder1 as Record<string, ICXOfferInfo>)[makeOfferTxId].status).toStrictEqual(ICXOrderStatus.OPEN)
 
     // No DFC HTLC submitted yet.
@@ -529,7 +529,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(1) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(1) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCAfterDFCHTLC
@@ -562,7 +562,7 @@ describe('ICXOrderBook.submitExtHTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs: Record<string, ICXDFCHTLCInfo | ICXEXTHTLCInfo | ICXClaimDFCHTLCInfo> = await container.call('icx_listhtlcs', [listHTLCOptions])
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
 
     const accountBTCAfterEXTHTLC: Record<string, BigNumber> = await client.call('getaccount', [accountBTC, {}, true], 'bignumber')
     // should have the same balance as accountBTCBeforeEXTHTLC

--- a/packages/jellyfish-api-core/__tests__/category/server/getRpcInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/server/getRpcInfo.test.ts
@@ -18,7 +18,7 @@ describe('Server on masternode', () => {
     const info = await client.server.getRpcInfo()
     expect(info.active_commands[0].method).toStrictEqual('getrpcinfo')
     expect(info.active_commands[0].duration).toBeGreaterThanOrEqual(0)
-    expect(typeof info.logpath).toBe('string')
+    expect(typeof info.logpath).toStrictEqual('string')
     expect(info.logpath).toContain('regtest/debug.log')
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/server/uptime.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/server/uptime.test.ts
@@ -16,6 +16,6 @@ describe('Server on masternode', () => {
 
   it('should get uptime', async () => {
     const uptime = await client.server.uptime()
-    expect(typeof uptime).toBe('number')
+    expect(typeof uptime).toStrictEqual('number')
   })
 })

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_account.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_account.test.ts
@@ -91,20 +91,20 @@ describe('account.accountToAccount()', () => {
     const txn = await builder.account.accountToAccount(accountToAccount, script)
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
     const encoded: string = OP_CODES.OP_DEFI_TX_ACCOUNT_TO_ACCOUNT(accountToAccount).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
-    expect(outs[0].tokenId).toEqual(0)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
+    expect(outs[0].tokenId).toStrictEqual(0)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // burnt token
     const account = await jsonRpc.account.getAccount(await providers.getAddress())
@@ -144,20 +144,20 @@ describe('account.accountToAccount()', () => {
     const txn = await builder.account.accountToAccount(accountToAccount, script)
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
     const encoded: string = OP_CODES.OP_DEFI_TX_ACCOUNT_TO_ACCOUNT(accountToAccount).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
-    expect(outs[0].tokenId).toEqual(0)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
+    expect(outs[0].tokenId).toStrictEqual(0)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // burnt token
     const account = await jsonRpc.account.getAccount(await providers.getAddress())
@@ -208,20 +208,20 @@ describe('account.accountToAccount()', () => {
     const txn = await builder.account.accountToAccount(accountToAccount, script)
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
     const encoded: string = OP_CODES.OP_DEFI_TX_ACCOUNT_TO_ACCOUNT(accountToAccount).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
-    expect(outs[0].tokenId).toEqual(0)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
+    expect(outs[0].tokenId).toStrictEqual(0)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // burnt token
     const account = await jsonRpc.account.getAccount(await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_utxos.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_utxos.test.ts
@@ -68,13 +68,13 @@ describe('account.accountToUtxos()', () => {
 
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(3)
+    expect(outs.length).toStrictEqual(3)
     const encoded: string = OP_CODES.OP_DEFI_TX_ACCOUNT_TO_UTXOS(accountToUtxos).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
-    expect(outs[0].tokenId).toEqual(0)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
+    expect(outs[0].tokenId).toStrictEqual(0)
 
     const txOuts = await findOuts(outs, providers.elliptic.ellipticPair)
     expect(txOuts.length).toStrictEqual(2)
@@ -86,14 +86,14 @@ describe('account.accountToUtxos()', () => {
     // change returned
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(expectedUtxosRedeemScript)
-    expect(change.scriptPubKey.addresses[0]).toBe(expectedOutAddress)
+    expect(change.scriptPubKey.hex).toStrictEqual(expectedUtxosRedeemScript)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(expectedOutAddress)
     expect(outs[1].scriptPubKey.addresses[0]).toStrictEqual(expectedOutAddress)
 
     // minted utxos
     expect(minted.value).toStrictEqual(conversionAmount)
-    expect(minted.scriptPubKey.hex).toBe(expectedUtxosRedeemScript)
-    expect(minted.scriptPubKey.addresses[0]).toBe(expectedOutAddress)
+    expect(minted.scriptPubKey.hex).toStrictEqual(expectedUtxosRedeemScript)
+    expect(minted.scriptPubKey.addresses[0]).toStrictEqual(expectedOutAddress)
     expect(outs[2].scriptPubKey.addresses[0]).toStrictEqual(expectedOutAddress)
 
     // burnt token

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_vote.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_vote.test.ts
@@ -79,8 +79,8 @@ describe('vote', () => {
     const expectedRedeemScript = `6a${encoded}`
 
     const outs = await sendTransaction(testing.container, txn)
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
   })
 })
 

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_create_order.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_create_order.test.ts
@@ -54,7 +54,7 @@ describe('create ICX order', () => {
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
     expect(outs[0].scriptPubKey.type).toStrictEqual('nulldata')
 
-    expect(outs[1].value).toEqual(expect.any(Number))
+    expect(outs[1].value).toStrictEqual(expect.any(Number))
     expect(outs[1].n).toStrictEqual(1)
     expect(outs[1].tokenId).toStrictEqual(0)
     expect(outs[1].scriptPubKey.type).toStrictEqual('witness_v0_keyhash')

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_make_offer.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_make_offer.test.ts
@@ -140,7 +140,7 @@ describe('make ICX offer', () => {
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
     expect(outs[0].scriptPubKey.type).toStrictEqual('nulldata')
 
-    expect(outs[1].value).toEqual(expect.any(Number))
+    expect(outs[1].value).toStrictEqual(expect.any(Number))
     expect(outs[1].n).toStrictEqual(1)
     expect(outs[1].tokenId).toStrictEqual(0)
     expect(outs[1].scriptPubKey.type).toStrictEqual('witness_v0_keyhash')
@@ -200,7 +200,7 @@ describe('make ICX offer', () => {
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
     expect(outs[0].scriptPubKey.type).toStrictEqual('nulldata')
 
-    expect(outs[1].value).toEqual(expect.any(Number))
+    expect(outs[1].value).toStrictEqual(expect.any(Number))
     expect(outs[1].n).toStrictEqual(1)
     expect(outs[1].tokenId).toStrictEqual(0)
     expect(outs[1].scriptPubKey.type).toStrictEqual('witness_v0_keyhash')

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_add_liquidity.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_add_liquidity.test.ts
@@ -95,19 +95,19 @@ describe('liqPool.addLiquidity()', () => {
     const txn = await builder.liqPool.addLiquidity(addLiquidity, script)
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
     const encoded: string = OP_CODES.OP_DEFI_TX_POOL_ADD_LIQUIDITY(addLiquidity).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // updated balance
     const account = await jsonRpc.account.getAccount(await providers.getAddress())
@@ -153,19 +153,19 @@ describe('liqPool.addLiquidity()', () => {
     const txn = await builder.liqPool.addLiquidity(addLiquidity, script)
     const outs = await sendTransaction(container, txn)
 
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
     const encoded: string = OP_CODES.OP_DEFI_TX_POOL_ADD_LIQUIDITY(addLiquidity).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // updated balance
     const account = await jsonRpc.account.getAccount(await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_remove_liquidity.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_remove_liquidity.test.ts
@@ -83,20 +83,20 @@ describe('liqPool.removeLiquidity()', () => {
 
     const txn = await builder.liqPool.removeLiquidity(removeLiquidity, script)
     const outs = await sendTransaction(container, txn)
-    expect(outs.length).toEqual(2)
+    expect(outs.length).toStrictEqual(2)
 
     const encoded: string = OP_CODES.OP_DEFI_TX_POOL_REMOVE_LIQUIDITY(removeLiquidity).asBuffer().toString('hex')
     // OP_RETURN + DfTx full buffer
     const expectedRedeemScript = `6a${encoded}`
-    expect(outs[0].value).toEqual(0)
-    expect(outs[0].scriptPubKey.hex).toEqual(expectedRedeemScript)
+    expect(outs[0].value).toStrictEqual(0)
+    expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
 
     // change
     const change = await findOut(outs, providers.elliptic.ellipticPair)
     expect(change.value).toBeLessThan(1)
     expect(change.value).toBeGreaterThan(1 - 0.001) // deducted fee
-    expect(change.scriptPubKey.hex).toBe(`0014${HASH160(destPubKey).toString('hex')}`)
-    expect(change.scriptPubKey.addresses[0]).toBe(Bech32.fromPubKey(destPubKey, 'bcrt'))
+    expect(change.scriptPubKey.hex).toStrictEqual(`0014${HASH160(destPubKey).toString('hex')}`)
+    expect(change.scriptPubKey.addresses[0]).toStrictEqual(Bech32.fromPubKey(destPubKey, 'bcrt'))
 
     // updated balance, receive invidual token
     const account = await jsonRpc.account.getAccount(await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
@@ -86,7 +86,7 @@ describe('submit DFC HTLC', () => {
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
     expect(outs[0].scriptPubKey.type).toStrictEqual('nulldata')
 
-    expect(outs[1].value).toEqual(expect.any(Number))
+    expect(outs[1].value).toStrictEqual(expect.any(Number))
     expect(outs[1].n).toStrictEqual(1)
     expect(outs[1].tokenId).toStrictEqual(0)
     expect(outs[1].scriptPubKey.type).toStrictEqual('witness_v0_keyhash')
@@ -100,7 +100,7 @@ describe('submit DFC HTLC', () => {
       offerTx: makeOfferTxId
     }
     const HTLCs = await testing.rpc.icxorderbook.listHTLCs(listHTLCOptions)
-    expect(Object.keys(HTLCs).length).toBe(2) // extra entry for the warning text returned by the RPC atm.
+    expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     const DFCHTLCTxId = calculateTxid(txn)
     expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
       {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
@@ -96,7 +96,7 @@ describe('submit EXT HTLC', () => {
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
     expect(outs[0].scriptPubKey.type).toStrictEqual('nulldata')
 
-    expect(outs[1].value).toEqual(expect.any(Number))
+    expect(outs[1].value).toStrictEqual(expect.any(Number))
     expect(outs[1].n).toStrictEqual(1)
     expect(outs[1].tokenId).toStrictEqual(0)
     expect(outs[1].scriptPubKey.type).toStrictEqual('witness_v0_keyhash')

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/SetGovernance.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/SetGovernance.test.ts
@@ -24,8 +24,8 @@ it('should bi-directional buffer-object-buffer', () => {
     )
 
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x47)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x47)
   })
 })
 
@@ -75,7 +75,7 @@ describe('multiple variable', () => {
     ]
 
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(header + data)
+    expect(buffer.toString('hex')).toStrictEqual(header + data)
   })
 
   describe('Composable', () => {
@@ -83,7 +83,7 @@ describe('multiple variable', () => {
       const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
       const composable = new CSetGovernance(buffer)
 
-      expect(composable.toObject()).toEqual(setGovernance)
+      expect(composable.toObject()).toStrictEqual(setGovernance)
     })
 
     it('should compose from composable to buffer', () => {
@@ -91,7 +91,7 @@ describe('multiple variable', () => {
       const buffer = new SmartBuffer()
       composable.toBuffer(buffer)
 
-      expect(buffer.toBuffer().toString('hex')).toEqual(data)
+      expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
     })
   })
 })
@@ -137,7 +137,7 @@ describe('single variable', () => {
     ]
 
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(header + data)
+    expect(buffer.toString('hex')).toStrictEqual(header + data)
   })
 
   describe('Composable', () => {
@@ -145,7 +145,7 @@ describe('single variable', () => {
       const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
       const composable = new CSetGovernance(buffer)
 
-      expect(composable.toObject()).toEqual(setGovernance)
+      expect(composable.toObject()).toStrictEqual(setGovernance)
     })
 
     it('should compose from composable to buffer', () => {
@@ -153,7 +153,7 @@ describe('single variable', () => {
       const buffer = new SmartBuffer()
       composable.toBuffer(buffer)
 
-      expect(buffer.toBuffer().toString('hex')).toEqual(data)
+      expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
     })
   })
 })
@@ -179,7 +179,7 @@ describe('Unmapped Governance Variable handling', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(lpRewards + fooBaz, 'hex'))
     const composable = new CSetGovernance(buffer)
 
-    expect(composable.toObject()).toEqual(setGovernance)
+    expect(composable.toObject()).toStrictEqual(setGovernance)
   })
 
   it('should compose from composable to buffer', () => {
@@ -187,6 +187,6 @@ describe('Unmapped Governance Variable handling', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(lpRewards + fooBaz)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(lpRewards + fooBaz)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_icxorderbook/ICXSubmitDFCHTLC.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_icxorderbook/ICXSubmitDFCHTLC.test.ts
@@ -18,8 +18,8 @@ it('should bi-directional buffer-object-buffer', () => {
     )
 
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x33)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x33)
   })
 })
 
@@ -42,7 +42,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -50,7 +50,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CICXSubmitDFCHTLC(buffer)
 
-    expect(composable.toObject()).toEqual(submitDFCHTLC)
+    expect(composable.toObject()).toStrictEqual(submitDFCHTLC)
   })
 
   it('should compose from composable to buffer', () => {
@@ -58,6 +58,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_icxorderbook/ICXSubmitEXTHTLC.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_icxorderbook/ICXSubmitEXTHTLC.test.ts
@@ -53,7 +53,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CICXSubmitEXTHTLC(buffer)
 
-    expect(composable.toObject()).toEqual(submitEXTHTLC)
+    expect(composable.toObject()).toStrictEqual(submitEXTHTLC)
   })
 
   it('should compose from composable to buffer', () => {
@@ -61,6 +61,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_op_push_anomaly.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_op_push_anomaly.test.ts
@@ -88,7 +88,7 @@ describe('CTransaction PoolSwap Anomaly', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     const composable = new CTransactionSegWit(buffer)
 
-    expect(composable.toObject()).toEqual(transaction)
+    expect(composable.toObject()).toStrictEqual(transaction)
   })
 
   it('should compose from composable to buffer', () => {
@@ -96,6 +96,6 @@ describe('CTransaction PoolSwap Anomaly', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(hex)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(hex)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/AppointOracle.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/AppointOracle.test.ts
@@ -17,8 +17,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x6f)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x6f)
   })
 })
 
@@ -54,7 +54,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -62,7 +62,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CAppointOracle(buffer)
 
-    expect(composable.toObject()).toEqual(appointOracle)
+    expect(composable.toObject()).toStrictEqual(appointOracle)
   })
 
   it('should compose from composable to buffer', () => {
@@ -70,6 +70,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/RemoveOracle.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/RemoveOracle.test.ts
@@ -17,8 +17,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x68)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x68)
   })
 })
 
@@ -35,7 +35,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -43,7 +43,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CRemoveOracle(buffer)
 
-    expect(composable.toObject()).toEqual(removeOracle)
+    expect(composable.toObject()).toStrictEqual(removeOracle)
   })
 
   it('should compose from composable to buffer', () => {
@@ -51,6 +51,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/SetOracleData.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/SetOracleData.test.ts
@@ -18,8 +18,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x79)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x79)
   })
 })
 
@@ -49,7 +49,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -57,7 +57,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CSetOracleData(buffer)
 
-    expect(composable.toObject()).toEqual(setOracleData)
+    expect(composable.toObject()).toStrictEqual(setOracleData)
   })
 
   it('should compose from composable to buffer', () => {
@@ -65,6 +65,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/UpdateOracle.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_oracles/UpdateOracle.test.ts
@@ -17,8 +17,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x74)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x74)
   })
 })
 
@@ -59,7 +59,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -67,7 +67,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CUpdateOracle(buffer)
 
-    expect(composable.toObject()).toEqual(updateOracle)
+    expect(composable.toObject()).toStrictEqual(updateOracle)
   })
 
   it('should compose from composable to buffer', () => {
@@ -75,6 +75,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_pool/PoolCreatePair.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_pool/PoolCreatePair.test.ts
@@ -52,8 +52,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x70)
-    expect(buffer.toString('hex')).toBe(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x70)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
   })
 })
 
@@ -85,7 +85,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -93,7 +93,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CPoolCreatePair(buffer)
 
-    expect(composable.toObject()).toEqual(poolCreatePair)
+    expect(composable.toObject()).toStrictEqual(poolCreatePair)
   })
 
   it('should compose from composable to buffer', () => {
@@ -101,6 +101,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_pool/PoolUpdatePair.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_pool/PoolUpdatePair.test.ts
@@ -30,8 +30,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x75)
-    expect(buffer.toString('hex')).toBe(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x75)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
   })
 })
 
@@ -61,7 +61,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -69,7 +69,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CPoolUpdatePair(buffer)
 
-    expect(composable.toObject()).toEqual(poolUpdatePair)
+    expect(composable.toObject()).toStrictEqual(poolUpdatePair)
   })
 
   it('should compose from composable to buffer', () => {
@@ -77,6 +77,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenCreate.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenCreate.test.ts
@@ -30,8 +30,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x54)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x54)
   })
 })
 
@@ -54,7 +54,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -62,7 +62,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CTokenCreate(buffer)
 
-    expect(composable.toObject()).toEqual(tokenCreate)
+    expect(composable.toObject()).toStrictEqual(tokenCreate)
   })
 
   it('should compose from composable to buffer', () => {
@@ -70,6 +70,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenUpdate.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenUpdate.test.ts
@@ -21,8 +21,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x4e)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x4e)
   })
 })
 
@@ -40,7 +40,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -48,7 +48,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CTokenUpdate(buffer)
 
-    expect(composable.toObject()).toEqual(tokenUpdate)
+    expect(composable.toObject()).toStrictEqual(tokenUpdate)
   })
 
   it('should compose from composable to buffer', () => {
@@ -56,6 +56,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenUpdateAny.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_token/TokenUpdateAny.test.ts
@@ -23,8 +23,8 @@ it('should bi-directional buffer-object-buffer', () => {
       SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
     )
     const buffer = toBuffer(stack)
-    expect(buffer.toString('hex')).toBe(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toBe(0x6e)
+    expect(buffer.toString('hex')).toStrictEqual(hex)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x6e)
   })
 })
 
@@ -48,7 +48,7 @@ it('should craft dftx with OP_CODES._()', () => {
   ]
 
   const buffer = toBuffer(stack)
-  expect(buffer.toString('hex')).toBe(header + data)
+  expect(buffer.toString('hex')).toStrictEqual(header + data)
 })
 
 describe('Composable', () => {
@@ -56,7 +56,7 @@ describe('Composable', () => {
     const buffer = SmartBuffer.fromBuffer(Buffer.from(data, 'hex'))
     const composable = new CTokenUpdateAny(buffer)
 
-    expect(composable.toObject()).toEqual(tokenUpdateAny)
+    expect(composable.toObject()).toStrictEqual(tokenUpdateAny)
   })
 
   it('should compose from composable to buffer', () => {
@@ -64,6 +64,6 @@ describe('Composable', () => {
     const buffer = new SmartBuffer()
     composable.toBuffer(buffer)
 
-    expect(buffer.toBuffer().toString('hex')).toEqual(data)
+    expect(buffer.toBuffer().toString('hex')).toStrictEqual(data)
   })
 })


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Refactors jest `toBe`/`toEqual` to `toStrictEqual`

#### Which issue(s) does this PR fixes?:

Fixes #613

#### Additional comments?:

Missing eslint configuration to catch this on lint