### PR TITLE
jellyfish-wallet to use `coinType/purpose/0/account` pathing

### DIFF
--- a/packages/jellyfish-wallet/__tests__/wallet.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet.test.ts
@@ -25,7 +25,7 @@ describe('discover accounts', () => {
 
   it('should discover [] when [1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -36,7 +36,7 @@ describe('discover accounts', () => {
   it('should discover [0,1] when [0,1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
       'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -47,8 +47,8 @@ describe('discover accounts', () => {
   it('should discover [0,1,2] when [0,1,2] has activity', async () => {
     const accountProvider = new TestAccountProvider([
       'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp',
-      'bcrt1qhu2pkzfx4gc8r5nry89ma9xvvt6rz0r4xe5yyw'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze',
+      'bcrt1qm4kmrktw4xtcd9xy5v643u8qc8pf7elfy54mm7'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -59,9 +59,9 @@ describe('discover accounts', () => {
   it('should discover [0,1] when [0,1,3,4] has activity', async () => {
     const accountProvider = new TestAccountProvider([
       'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp',
-      'bcrt1q5kn8n6wne38q84z86ukghluh4d0seqp2rcfw5g',
-      'bcrt1qwtjj8kjc92zcya6jjprjvdn3h2vw9uh003q4c3'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze',
+      'bcrt1quak0rspszf8l0r4kw8a0ypexdl9frsp56h62vg',
+      'bcrt1qufm8zulstmwej6jq2qr98m80uvj2v9l40rhll4'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -72,7 +72,7 @@ describe('discover accounts', () => {
   it('should discover [0] when [0,1] has activity as max account is set to 1', async () => {
     const accountProvider = new TestAccountProvider([
       'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
@@ -101,7 +101,7 @@ describe('is usable', () => {
   it('[0,1,2] should be usable when [0,1] has activity', async () => {
     const accountProvider = new TestAccountProvider([
       'bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2',
-      'bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp'
+      'bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze'
     ])
     const wallet = new JellyfishWallet(nodeProvider, accountProvider)
     expect(await wallet.isUsable(0)).toStrictEqual(true)
@@ -116,11 +116,11 @@ describe('is usable', () => {
   })
 })
 
-describe('get accounts', () => {
+describe('get accounts LIGHT_WALLET default', () => {
   const accountProvider = new TestAccountProvider([])
   const wallet = new JellyfishWallet(nodeProvider, accountProvider)
 
-  it('should get account 0', async () => {
+  it('should get account 0 (default address)', async () => {
     const account = wallet.get(0)
     const address = await account.getAddress()
     expect(address).toStrictEqual('bcrt1qwm0jzcy0jfyel8he42u9536u9wzefmwr5mdkc2')
@@ -129,48 +129,67 @@ describe('get accounts', () => {
   it('should get account 1', async () => {
     const account = wallet.get(1)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp')
+    expect(address).toStrictEqual('bcrt1qyf5c9593u8v5s7exh3mfndw28k6sz84788tlze')
   })
 
   it('should get account 2', async () => {
     const account = wallet.get(2)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1qhu2pkzfx4gc8r5nry89ma9xvvt6rz0r4xe5yyw')
+    expect(address).toStrictEqual('bcrt1qm4kmrktw4xtcd9xy5v643u8qc8pf7elfy54mm7')
   })
 
   it('should get account 3', async () => {
     const account = wallet.get(3)
     const address = await account.getAddress()
-    expect(address).toStrictEqual('bcrt1q5kn8n6wne38q84z86ukghluh4d0seqp2rcfw5g')
+    expect(address).toStrictEqual('bcrt1quak0rspszf8l0r4kw8a0ypexdl9frsp56h62vg')
   })
 
   it('should get account 4', async () => {
     const address = await wallet.get(4).getAddress()
-    expect(address).toStrictEqual('bcrt1qwtjj8kjc92zcya6jjprjvdn3h2vw9uh003q4c3')
+    expect(address).toStrictEqual('bcrt1qufm8zulstmwej6jq2qr98m80uvj2v9l40rhll4')
   })
 
   it('should get account 5', async () => {
     const address = await wallet.get(5).getAddress()
-    expect(address).toStrictEqual('bcrt1qcs3ny98wsfpch99mhp24gthzy0scz0l2ej43y0')
+    expect(address).toStrictEqual('bcrt1qnzl6heuvzzalutvftq7prwqtlgcsujmr8wukmw')
   })
 
   it('should get account 6', async () => {
     const address = await wallet.get(6).getAddress()
-    expect(address).toStrictEqual('bcrt1qrl6m7payyuuwgqv6zmx5yk09l4najqphgljcpp')
+    expect(address).toStrictEqual('bcrt1q5urh79qjuj3j55d29cl8nhjh5mvauu6s7xfcdd')
   })
 
   it('should get account 7', async () => {
     const address = await wallet.get(7).getAddress()
-    expect(address).toStrictEqual('bcrt1qm8y3cvv6g3az6k5lj3435d79wnepspx6j8hqqj')
+    expect(address).toStrictEqual('bcrt1qk8w8gv8g5508wcjcerpx6a2esatqf44h9cj8l5')
   })
 
   it('should get account 8', async () => {
     const address = await wallet.get(8).getAddress()
-    expect(address).toStrictEqual('bcrt1qfm27gdjmr739est3jgv84cnxnavdp6y0zgm3wv')
+    expect(address).toStrictEqual('bcrt1qyrx9j2nhuulgv3nclpv43r9vmp2ky6w7hv3t8h')
   })
 
   it('should get account 9', async () => {
     const address = await wallet.get(9).getAddress()
-    expect(address).toStrictEqual('bcrt1q4pj4gfe73x4ww58a42ysdktpj98fn64pjeh47d')
+    expect(address).toStrictEqual('bcrt1qg34rgkscf3l4h9j02g4vr9t5vmmw6crtmucz0k')
+  })
+})
+
+describe('get accounts on MASTERNODE', () => {
+  const accountProvider = new TestAccountProvider([])
+  const wallet = new JellyfishWallet(
+    nodeProvider, accountProvider, JellyfishWallet.COIN_TYPE_DFI, JellyfishWallet.PURPOSE_LIGHT_MASTERNODE
+  )
+
+  it('should get account 0', async () => {
+    const account = wallet.get(0)
+    const address = await account.getAddress()
+    expect(address).toStrictEqual('bcrt1qn823x6sqpc66fuy2g0ylufe4sfaculfs87sulp')
+  })
+
+  it('should get account 1', async () => {
+    const account = wallet.get(1)
+    const address = await account.getAddress()
+    expect(address).toStrictEqual('bcrt1qfyygclxhcwh97hyylhkn3asucae29x6qhnnh47')
   })
 })

--- a/packages/jellyfish-wallet/src/wallet.ts
+++ b/packages/jellyfish-wallet/src/wallet.ts
@@ -5,18 +5,33 @@ import { WalletHdNode, WalletHdNodeProvider } from './wallet_hd_node'
  * Jellyfish managed wallet.
  * WalletHdNode instance is provided by WalletHdNodeProvider.
  * WalletAccount instance for interfacing layer/upstream to service will be provided by WalletAccountProvider.
+ *
+ * JellyfishWallet doesn't follow BIP-44.
  */
 export class JellyfishWallet<Account extends WalletAccount, HdNode extends WalletHdNode> {
-  private readonly nodeProvider: WalletHdNodeProvider<HdNode>
-  private readonly accountProvider: WalletAccountProvider<Account>
+  static COIN_TYPE_BTC: number = 0
+  static COIN_TYPE_DFI: number = 1129
+  /**
+   * Default purpose, for Light Wallet Implementation
+   */
+  static PURPOSE_LIGHT_WALLET: number = 0
+  /**
+   * For Masternode creation UTXO locking
+   */
+  static PURPOSE_LIGHT_MASTERNODE: number = 1
 
   /**
    * @param {WalletHdNodeProvider} nodeProvider
    * @param {WalletAccountProvider} accountProvider
+   * @param {number} [coinType=1129] COIN_TYPE_DFI
+   * @param {number} [purpose=0] PURPOSE_LIGHT_WALLET
    */
-  constructor (nodeProvider: WalletHdNodeProvider<HdNode>, accountProvider: WalletAccountProvider<Account>) {
-    this.nodeProvider = nodeProvider
-    this.accountProvider = accountProvider
+  constructor (
+    private readonly nodeProvider: WalletHdNodeProvider<HdNode>,
+    private readonly accountProvider: WalletAccountProvider<Account>,
+    private readonly coinType: number = JellyfishWallet.COIN_TYPE_DFI,
+    private readonly purpose: number = JellyfishWallet.PURPOSE_LIGHT_WALLET
+  ) {
   }
 
   /**
@@ -24,7 +39,7 @@ export class JellyfishWallet<Account extends WalletAccount, HdNode extends Walle
    * @return Promise<WalletAccount>
    */
   get (account: number): Account {
-    const path = `1129/${account}/0/0`
+    const path = `${this.coinType}/${this.purpose}/0/${account}`
     const node = this.nodeProvider.derive(path)
     return this.accountProvider.provide(node)
   }


### PR DESCRIPTION
#### What kind of PR is this?:
/kind feature

#### What this PR does / why we need it:

Updated JellyfishWallet to use path "coinType/purpose/0/account" non-hardened derivation with:
- `coinType` support  for BTC/DFI for ICX
- `purpose` support for LIGHT_WALLET and MASTERNODE locked UTXO.
- `account` for addresses within the purpose use case. E.g. light wallet addresses, masternodes.


This won't break compatibility with DeFiCh/wallet because currently we only use one default address.

Where account = `0`.

Before:
- `1129/account/0/0 -> 1129/0/0/0`

After:
- COIN_TYPE = 1129, default
- PURPOSE = 0, default
- `coinType/purpose/0/account -> 1129/0/0/0`