### PR TITLE
Added additional `network: Network` param to all P2WPKHTxnBuilder

### DIFF
--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_account.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_account.test.ts
@@ -1,16 +1,12 @@
 import BigNumber from 'bignumber.js'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import { OP_CODES, AccountToAccount } from '@defichain/jellyfish-transaction'
+import { AccountToAccount, OP_CODES } from '@defichain/jellyfish-transaction'
 import { P2WPKH } from '@defichain/jellyfish-address'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { createToken, mintTokens, sendTokensToAddress, utxosToAccount } from '@defichain/testing'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  findOut,
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, sendTransaction } from '../test.utils'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
 import { RegTest } from '@defichain/jellyfish-network'
 
@@ -46,7 +42,7 @@ afterAll(async () => {
 beforeEach(async () => {
   await providers.randomizeEllipticPair()
   await container.waitForWalletBalanceGTE(11.1)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Fund 10 DFI TOKEN
   await providers.setupMocks() // required to move utxos

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_utxos.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_account_to_utxos.test.ts
@@ -1,16 +1,13 @@
 import BigNumber from 'bignumber.js'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
-import { OP_CODES, AccountToUtxos } from '@defichain/jellyfish-transaction'
+import { AccountToUtxos, OP_CODES } from '@defichain/jellyfish-transaction'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { utxosToAccount } from '@defichain/testing'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  findOuts,
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOuts, fundEllipticPair, sendTransaction } from '../test.utils'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -35,7 +32,7 @@ afterAll(async () => {
 beforeEach(async () => {
   await providers.randomizeEllipticPair()
   await container.waitForWalletBalanceGTE(11.1)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Fund 10 DFI TOKEN
   await providers.setupMocks() // required to move utxos

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_utxos_to_account.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_account_utxos_to_account.test.ts
@@ -5,11 +5,7 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  findOut,
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, sendTransaction } from '../test.utils'
 import { P2WPKH } from '@defichain/jellyfish-address'
 import { RegTest } from '@defichain/jellyfish-network'
 
@@ -24,7 +20,7 @@ beforeAll(async () => {
   await container.waitForWalletCoinbaseMaturity()
 
   providers = await getProviders(container)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
   jsonRpc = new JsonRpcClient(await container.getCachedRpcUrl())
 })
 

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_appoint_oracle.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_appoint_oracle.test.ts
@@ -1,8 +1,9 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, fundEllipticPair, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('appoint oracle', () => {
   const container = new MasterNodeRegTestContainer()
@@ -16,7 +17,7 @@ describe('appoint oracle', () => {
 
     providers = await getProviders(container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // Prep 1000 DFI Token for testing
     await container.waitForWalletBalanceGTE(1001)
@@ -100,7 +101,7 @@ describe('appoint oracle', () => {
 
     providers = await getProviders(container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // Prep 1000 DFI Token for testing
     await container.waitForWalletBalanceGTE(1001)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_claim_dfc_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_claim_dfc_htlc.test.ts
@@ -1,4 +1,4 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
@@ -9,6 +9,7 @@ import { ICXClaimDFCHTLC } from '@defichain/jellyfish-transaction/script/dftx/df
 import { ICXClaimDFCHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('claim DFC HTLC', () => {
   const container = new MasterNodeRegTestContainer()
@@ -22,7 +23,7 @@ describe('claim DFC HTLC', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // steps required for ICX testing
     await testing.icxorderbook.setAccounts(await providers.getAddress(), await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_create_loan_scheme.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_create_loan_scheme.test.ts
@@ -6,6 +6,7 @@ import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
 import { LoanMasterNodeRegTestContainer } from './loan_container'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new LoanMasterNodeRegTestContainer()
 const testing = Testing.create(container)
@@ -19,7 +20,7 @@ beforeAll(async () => {
 
   providers = await getProviders(testing.container)
   providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Default scheme
   await testing.container.call('createloanscheme', [100, new BigNumber(1.5), 'default'])

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_poolswap.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_dex_poolswap.test.ts
@@ -12,6 +12,7 @@ import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { fundEllipticPair, sendTransaction } from '../test.utils'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -33,7 +34,7 @@ beforeAll(async () => {
   jsonRpc = new JsonRpcClient(await container.getCachedRpcUrl())
 
   providers = await getProviders(container)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // creating DFI-* pool pairs and funding liquidity
   for (const symbol of Object.keys(pairs)) {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_error.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_error.test.ts
@@ -4,6 +4,7 @@ import { OP_CODES, Script } from '@defichain/jellyfish-transaction'
 import { getProviders, MockProviders } from '../provider.mock'
 import { fundEllipticPair, randomEllipticPair } from '../test.utils'
 import { P2WPKHTransactionBuilder } from '../../src'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -43,7 +44,7 @@ describe('FeeRateProvider', () => {
       }
     }
 
-    const builder = new P2WPKHTransactionBuilder(feeProvider, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(feeProvider, providers.prevout, providers.elliptic, RegTest)
     await expect(builder.utxo.sendAll(script))
       .rejects.toThrow('attempting to use a fee rate higher than MAX_FEE_RATE of 0.001 is not allowed')
   })
@@ -55,7 +56,7 @@ describe('FeeRateProvider', () => {
       }
     }
 
-    const builder = new P2WPKHTransactionBuilder(feeProvider, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(feeProvider, providers.prevout, providers.elliptic, RegTest)
     await expect(builder.utxo.sendAll(script))
       .rejects.toThrow('fee rate NaN is invalid')
   })
@@ -66,7 +67,7 @@ describe('PrevoutProvider', () => {
     await providers.randomizeEllipticPair()
     await providers.setupMocks()
 
-    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
     await expect(builder.utxo.sendAll(script))
       .rejects.toThrow('no prevouts available to create a transaction')
   })
@@ -75,13 +76,13 @@ describe('PrevoutProvider', () => {
     await providers.randomizeEllipticPair()
     await providers.setupMocks()
 
-    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
     await expect(builder.utxo.sendAll(script))
       .rejects.toThrow('no prevouts available to create a transaction')
   })
 
   it('should fail balance not enough in PrevoutProvider.collect(): MIN_BALANCE_NOT_ENOUGH', async () => {
-    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
     await expect(builder.utxo.send(new BigNumber(1000), script, script))
       .rejects.toThrow('not enough balance after combing all prevouts')
   })
@@ -89,7 +90,7 @@ describe('PrevoutProvider', () => {
 
 describe('EllipticPairProvider', () => {
   it('should fail as provided EllipticPair cannot sign transaction: SIGN_TRANSACTION_ERROR', async () => {
-    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    const builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
     providers.elliptic.ellipticPair = randomEllipticPair()
 
     await expect(builder.utxo.sendAll(script))

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createcfp.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createcfp.test.ts
@@ -8,6 +8,7 @@ import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
 import { GovernanceMasterNodeRegTestContainer } from '../../../jellyfish-api-core/__tests__/category/governance/governance_container'
 import { governance } from '@defichain/jellyfish-api-core'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('createCfp', () => {
   let providers: MockProviders
@@ -20,7 +21,7 @@ describe('createCfp', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(11)
     await fundEllipticPair(testing.container, providers.ellipticPair, 21) // Amount needed for two cfp creation + fees

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createcfp.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createcfp.test.ts
@@ -24,7 +24,7 @@ describe('createCfp', () => {
     builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(11)
-    await fundEllipticPair(testing.container, providers.ellipticPair, 21) // Amount needed for two cfp creation + fees
+    await fundEllipticPair(testing.container, providers.ellipticPair, 3) // Amount needed for two cfp creation + fees
     await providers.setupMocks()
   })
 
@@ -53,7 +53,7 @@ describe('createCfp', () => {
     const expectedRedeemScript = `6a${encoded}`
 
     const outs = await sendTransaction(testing.container, txn)
-    expect(outs[0].value).toStrictEqual(10)
+    expect(outs[0].value).toStrictEqual(1)
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
 
     const listProposals = await testing.rpc.governance.listProposals()

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createvoc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createvoc.test.ts
@@ -25,7 +25,7 @@ describe('createVoc', () => {
     builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(11)
-    await fundEllipticPair(testing.container, providers.ellipticPair, 101) // Amount needed for two createVoc creation + fees
+    await fundEllipticPair(testing.container, providers.ellipticPair, 11) // Amount needed for two createVoc creation + fees
     await providers.setupMocks()
   })
 
@@ -50,7 +50,7 @@ describe('createVoc', () => {
     const expectedRedeemScript = `6a${encoded}`
 
     const outs = await sendTransaction(testing.container, txn)
-    expect(outs[0].value).toStrictEqual(50)
+    expect(outs[0].value).toStrictEqual(5)
     expect(outs[0].scriptPubKey.hex).toStrictEqual(expectedRedeemScript)
 
     const listProposals = await testing.rpc.governance.listProposals()

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createvoc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_createvoc.test.ts
@@ -9,6 +9,7 @@ import BigNumber from 'bignumber.js'
 import { GovernanceMasterNodeRegTestContainer } from '../../../jellyfish-api-core/__tests__/category/governance/governance_container'
 import { governance } from '@defichain/jellyfish-api-core'
 import { TxnBuilderError } from '../../src/txn/txn_builder_error'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('createVoc', () => {
   let providers: MockProviders
@@ -21,7 +22,7 @@ describe('createVoc', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(11)
     await fundEllipticPair(testing.container, providers.ellipticPair, 101) // Amount needed for two createVoc creation + fees

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_vote.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_governance_vote.test.ts
@@ -7,6 +7,7 @@ import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
 import { GovernanceMasterNodeRegTestContainer } from '../../../jellyfish-api-core/__tests__/category/governance/governance_container'
 import { OP_CODES, Vote } from '@defichain/jellyfish-transaction'
+import { RegTest } from '@defichain/jellyfish-network'
 
 class CustomOperatorGovernanceMasterNodeRegTestContainer extends GovernanceMasterNodeRegTestContainer {
   protected getCmd (opts: StartOptions): string[] {
@@ -42,7 +43,7 @@ describe('vote', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(12)
     await fundEllipticPair(testing.container, providers.ellipticPair, 50)
@@ -107,7 +108,7 @@ describe('vote with masternode operator with legacy address', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey))
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.container.waitForWalletBalanceGTE(12)
     await fundEllipticPair(testing.container, providers.ellipticPair, 50)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_create_order.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_create_order.test.ts
@@ -1,11 +1,12 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, fundEllipticPair, sendTransaction, TxOut } from '../test.utils'
-import { OP_CODES, ICXCreateOrder, ICXOrderType } from '@defichain/jellyfish-transaction'
+import { ICXCreateOrder, ICXOrderType, OP_CODES } from '@defichain/jellyfish-transaction'
 import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('create ICX order', () => {
   const testing = Testing.create(new MasterNodeRegTestContainer())
@@ -18,7 +19,7 @@ describe('create ICX order', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to testing.container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     await testing.icxorderbook.setAccounts(await providers.getAddress(), await providers.getAddress())
     await testing.rpc.account.utxosToAccount({ [testing.icxorderbook.accountDFI]: `${500}@${testing.icxorderbook.symbolDFI}` })

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_make_offer.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_icx_make_offer.test.ts
@@ -1,11 +1,12 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { WIF } from '@defichain/jellyfish-crypto'
 import { calculateTxid, fundEllipticPair, sendTransaction } from '../test.utils'
 import BigNumber from 'bignumber.js'
-import { OP_CODES, ICXMakeOffer } from '@defichain/jellyfish-transaction'
+import { ICXMakeOffer, OP_CODES } from '@defichain/jellyfish-transaction'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('make ICX offer', () => {
   const testing = Testing.create(new MasterNodeRegTestContainer())
@@ -18,7 +19,7 @@ describe('make ICX offer', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to testing.container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // steps required for ICX setup
     await testing.icxorderbook.setAccounts(await providers.getAddress(), await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_add_liquidity.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_add_liquidity.test.ts
@@ -7,11 +7,7 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { createPoolPair, createToken, mintTokens, sendTokensToAddress, utxosToAccount } from '@defichain/testing'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  findOut,
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, sendTransaction } from '../test.utils'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
 
 const container = new MasterNodeRegTestContainer()
@@ -45,7 +41,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await providers.randomizeEllipticPair()
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Fund 100 DFI TOKEN
   await providers.setupMocks() // required to move utxos

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_remove_liquidity.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_liq_pool_remove_liquidity.test.ts
@@ -5,12 +5,9 @@ import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { addPoolLiquidity, createPoolPair, createToken, mintTokens } from '@defichain/testing'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  findOut,
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, sendTransaction } from '../test.utils'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -47,7 +44,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await providers.randomizeEllipticPair()
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   await container.waitForWalletBalanceGTE(1)
 

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_masternode_create.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_masternode_create.test.ts
@@ -1,14 +1,11 @@
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { RegTest } from '@defichain/jellyfish-network'
-import { OP_CODES, CreateMasternode, TransactionSegWit } from '@defichain/jellyfish-transaction'
+import { CreateMasternode, OP_CODES, TransactionSegWit } from '@defichain/jellyfish-transaction'
 import { P2PKH, P2SH, P2WPKH } from '@defichain/jellyfish-address'
 import { DeFiDRpcError, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
-import {
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { fundEllipticPair, sendTransaction } from '../test.utils'
 
 describe('CreateMasternode', () => {
   const container = new MasterNodeRegTestContainer()
@@ -32,7 +29,7 @@ describe('CreateMasternode', () => {
 
   beforeEach(async () => {
     await providers.randomizeEllipticPair()
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // Note(canonbrother): in regtest, collateral amount must be equal to 2 and creation fee must be greater than 1
     // https://github.com/DeFiCh/ain/blob/85360ad432ae8c5ecbfbfc7d63dd5bc6fe41e875/src/masternodes/mn_checks.cpp#L439-L446
@@ -59,7 +56,7 @@ describe('CreateMasternode', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     const encoded: string = OP_CODES.OP_DEFI_TX_CREATE_MASTER_NODE(createMasternode).asBuffer().toString('hex')
     const expectedRedeemScript = `6a${encoded}`
@@ -105,7 +102,7 @@ describe('CreateMasternode', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     const encoded: string = OP_CODES.OP_DEFI_TX_CREATE_MASTER_NODE(createMasternode).asBuffer().toString('hex')
     const expectedRedeemScript = `6a${encoded}`
@@ -143,7 +140,7 @@ describe('CreateMasternode', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     const promise = sendTransaction(container, txn)
     await expect(promise).rejects.toThrow(DeFiDRpcError)
@@ -173,7 +170,7 @@ describe('CreateMasternode', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     try {
       await sendTransaction(container, txn)
@@ -205,7 +202,7 @@ describe('CreateMasternode with timelock', () => {
 
   beforeEach(async () => {
     await providers.randomizeEllipticPair()
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // 0.00000755 is added for calculateFeeP2WPKH deduction
     // with timelock fee increases 0.000001
@@ -232,7 +229,7 @@ describe('CreateMasternode with timelock', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     const encoded: string = OP_CODES.OP_DEFI_TX_CREATE_MASTER_NODE(createMasternode).asBuffer().toString('hex')
     const expectedRedeemScript = `6a${encoded}`
@@ -272,7 +269,7 @@ describe('CreateMasternode with timelock', () => {
 
     const script = await providers.elliptic.script()
 
-    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script, 'regtest')
+    const txn: TransactionSegWit = await builder.masternode.create(createMasternode, script)
 
     const promise = sendTransaction(container, txn)
     await expect(promise).rejects.toThrow(DeFiDRpcError)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_masternode_resign.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_masternode_resign.test.ts
@@ -5,10 +5,8 @@ import { DeFiDRpcError, MasterNodeRegTestContainer } from '@defichain/testcontai
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { MasternodeState, MasternodeTimeLock } from '../../../jellyfish-api-core/src/category/masternode'
-import {
-  fundEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { fundEllipticPair, sendTransaction } from '../test.utils'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -31,7 +29,7 @@ afterAll(async () => {
 
 beforeEach(async () => {
   await providers.randomizeEllipticPair()
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   await fundEllipticPair(container, providers.ellipticPair, 10)
   await providers.setupMocks()

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_p2wpkh.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_p2wpkh.test.ts
@@ -4,6 +4,7 @@ import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTxnBuilder } from '../../src'
 import { fundEllipticPair } from '../test.utils'
 import { CDfTx, DeFiOpUnmapped, OP_CODES, OP_DEFI_TX } from '@defichain/jellyfish-transaction'
+import { RegTest } from '@defichain/jellyfish-network'
 
 // P2WPKHTxnBuilder is abstract and not instantiable
 class TestBuilder extends P2WPKHTxnBuilder {}
@@ -28,7 +29,7 @@ beforeAll(async () => {
   await container.waitForWalletCoinbaseMaturity()
 
   providers = await getProviders(container)
-  builder = new TestBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new TestBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 })
 
 afterAll(async () => {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_remove_oracle.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_remove_oracle.test.ts
@@ -1,8 +1,9 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, fundEllipticPair, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -15,7 +16,7 @@ beforeAll(async () => {
 
   providers = await getProviders(container)
   providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Prep 1000 DFI Token for testing
   await container.waitForWalletBalanceGTE(1001)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_set_default_loan_scheme.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_set_default_loan_scheme.test.ts
@@ -6,6 +6,7 @@ import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
 import { LoanMasterNodeRegTestContainer } from './loan_container'
 import { Testing } from '@defichain/jellyfish-testing'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new LoanMasterNodeRegTestContainer()
 const testing = Testing.create(container)
@@ -19,7 +20,7 @@ beforeAll(async () => {
 
   providers = await getProviders(testing.container)
   providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Default scheme
   await testing.container.call('createloanscheme', [100, new BigNumber(1.5), 'scheme1'])

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_set_oracle_data.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_set_oracle_data.test.ts
@@ -1,9 +1,10 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, fundEllipticPair, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -16,7 +17,7 @@ beforeAll(async () => {
 
   providers = await getProviders(container)
   providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Prep 1000 DFI Token for testing
   await container.waitForWalletBalanceGTE(1001)
@@ -111,7 +112,7 @@ describe('set oracle data', () => {
     await sendTransaction(container, appointTxn)
 
     const newProviders = await getProviders(container)
-    const newBuilder = new P2WPKHTransactionBuilder(newProviders.fee, newProviders.prevout, newProviders.elliptic)
+    const newBuilder = new P2WPKHTransactionBuilder(newProviders.fee, newProviders.prevout, newProviders.elliptic, RegTest)
     const newAddressScript = await newProviders.elliptic.script()
 
     // Fund 1 DFI UTXO

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
@@ -1,4 +1,4 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
@@ -9,6 +9,7 @@ import { ICXSubmitDFCHTLC } from '@defichain/jellyfish-transaction/script/dftx/d
 import { ICXDFCHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
 import { Testing } from '@defichain/jellyfish-testing'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('submit DFC HTLC', () => {
   const container = new MasterNodeRegTestContainer()
@@ -22,7 +23,7 @@ describe('submit DFC HTLC', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // steps required for ICX testing
     await testing.icxorderbook.setAccounts(await providers.getAddress(), await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
@@ -1,4 +1,4 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
@@ -9,6 +9,7 @@ import { ICXSubmitEXTHTLC } from '@defichain/jellyfish-transaction/script/dftx/d
 import { ICXEXTHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
 import { Testing } from '@defichain/jellyfish-testing'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
+import { RegTest } from '@defichain/jellyfish-network'
 
 describe('submit EXT HTLC', () => {
   const container = new MasterNodeRegTestContainer()
@@ -22,7 +23,7 @@ describe('submit EXT HTLC', () => {
 
     providers = await getProviders(testing.container)
     providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[0].owner.privKey)) // set it to container default
-    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+    builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
     // steps required for ICX testing
     await testing.icxorderbook.setAccounts(await providers.getAddress(), await providers.getAddress())

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_update_oracle.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_update_oracle.test.ts
@@ -1,8 +1,9 @@
-import { MasterNodeRegTestContainer, GenesisKeys } from '@defichain/testcontainers'
+import { GenesisKeys, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, fundEllipticPair, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -15,7 +16,7 @@ beforeAll(async () => {
 
   providers = await getProviders(container)
   providers.setEllipticPair(WIF.asEllipticPair(GenesisKeys[GenesisKeys.length - 1].owner.privKey))
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 
   // Prep 1000 DFI Token for testing
   await container.waitForWalletBalanceGTE(1001)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_utxo.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_utxo.test.ts
@@ -4,12 +4,8 @@ import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { OP_CODES, OP_PUSHDATA, Script } from '@defichain/jellyfish-transaction'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
-import {
-  findOut,
-  fundEllipticPair,
-  randomEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, randomEllipticPair, sendTransaction } from '../test.utils'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -21,7 +17,7 @@ beforeAll(async () => {
   await container.waitForWalletCoinbaseMaturity()
 
   providers = await getProviders(container)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 })
 
 afterAll(async () => {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_utxo_many.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_utxo_many.test.ts
@@ -4,12 +4,8 @@ import { getProviders, MockProviders } from '../provider.mock'
 import { P2WPKHTransactionBuilder } from '../../src'
 import { OP_CODES, OP_PUSHDATA, Script } from '@defichain/jellyfish-transaction'
 import { Bech32, HASH160 } from '@defichain/jellyfish-crypto'
-import {
-  findOut,
-  fundEllipticPair,
-  randomEllipticPair,
-  sendTransaction
-} from '../test.utils'
+import { findOut, fundEllipticPair, randomEllipticPair, sendTransaction } from '../test.utils'
+import { RegTest } from '@defichain/jellyfish-network'
 
 const container = new MasterNodeRegTestContainer()
 let providers: MockProviders
@@ -21,7 +17,7 @@ beforeAll(async () => {
   await container.waitForWalletCoinbaseMaturity()
 
   providers = await getProviders(container)
-  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic)
+  builder = new P2WPKHTransactionBuilder(providers.fee, providers.prevout, providers.elliptic, RegTest)
 })
 
 afterAll(async () => {

--- a/packages/jellyfish-transaction-builder/src/index.ts
+++ b/packages/jellyfish-transaction-builder/src/index.ts
@@ -27,13 +27,13 @@ export * from './txn/txn_builder_icxorderbook'
  * Currently only support sending from P2PKH operations.
  */
 export class P2WPKHTransactionBuilder extends P2WPKHTxnBuilder {
-  public readonly dex = new TxnBuilderDex(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly utxo = new TxnBuilderUtxo(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly account = new TxnBuilderAccount(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly liqPool = new TxnBuilderLiqPool(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly oracles = new TxnBuilderOracles(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly governance = new TxnBuilderGovernance(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly icxorderbook = new TxnBuilderICXOrderBook(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly masternode = new TxnBuilderMasternode(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
-  public readonly loans = new TxnBuilderLoans(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider)
+  public readonly dex = new TxnBuilderDex(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly utxo = new TxnBuilderUtxo(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly account = new TxnBuilderAccount(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly liqPool = new TxnBuilderLiqPool(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly oracles = new TxnBuilderOracles(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly governance = new TxnBuilderGovernance(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly icxorderbook = new TxnBuilderICXOrderBook(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly masternode = new TxnBuilderMasternode(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
+  public readonly loans = new TxnBuilderLoans(this.feeProvider, this.prevoutProvider, this.ellipticPairProvider, this.network)
 }

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder.ts
@@ -14,6 +14,7 @@ import { EllipticPairProvider, FeeRateProvider, Prevout, PrevoutProvider } from 
 import { calculateFeeP2WPKH } from './txn_fee'
 import { TxnBuilderError, TxnBuilderErrorType } from './txn_builder_error'
 import { EllipticPair } from '@defichain/jellyfish-crypto'
+import { Network } from '@defichain/jellyfish-network'
 
 const MAX_FEE_RATE = new BigNumber('0.00100000')
 
@@ -24,7 +25,8 @@ export abstract class P2WPKHTxnBuilder {
   constructor (
     public readonly feeProvider: FeeRateProvider,
     public readonly prevoutProvider: PrevoutProvider,
-    public readonly ellipticPairProvider: EllipticPairProvider
+    public readonly ellipticPairProvider: EllipticPairProvider,
+    public readonly network: Network
   ) {
   }
 

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder_governance.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder_governance.ts
@@ -1,11 +1,4 @@
-import {
-  OP_CODES,
-  Script,
-  TransactionSegWit,
-  CreateVoc,
-  CreateCfp,
-  Vote
-} from '@defichain/jellyfish-transaction'
+import { CreateCfp, CreateVoc, OP_CODES, Script, TransactionSegWit, Vote } from '@defichain/jellyfish-transaction'
 import { P2WPKHTxnBuilder } from './txn_builder'
 import { TxnBuilderError, TxnBuilderErrorType } from './txn_builder_error'
 import BigNumber from 'bignumber.js'
@@ -18,8 +11,8 @@ export class TxnBuilderGovernance extends P2WPKHTxnBuilder {
    * @param {Script} changeScript to send unspent to after deducting the (converted + fees)
    * @returns {Promise<TransactionSegWit>}
    */
-  async createCfp (createCfp: CreateCfp, changeScript: Script, network = 'mainnet'): Promise<TransactionSegWit> {
-    const creationFee = network === 'regtest' ? new BigNumber('1') : new BigNumber('10')
+  async createCfp (createCfp: CreateCfp, changeScript: Script): Promise<TransactionSegWit> {
+    const creationFee = this.network.name === 'regtest' ? new BigNumber('1') : new BigNumber('10')
     return await this.createDeFiTx(
       OP_CODES.OP_DEFI_TX_CREATE_CFP(createCfp),
       changeScript,
@@ -34,7 +27,7 @@ export class TxnBuilderGovernance extends P2WPKHTxnBuilder {
    * @param {Script} changeScript to send unspent to after deducting the (converted + fees)
    * @returns {Promise<TransactionSegWit>}
    */
-  async createVoc (createVoc: CreateVoc, changeScript: Script, network = 'mainnet'): Promise<TransactionSegWit> {
+  async createVoc (createVoc: CreateVoc, changeScript: Script): Promise<TransactionSegWit> {
     if (!createVoc.amount.isEqualTo(new BigNumber(0))) {
       throw new TxnBuilderError(TxnBuilderErrorType.INVALID_VOC_AMOUNT,
         'CreateVoc amount should be 0'
@@ -45,7 +38,7 @@ export class TxnBuilderGovernance extends P2WPKHTxnBuilder {
         'CreateVoc address stack should be empty'
       )
     }
-    const creationFee = network === 'regtest' ? new BigNumber('5') : new BigNumber('50')
+    const creationFee = this.network.name === 'regtest' ? new BigNumber('5') : new BigNumber('50')
     return await this.createDeFiTx(
       OP_CODES.OP_DEFI_TX_CREATE_VOC(createVoc),
       changeScript,

--- a/packages/jellyfish-transaction-builder/src/txn/txn_builder_masternode.ts
+++ b/packages/jellyfish-transaction-builder/src/txn/txn_builder_masternode.ts
@@ -1,5 +1,11 @@
 import { BigNumber } from '@defichain/jellyfish-json'
-import { OP_CODES, Script, TransactionSegWit, CreateMasternode, ResignMasternode } from '@defichain/jellyfish-transaction'
+import {
+  CreateMasternode,
+  OP_CODES,
+  ResignMasternode,
+  Script,
+  TransactionSegWit
+} from '@defichain/jellyfish-transaction'
 import { P2WPKHTxnBuilder } from './txn_builder'
 
 export class TxnBuilderMasternode extends P2WPKHTxnBuilder {
@@ -10,8 +16,8 @@ export class TxnBuilderMasternode extends P2WPKHTxnBuilder {
    * @param {Script} changeScript to send unspent to after deducting the (converted + fees)
    * @return {Promise<TransactionSegWit>}
    */
-  async create (createMasternode: CreateMasternode, changeScript: Script, network = 'mainnet'): Promise<TransactionSegWit> {
-    const creationFee = network === 'regtest' ? new BigNumber('1') : new BigNumber('10')
+  async create (createMasternode: CreateMasternode, changeScript: Script): Promise<TransactionSegWit> {
+    const creationFee = this.network.name === 'regtest' ? new BigNumber('1') : new BigNumber('10')
     // NOTE(canonbrother): adding a force default timelock handling here for better ux as from now on, timelock is mandatory
     // https://github.com/DeFiCh/ain/blob/ff53dcee23db2ffe0da9b147a0a53956f4e7ee31/src/masternodes/mn_checks.h#L159
     createMasternode.timelock = createMasternode.timelock ?? 0x0000


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Added additional `network: Network` param to all P2WPKHTxnBuilder, allowing `TxnBuilder` to access network information required for building transactions.
