### PR TITLE
Update governance opcodes

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/governance/createCfp.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/createCfp.test.ts
@@ -10,7 +10,6 @@ describe('Governance', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
   })
 

--- a/packages/jellyfish-api-core/__tests__/category/governance/createVoc.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/createVoc.test.ts
@@ -9,7 +9,6 @@ describe('Governance', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
   })
 

--- a/packages/jellyfish-api-core/__tests__/category/governance/governance_container.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/governance_container.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer, StartOptions } from '@defichain/testcontain
 
 export class GovernanceMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor () {
-    super(undefined, 'defi/defichain:HEAD-3c03721')
+    super(undefined, 'defi/defichain:HEAD-677ada8')
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/jellyfish-api-core/__tests__/category/governance/vote.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/governance/vote.test.ts
@@ -9,7 +9,6 @@ describe('Governance', () => {
 
   beforeAll(async () => {
     await container.start()
-    await container.waitForReady()
     await container.waitForWalletCoinbaseMaturity()
   })
 

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/CreateCfp.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/CreateCfp.test.ts
@@ -9,7 +9,7 @@ import BigNumber from 'bignumber.js'
 
 it('should bi-directional buffer-object-buffer', () => {
   const fixtures = [
-    '6a4b44665478460117a9148b5401d88a3d4e54fc701663dd99a5ab792af0a48700e40b5402000000022354657374696e67206e657720636f6d6d756e6974792066756e642070726f706f73616c'
+    '6a4b44665478650117a9148b5401d88a3d4e54fc701663dd99a5ab792af0a48700e40b5402000000022354657374696e67206e657720636f6d6d756e6974792066756e642070726f706f73616c'
   ]
 
   fixtures.forEach(hex => {
@@ -19,12 +19,12 @@ it('should bi-directional buffer-object-buffer', () => {
 
     const buffer = toBuffer(stack)
     expect(buffer.toString('hex')).toStrictEqual(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x46)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x65)
   })
 })
 
 describe('createCfp', () => {
-  const header = '6a4b4466547846' // OP_RETURN(0x6a) OP_PUSHDATA1(0x4b) (length 68 = 0x44) CDfTx.SIGNATURE(0x44665478) CreateProposal.OP_CODE(0x46)
+  const header = '6a4b4466547865' // OP_RETURN(0x6a) OP_PUSHDATA1(0x4b) (length 68 = 0x44) CDfTx.SIGNATURE(0x44665478) CreateProposal.OP_CODE(0x65)
   const data = '0117a9148b5401d88a3d4e54fc701663dd99a5ab792af0a48700e40b5402000000022354657374696e67206e657720636f6d6d756e6974792066756e642070726f706f73616c' // CreateProposal.type(0x01) CreateProposal.address (0x17a9148b5401d88a3d4e54fc701663dd99a5ab792af0a487) CreateProposal.amount(0x00e40b5402000000) CreateProposal.cycles(0x02) CreateProposal.title[BE](0x2354657374696e67206e657720636f6d6d756e6974792066756e642070726f706f73616c)
   const CreateProposal: CreateCfp = {
     type: 0x01,

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/Vote.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_governance/Vote.test.ts
@@ -6,9 +6,9 @@ import { OP_DEFI_TX } from '../../../../src/script/dftx'
 
 it('should bi-directional buffer-object-buffer', () => {
   const fixtures = [
-    '6a464466547856680aaa128c5f016b04f1a496ada226a99f5a18ead478a2ac6a665620b0987869b45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce801',
-    '6a464466547856e91d11fb83d2b533dff7681007e2e4fa071e9d43b447ab01e37ed9351d270d2ab45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce802',
-    '6a46446654785682e2059745d5e2c886b07b25dce73e2fb803aec8cb0f9adcbecd43e8dd879603b45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce803'
+    '6a46446654784f680aaa128c5f016b04f1a496ada226a99f5a18ead478a2ac6a665620b0987869b45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce801',
+    '6a46446654784fe91d11fb83d2b533dff7681007e2e4fa071e9d43b447ab01e37ed9351d270d2ab45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce802',
+    '6a46446654784f82e2059745d5e2c886b07b25dce73e2fb803aec8cb0f9adcbecd43e8dd879603b45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce803'
   ]
 
   fixtures.forEach(hex => {
@@ -18,12 +18,12 @@ it('should bi-directional buffer-object-buffer', () => {
 
     const buffer = toBuffer(stack)
     expect(buffer.toString('hex')).toStrictEqual(hex)
-    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x56)
+    expect((stack[1] as OP_DEFI_TX).tx.type).toStrictEqual(0x4f)
   })
 })
 
 describe('vote', () => {
-  const header = '6a464466547856' // OP_RETURN(0x6a) (length 70 = 0x46) CDfTx.SIGNATURE(0x44665478) Vote.OP_CODE(0x56)
+  const header = '6a46446654784f' // OP_RETURN(0x6a) (length 70 = 0x46) CDfTx.SIGNATURE(0x44665478) Vote.OP_CODE(0x4f)
   const data = '680aaa128c5f016b04f1a496ada226a99f5a18ead478a2ac6a665620b0987869b45fd5be75bde9dda6f11bb58e386a29834aa452413f3123f40acc6178026ce801' // Vote.proposalId[BE](0x697898b02056666aaca278d4ea185a9fa926a2ad96a4f1046b015f8c12aa0a68) Vote.masternodeId[BE] (0xe86c027861cc0af423313f4152a44a83296a388eb51bf1a6dde9bd75bed55fb4) Vote.voteDecision(0x01)
   const Vote: Vote = {
     voteDecision: 0x01,

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_governance.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_governance.ts
@@ -137,7 +137,7 @@ export class CCreateProposal extends ComposableBuffer<CreateProposal> {
 }
 
 export class CCreateCfp extends CCreateProposal {
-  static OP_CODE = 0x46 // 'F'
+  static OP_CODE = 0x65 // 'e'
   static OP_NAME = 'OP_DEFI_TX_CREATE_CFP'
 }
 
@@ -159,7 +159,7 @@ export interface Vote {
  * Immutable by design, bi-directional fromBuffer, toBuffer deep composer.
  */
 export class CVote extends ComposableBuffer<Vote> {
-  static OP_CODE = 0x56 // 'V'
+  static OP_CODE = 0x4f // 'O'
   static OP_NAME = 'OP_DEFI_TX_CREATE_CFP'
   composers (vote: Vote): BufferComposer[] {
     return [


### PR DESCRIPTION
#### What kind of PR is this?:

/kind chore

#### What this PR does / why we need it:

Bumps docker image to latest governance PR state e1503fc38df50e5ca8ae4caf400d533704be12ee
Update governance opcodes to match change. 
The opcodes were changed as they were conflicting with loan opcodes.