### PR TITLE
initial jellyfish ecosystem consolidation PR setup

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,4 +11,5 @@ exclude_patterns:
   - "**/node_modules/"
   - "**/*.test.ts"
   - "**/*.test.tsx"
+  - "**/*.e2e.ts"
   - "**/*.d.ts"

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,9 +12,18 @@
     "website"
   ],
   "rules": {
-    "curly": ["error", "all"],
-    "brace-style": ["error", "1tbs"],
-    "func-style": [2, "declaration"],
+    "curly": [
+      "error",
+      "all"
+    ],
+    "brace-style": [
+      "error",
+      "1tbs"
+    ],
+    "func-style": [
+      2,
+      "declaration"
+    ],
     "import/no-default-export": "error"
   },
   "overrides": [

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Define individuals that are responsible for code in this repository.
 # More details are here: https://help.github.com/articles/about-codeowners/
 
-/.github/                                       @fuxingloh
-/.husky/                                        @fuxingloh
+/.github/                                       @fuxingloh @monstrobishi
+/.husky/                                        @fuxingloh @monstrobishi
 
 /packages/jellyfish/                            @fuxingloh @canonbrother
 /packages/jellyfish-address/                    @fuxingloh @ivan-zynesis
@@ -39,7 +39,10 @@ tsconfig.build.json                             @fuxingloh @canonbrother @ivan-z
 jest.config.js                                  @fuxingloh @canonbrother @ivan-zynesis
 package.json                                    @fuxingloh
 package-lock.json                               @fuxingloh
+.codeclimate.yml                                @fuxingloh
+.eslintrc                                       @fuxingloh
+netlify.toml                                    @fuxingloh
 
-CONTRIBUTING.md                                 @fuxingloh @canonbrother @jingyi2811
+CONTRIBUTING.md                                 @fuxingloh
 README.md                                       @fuxingloh
 LICENSE                                         @fuxingloh

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ coverage
 
 # typescript
 tsconfig.build.tsbuildinfo
+
+# Level
+.level
+.leveldb

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -32,6 +32,7 @@
       <w>checksig</w>
       <w>checksigverify</w>
       <w>clarkequayheight</w>
+      <w>codeclimate</w>
       <w>codeseparator</w>
       <w>createmasternode</w>
       <w>createpoolpair</w>
@@ -44,6 +45,7 @@
       <w>dakotaheight</w>
       <w>debugexclude</w>
       <w>defi</w>
+      <w>defich</w>
       <w>defichain</w>
       <w>defid</w>
       <w>descendantcount</w>
@@ -52,6 +54,7 @@
       <w>devnet</w>
       <w>dftx</w>
       <w>dockerode</w>
+      <w>dogfooding</w>
       <w>dummypos</w>
       <w>dumpprivkey</w>
       <w>emissionburn</w>
@@ -83,6 +86,7 @@
       <w>gettxout</w>
       <w>getunconfirmedbalance</w>
       <w>getwalletinfo</w>
+      <w>ghcr</w>
       <w>greaterthan</w>
       <w>greaterthanorequal</w>
       <w>hdkeypath</w>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,13 @@
 
 ## All features must be unit tested with accepted coverage. (Target 100%)
 
+```txt
+packages/
+├─ jellyfish-*/
+│  ├─ __tests__/following-src-structure.test.ts
+│  └─ src/following-src-structure.ts
+```
+
 Each package or functionality must be accompanied by full coverage testing.
 
 Due to Javascript type coercion, all test assertions must use strict equality checking.
@@ -30,13 +37,12 @@ Each pull request with feature change should have accompanying documentations un
 
 ## Explicit over implicit
 
-Each package, feature, code and decision should be explicit and well documented over implicitly guessing.
+- Each package, feature, code and decision should be explicit and well documented over implicitly guessing.
+- Each test must be written explicitly as clear as possible with no implicit guessing.
 
 ## TypeScript
 
 TypeScript must be used for all code written in this project.
-
-> Heavily adapted from [deno style guide](https://github.com/denoland/deno/blob/main/docs/contributing/style_guide.md).
 
 ### Document and maintain browser compatibility.
 
@@ -44,9 +50,12 @@ TypeScript must be used for all code written in this project.
 
 ### Do not depend on external code. (never if possible)
 
-### Use underscores, not dashes in filenames.
+### Use PascalCase and period, not underscores, or dashes in filenames.
 
-Example: Use `foo_bar.ts` instead of `foo-bar.ts`.
+Example: Use `FooBar.ts` instead of `foo-bar.ts` or `foo_bar.ts`.
+
+> Previously the preferred method is underscores (`foo_bar.ts`), this has be deprecated in favour of PascalCase.
+> PascalCase follows the natural class naming pattern while underscores or dashes doesn't.
 
 ### Exported functions: max 2 args, put the rest into an options object.
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 [![CI](https://github.com/DeFiCh/jellyfish/actions/workflows/ci.yml/badge.svg)](https://github.com/DeFiCh/jellyfish/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/DeFiCh/jellyfish/branch/main/graph/badge.svg?token=IYL9K0WROA)](https://codecov.io/gh/DeFiCh/jellyfish)
 [![Maintainability](https://api.codeclimate.com/v1/badges/7019f1d74a0500951b2a/maintainability)](https://codeclimate.com/github/DeFiCh/jellyfish/maintainability)
-[![TS-Standard](https://badgen.net/badge/code%20style/ts-standard/blue?icon=typescript)](https://github.com/standard/ts-standard)
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish)
 
 # [@defichain/jellyfish](https://jellyfish.defichain.com)
 
-DeFiChain SDK. A collection of TypeScript + JavaScript tools and libraries for DeFi Blockchain developers to build
-decentralized finance on Bitcoin.
+> https://jellyfish.defichain.com
 
-> 🚧 @defichain/jellyfish is considered BETA SOFTWARE with frequent minor breaking releases. Used in production at
-> @defichain. This is a free software, @defichain assumes no responsibility nor liability if there is a bug in the
-> implementation.
+DeFiChain Jellyfish SDK. A collection of TypeScript + JavaScript tools and libraries to build Native DeFi products.
+
+<details>
+<summary><b>Watch this space!</b></summary>
+
+We are consolidating all jellyfish ecosystem projects ocean, whale, playground, and salmon into this repository.
+
+- For better synergy of DeFiChain open source development across all concerns.
+- Consistent versioning for all ecosystem releases with a single source of truth.
+- Documentation for the entirety of the jellyfish ecosystem via `jellyfish.defichain.com`. Incorporating sample and
+  playground.
+- Early regression detection upstream to downstream changes with monolithic repo structure.
+
+</details>
 
 ## Installation
+
+> We are deprecating the CJS/UMD bundle in `@defichain/jellyfish`, please use individual packages (`@defichain/jellyfish-*`) for better control of what you need.
 
 ### Node
 
@@ -39,7 +50,7 @@ client.mining.getMiningInfo().then((info) => {
 ### ES6 Modules
 
 ```js
-import {Client} from '@defichain/jellyfish'
+import { Client } from '@defichain/jellyfish'
 
 const client = new Client('http://localhost:8554')
 const info = await client.mining.getMiningInfo()
@@ -48,7 +59,7 @@ const info = await client.mining.getMiningInfo()
 ### Providers
 
 ```js
-import {Client, HttpProvider} from '@defichain/jellyfish'
+import { Client, HttpProvider } from '@defichain/jellyfish'
 
 const options = {} // optional
 
@@ -77,7 +88,6 @@ version tag.
 
 Package                                            | Description
 ---------------------------------------------------|-------------
-`@defichain/jellyfish`                             | Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts
 `@defichain/jellyfish-address`                     | Provide address builder, parser, validator utility library for DeFi Blockchain.
 `@defichain/jellyfish-api-core`                    | A protocol agnostic DeFi Blockchain client interfaces, with a "foreign function interface" design.
 `@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification for api-core.
@@ -91,10 +101,11 @@ Package                                            | Description
 `@defichain/jellyfish-transaction-signature`       | Stateless utility library to perform transaction signing.
 `@defichain/jellyfish-wallet`                      | Jellyfish wallet is a managed wallet, where account can get discovered from an HD seed.
 `@defichain/jellyfish-wallet-classic`              | WalletClassic implements a simple, single elliptic pair wallet.
-`@defichain/jellyfish-wallet-encrypted`            | Library to encrypt MnemonicHdNode as EncryptedMnemonicHdNode. Able to perform as MnemonicHdNode with passphrase known. 
+`@defichain/jellyfish-wallet-encrypted`            | Library to encrypt MnemonicHdNode as EncryptedMnemonicHdNode. Able to perform as MnemonicHdNode with passphrase known.
 `@defichain/jellyfish-wallet-mnemonic`             | MnemonicHdNode implements the WalletHdNode from jellyfish-wallet; a CoinType-agnostic HD Wallet for noncustodial DeFi.
 `@defichain/testcontainers`                        | Provides a lightweight, throw away instances for DeFiD node provisioned automatically in a Docker container.
-~~@defichain/testing~~                             | Provides rich test fixture setup functions for effective and effortless testing.
+~~@defichain/jellyfish~~                           | (deprecated) ~~Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts~~
+~~@defichain/testing~~                             | (deprecated) ~~Provides rich test fixture setup functions for effective and effortless testing.~~
 
 ## Developing & Contributing
 
@@ -132,11 +143,30 @@ jest `--maxConcurrency` count. Test are known to be flaky due to the usage of mu
 concurrency. Although testcontainers cleans up after itself, there are cases where the tests fail exceptionally you
 might need to occasionally: `docker system prune --volumes`.
 
-Coverage is collected at each pull request to main with `codecov`; more testing 🚀 less 🐛 = 😎
+#### Unit Testing
 
-```shell
-jest
-```
+Unit testing are created to test each individual units/components of a software. As they are unit tests, they should
+accompany each unitized component or module. They follow the naming semantic of `*.test.ts` and are placed together in
+the same directory structure in `/__tests__` of the code you are testing. Code coverage is collected for this.
+
+#### End-to-end Testing
+
+On top of unit tests, this provides additional testing that tests the entire lifecycle. All dependencies and modules are
+integrated together as expected. They follow the naming semantic of `*.e2e.ts`. Code coverage is collected for this.
+
+For API service endpoints that are meant to be consumed by developer, the testing should also be done in the `*-cient`
+packages. Dogfooding at its finest.
+
+#### Sanity Testing
+
+On top of end-to-end testing, sanity testing is done after the docker image is build. This kind of testing is performed
+to ascertain the possibility of bugs within the workflow that generate the builds. To identify and determine whether a
+build artifact (docker) should be rejected. This is only done on CI and you are not expected to perform them manually.
+
+#### Code coverage
+
+Coverage is collected for all applicable tests at each pull request to main branch with `codecov`. The more testing 🚀
+less 🐛 = 😎
 
 ### Publishing
 
@@ -145,8 +175,11 @@ by [GitHub releases](https://github.com/DeFiCh/jellyfish/releases) with connecte
 release `types: [ published, prereleased ]`, GitHub Action will automatically build all packages in this repo and
 publish it into npm.
 
-* release are tagged as `@latest`
-* prerelease are tagged as `@next` (please use this cautiously)
+For packages with accompanying docker images, they are published automatically to GitHub Container Registry
+(ghcr.io/defich). When a new [GitHub releases](https://github.com/DeFiCh/whale/releases) is triggered, GitHub Action
+will automatically build the docker image in this repo and publish it. Two images are created for each release
+targeting `linux/amd64` and `linux/arm64`. The latest tag will always be updated with the last release and semantic
+release is enforced for each release.
 
 ### IntelliJ IDEA
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

The initial start of #580 - We are consolidating all jellyfish ecosystem projects ocean, whale, playground, and salmon into this repository.

- For better synergy of DeFiChain open source development across all concerns.
- Consistent versioning for all ecosystem releases with a single source of truth.
- Documentation for the entirety of the jellyfish ecosystem via `jellyfish.defichain.com`. Incorporating sample and playground.
- Early regression detection upstream to downstream changes with monolithic repo structure.
