### PR TITLE
initial setup of `jellyfish-oracle`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,9 +16,8 @@
 /packages/jellyfish-crypto/                     @fuxingloh @ivan-zynesis @surangap
 /packages/jellyfish-json/                       @fuxingloh @canonbrother
 /packages/jellyfish-network/                    @fuxingloh @ivan-zynesis
-
+/packages/jellyfish-oracle/                     @fuxingloh @monstrobishi
 /packages/jellyfish-testing/                    @fuxingloh @canonbrother @jingyi2811 @surangap @Jouzo
-
 /packages/jellyfish-transaction/                @fuxingloh @ivan-zynesis @canonbrother @monstrobishi @surangap @Jouzo @jingyi2811
 /packages/jellyfish-transaction-builder/        @fuxingloh @ivan-zynesis @canonbrother @monstrobishi @surangap @Jouzo @jingyi2811
 /packages/jellyfish-transaction-signature/      @fuxingloh @ivan-zynesis @surangap

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -46,6 +46,7 @@ issue:
         - jellyfish-crypto
         - jellyfish-json
         - jellyfish-network
+        - jellyfish-oracle
         - jellyfish-testing
         - jellyfish-transaction
         - jellyfish-transaction-builder

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,6 +51,11 @@ labels:
     matcher:
       files: "packages/jellyfish-network/**"
 
+  - label: area/jellyfish-oracle
+    sync: true
+    matcher:
+      files: "packages/jellyfish-oracle/**"
+
   - label: area/jellyfish-testing
     sync: true
     matcher:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,6 +73,8 @@
 - color: fbca04
   name: area/jellyfish-network
 - color: fbca04
+  name: area/jellyfish-oracle
+- color: fbca04
   name: area/jellyfish-testing
 - color: fbca04
   name: area/jellyfish-transaction

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -92,6 +92,7 @@
       <w>hdkeypath</w>
       <w>hdmasterfingerprint</w>
       <w>hdseedid</w>
+      <w>htlc</w>
       <w>icxorderbook</w>
       <w>ifdup</w>
       <w>importprivkey</w>

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Package                                            | Description
 `@defichain/jellyfish-json`                        | Allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
 `@defichain/jellyfish-network`                     | Contains DeFi Blockchain various network configuration for mainnet, testnet and regtest.
 `@defichain/jellyfish-testing`                     | Provides many abstractions for various commonly used setup pattern for DeFi Blockchain.
+`@defichain/jellyfish-oracle`                      | DeFiChain oracle adapter core
 `@defichain/jellyfish-transaction`                 | Dead simple modern stateless raw transaction composer for the DeFi Blockchain.
 `@defichain/jellyfish-transaction-builder`         | Provides a high-high level abstraction for constructing transaction ready to be broadcast for DeFi Blockchain.
 `@defichain/jellyfish-transaction-signature`       | Stateless utility library to perform transaction signing.

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,8 @@ module.exports = {
     '@defichain/jellyfish-crypto': '<rootDir>/packages/jellyfish-crypto/src',
     '@defichain/jellyfish-json': '<rootDir>/packages/jellyfish-json/src',
     '@defichain/jellyfish-network': '<rootDir>/packages/jellyfish-network/src',
+    '@defichain/jellyfish-oracle': '<rootDir>/packages/jellyfish-oracle/src',
+    '@defichain/jellyfish-testing': '<rootDir>/packages/jellyfish-testing/src',
     '@defichain/jellyfish-transaction-signature': '<rootDir>/packages/jellyfish-transaction-signature/src',
     '@defichain/jellyfish-transaction-builder': '<rootDir>/packages/jellyfish-transaction-builder/src',
     '@defichain/jellyfish-transaction': '<rootDir>/packages/jellyfish-transaction/src',
@@ -17,8 +19,7 @@ module.exports = {
     '@defichain/jellyfish-wallet-mnemonic': '<rootDir>/packages/jellyfish-wallet-mnemonic/src',
     '@defichain/jellyfish-wallet': '<rootDir>/packages/jellyfish-wallet/src',
     '@defichain/testcontainers': '<rootDir>/packages/testcontainers/src',
-    '@defichain/testing': '<rootDir>/packages/testing/src',
-    '@defichain/jellyfish-testing': '<rootDir>/packages/jellyfish-testing/src'
+    '@defichain/testing': '<rootDir>/packages/testing/src'
   },
   verbose: true,
   clearMocks: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1502,6 +1502,10 @@
       "resolved": "packages/jellyfish-network",
       "link": true
     },
+    "node_modules/@defichain/jellyfish-oracle": {
+      "resolved": "packages/jellyfish-oracle",
+      "link": true
+    },
     "node_modules/@defichain/jellyfish-testing": {
       "resolved": "packages/jellyfish-testing",
       "link": true
@@ -29402,6 +29406,10 @@
       "version": "0.0.0",
       "license": "MIT"
     },
+    "packages/jellyfish-oracle": {
+      "version": "0.0.0",
+      "license": "MIT"
+    },
     "packages/jellyfish-testing": {
       "name": "@defichain/jellyfish-testing",
       "version": "0.0.0",
@@ -30732,6 +30740,9 @@
     },
     "@defichain/jellyfish-network": {
       "version": "file:packages/jellyfish-network"
+    },
+    "@defichain/jellyfish-oracle": {
+      "version": "file:packages/jellyfish-oracle"
     },
     "@defichain/jellyfish-testing": {
       "version": "file:packages/jellyfish-testing",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "lint-staged": {
     "*.{ts,js}": [
-      "npm run lint"
+      "eslint --fix"
     ]
   },
   "size-limit": [

--- a/packages/jellyfish-api-core/__tests__/category/misc/setMockTime.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/misc/setMockTime.test.ts
@@ -1,4 +1,4 @@
-import { Block, Transaction } from '@defichain/jellyfish-api-core/category/blockchain'
+import { blockchain } from '@defichain/jellyfish-api-core'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 
@@ -15,7 +15,7 @@ describe('setMockTime', () => {
     await container.stop()
   })
 
-  async function getBlock (): Promise<Block<Transaction>> {
+  async function getBlock (): Promise<blockchain.Block<blockchain.Transaction>> {
     const count = await client.blockchain.getBlockCount()
     const hash = await client.blockchain.getBlockHash(count)
     return await client.blockchain.getBlock(hash, 2)

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/poolswap.test.ts
@@ -10,7 +10,7 @@ import {
   utxosToAccount
 } from '@defichain/testing'
 import { RpcApiError } from '../../../src'
-import { PoolSwapMetadata } from '@defichain/jellyfish-api-core/category/poolpair'
+import { poolpair } from '@defichain/jellyfish-api-core'
 import { Testing } from '@defichain/jellyfish-testing'
 
 describe('poolSwap', () => {
@@ -37,7 +37,7 @@ describe('poolSwap', () => {
     await testing.token.dfi({ amount: 700, address: dfiAddress })
     await testing.generate(1)
 
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: dfiAddress,
       tokenFrom: 'DFI',
       amountFrom: 555,
@@ -83,7 +83,7 @@ describe('poolSwap', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: dfiAddress,
       tokenFrom: 'DFI',
       amountFrom: 492,
@@ -121,7 +121,7 @@ describe('poolSwap', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: dfiAddress,
       tokenFrom: 'DFI',
       amountFrom: 492,
@@ -152,7 +152,7 @@ describe('poolSwap', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: dfiAddress,
       tokenFrom: 'DFI',
       amountFrom: 150,
@@ -184,7 +184,7 @@ describe('poolSwap', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: dfiAddress,
       amountFrom: 2,
       tokenFrom: 'DFI',
@@ -196,7 +196,7 @@ describe('poolSwap', () => {
 
   it('should not poolSwap with invalid token', async () => {
     const address = await getNewAddress(container)
-    const metadata: PoolSwapMetadata = {
+    const metadata: poolpair.PoolSwapMetadata = {
       from: address,
       amountFrom: 2,
       tokenFrom: 'INVALIDTOKEN',

--- a/packages/jellyfish-api-core/__tests__/category/poolpair/testpoolswap.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/poolpair/testpoolswap.test.ts
@@ -3,7 +3,7 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 import BigNumber from 'bignumber.js'
 import { addPoolLiquidity, createPoolPair, createToken, getNewAddress, mintTokens } from '@defichain/testing'
 import { RpcApiError } from '../../../src'
-import { PoolPairInfo, PoolPairsResult } from '@defichain/jellyfish-api-core/category/poolpair'
+import { poolpair } from '@defichain/jellyfish-api-core'
 
 describe('Poolpair', () => {
   const container = new MasterNodeRegTestContainer()
@@ -35,7 +35,7 @@ describe('Poolpair', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const poolpairResult: PoolPairsResult = await container.call('getpoolpair', ['CAT-DFI'])
+    const poolpairResult: poolpair.PoolPairsResult = await container.call('getpoolpair', ['CAT-DFI'])
     expect(Object.keys(poolpairResult).length).toStrictEqual(1)
 
     // Note(canonbrother): simulate poolswap calculation to find reserveB
@@ -45,7 +45,7 @@ describe('Poolpair', () => {
     // ? = 707.10678118^2 / 1666 = 300.120048014
     // 1666 : 300.120048014 = 707.10678118
     // 500 - 300.120048014 = 199.879951986  <-- testpoolswap returns
-    const poolpair: PoolPairInfo = Object.values(poolpairResult)[0]
+    const poolpair: poolpair.PoolPairInfo = Object.values(poolpairResult)[0]
     const reserveAAfter: BigNumber = new BigNumber(poolpair.reserveA).plus(666)
     const reserveBAfter: BigNumber = new BigNumber(poolpair.totalLiquidity).pow(2).div(reserveAAfter)
 
@@ -142,7 +142,7 @@ describe('Poolpair', () => {
       shareAddress: poolLiquidityAddress
     })
 
-    const poolpairResultBefore: PoolPairsResult = await container.call('getpoolpair', ['DOG-DFI'])
+    const poolpairResultBefore: poolpair.PoolPairsResult = await container.call('getpoolpair', ['DOG-DFI'])
     expect(Object.keys(poolpairResultBefore).length).toStrictEqual(1)
 
     await client.poolpair.testPoolSwap({
@@ -153,7 +153,7 @@ describe('Poolpair', () => {
       tokenTo: 'DFI'
     })
 
-    const poolpairResultAfter: PoolPairsResult = await container.call('getpoolpair', ['DOG-DFI'])
+    const poolpairResultAfter: poolpair.PoolPairsResult = await container.call('getpoolpair', ['DOG-DFI'])
     expect(Object.keys(poolpairResultAfter).length).toStrictEqual(1)
 
     expect(poolpairResultBefore).toStrictEqual(poolpairResultAfter)

--- a/packages/jellyfish-api-core/__tests__/category/rawtx/getRawTransaction.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/rawtx/getRawTransaction.test.ts
@@ -1,4 +1,3 @@
-import { RawTransaction } from '@defichain/jellyfish-api-core/category/rawtx'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import { RpcApiError } from '../../../src'
@@ -35,7 +34,7 @@ describe('RawTransaction', () => {
   it('should getRawTransaction with verbose true to get informative json object', async () => {
     const txid = await createToken('ANT')
 
-    const data: RawTransaction = await client.rawtx.getRawTransaction(txid, true)
+    const data = await client.rawtx.getRawTransaction(txid, true)
     expect(typeof data.txid).toStrictEqual('string')
     expect(typeof data.hash).toStrictEqual('string')
     expect(typeof data.version).toStrictEqual('number')
@@ -73,7 +72,7 @@ describe('RawTransaction', () => {
 
     const count = await container.call('getblockcount')
     const hash = await container.call('getblockhash', [count])
-    const data: RawTransaction = await client.rawtx.getRawTransaction(txid, true, hash)
+    const data = await client.rawtx.getRawTransaction(txid, true, hash)
     expect(typeof data.in_active_chain).toStrictEqual('boolean')
     expect(typeof data.txid).toStrictEqual('string')
     expect(typeof data.hash).toStrictEqual('string')

--- a/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
@@ -1,4 +1,4 @@
-import { CreateAnchorResult } from '@defichain/jellyfish-api-core/category/spv'
+import { spv } from '@defichain/jellyfish-api-core'
 import { TestingGroup } from '@defichain/jellyfish-testing'
 import { GenesisKeys } from '@defichain/testcontainers'
 
@@ -96,7 +96,7 @@ describe('Spv', () => {
     await tGroup.get(0).container.call('spv_setlastheight', [6])
   }
 
-  async function createAnchor (): Promise<CreateAnchorResult> {
+  async function createAnchor (): Promise<spv.CreateAnchorResult> {
     const rewardAddress = await tGroup.get(0).rpc.spv.getNewAddress()
     return await tGroup.get(0).rpc.spv.createAnchor([{
       txid: '11a276bb25585f6973a4dd68373cffff41dbcaddf12bbc1c2b489d1dc84564ee',

--- a/packages/jellyfish-oracle/README.md
+++ b/packages/jellyfish-oracle/README.md
@@ -1,0 +1,5 @@
+[![npm](https://img.shields.io/npm/v/@defichain/jellyfish-oracle)](https://www.npmjs.com/package/@defichain/jellyfish-oracle/v/latest)
+
+# @defichain/jellyfish-oracle
+
+DeFiChain oracle provider, adapter, publisher adapter core.

--- a/packages/jellyfish-oracle/package.json
+++ b/packages/jellyfish-oracle/package.json
@@ -1,0 +1,40 @@
+{
+  "private": false,
+  "name": "@defichain/jellyfish-oracle",
+  "version": "0.0.0",
+  "description": "A collection of TypeScript + JavaScript tools and libraries for DeFi Blockchain developers to build decentralized finance for Bitcoin",
+  "keywords": [
+    "DeFiChain",
+    "DeFi",
+    "Blockchain",
+    "API",
+    "Bitcoin"
+  ],
+  "repository": "DeFiCh/jellyfish",
+  "bugs": "https://github.com/DeFiCh/jellyfish/issues",
+  "license": "MIT",
+  "contributors": [
+    {
+      "name": "DeFiChain Foundation",
+      "email": "engineering@defichain.com",
+      "url": "https://defichain.com/"
+    },
+    {
+      "name": "DeFi Blockchain Contributors"
+    },
+    {
+      "name": "DeFi Jellyfish Contributors"
+    }
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b ./tsconfig.build.json"
+  },
+  "dependencies": {
+
+  }
+}

--- a/packages/jellyfish-oracle/tsconfig.build.json
+++ b/packages/jellyfish-oracle/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  }
+}

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_claim_dfc_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_claim_dfc_htlc.test.ts
@@ -4,9 +4,7 @@ import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
-import { OP_CODES } from '@defichain/jellyfish-transaction'
-import { ICXClaimDFCHTLC } from '@defichain/jellyfish-transaction/script/dftx/dftx_icxorderbook'
-import { ICXClaimDFCHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
+import { ICXClaimDFCHTLC, OP_CODES } from '@defichain/jellyfish-transaction'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
 import { Testing } from '@defichain/jellyfish-testing'
 import { RegTest } from '@defichain/jellyfish-network'
@@ -113,7 +111,7 @@ describe('claim DFC HTLC', () => {
     await testing.generate(1)
 
     // List htlc and check
-    const listHTLCOptions: ICXListHTLCOptions = {
+    const listHTLCOptions: icxorderbook.ICXListHTLCOptions = {
       offerTx: makeOfferTxId,
       closed: true
     }
@@ -122,7 +120,7 @@ describe('claim DFC HTLC', () => {
     const claimTxId = calculateTxid(txn)
     if (HTLCs[claimTxId].type === icxorderbook.ICXHTLCType.CLAIM_DFC) {
       // ICXClaimDFCHTLCInfo cast
-      const ClaimHTLCInfo: ICXClaimDFCHTLCInfo = HTLCs[claimTxId] as ICXClaimDFCHTLCInfo
+      const ClaimHTLCInfo: icxorderbook.ICXClaimDFCHTLCInfo = HTLCs[claimTxId] as icxorderbook.ICXClaimDFCHTLCInfo
       expect(ClaimHTLCInfo.dfchtlcTx).toStrictEqual(DFCHTLCTxId)
       expect(ClaimHTLCInfo.seed).toStrictEqual('f75a61ad8f7a6e0ab701d5be1f5d4523a9b534571e4e92e0c4610c6a6784ccef')
     }

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_dfc_htlc.test.ts
@@ -4,9 +4,7 @@ import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
-import { OP_CODES } from '@defichain/jellyfish-transaction'
-import { ICXSubmitDFCHTLC } from '@defichain/jellyfish-transaction/script/dftx/dftx_icxorderbook'
-import { ICXDFCHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
+import { ICXSubmitDFCHTLC, OP_CODES } from '@defichain/jellyfish-transaction'
 import { Testing } from '@defichain/jellyfish-testing'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
 import { RegTest } from '@defichain/jellyfish-network'
@@ -31,8 +29,14 @@ describe('submit DFC HTLC', () => {
     await testing.rpc.account.utxosToAccount({ [testing.icxorderbook.accountBTC]: `${10}@${testing.icxorderbook.symbolDFI}` }) // for fee
     await testing.generate(1)
     await testing.fixture.createPoolPair({
-      a: { amount: '1', symbol: testing.icxorderbook.symbolBTC },
-      b: { amount: '100', symbol: testing.icxorderbook.symbolDFI }
+      a: {
+        amount: '1',
+        symbol: testing.icxorderbook.symbolBTC
+      },
+      b: {
+        amount: '100',
+        symbol: testing.icxorderbook.symbolDFI
+      }
     })
     testing.icxorderbook.DEX_DFI_PER_BTC_RATE = new BigNumber(100 / 1)
     await testing.icxorderbook.setTakerFee(new BigNumber(0.001))
@@ -56,7 +60,10 @@ describe('submit DFC HTLC', () => {
       amountFrom: new BigNumber(15),
       orderPrice: new BigNumber(0.01)
     }
-    const { order, createOrderTxId } = await testing.icxorderbook.createDFISellOrder(createOrder)
+    const {
+      order,
+      createOrderTxId
+    } = await testing.icxorderbook.createDFISellOrder(createOrder)
 
     const makeOffer = {
       orderTx: createOrderTxId,
@@ -97,13 +104,13 @@ describe('submit DFC HTLC', () => {
     await testing.generate(1)
 
     // List htlc and check
-    const listHTLCOptions: ICXListHTLCOptions = {
+    const listHTLCOptions: icxorderbook.ICXListHTLCOptions = {
       offerTx: makeOfferTxId
     }
     const HTLCs = await testing.rpc.icxorderbook.listHTLCs(listHTLCOptions)
     expect(Object.keys(HTLCs).length).toStrictEqual(2) // extra entry for the warning text returned by the RPC atm.
     const DFCHTLCTxId = calculateTxid(txn)
-    expect(HTLCs[DFCHTLCTxId] as ICXDFCHTLCInfo).toStrictEqual(
+    expect(HTLCs[DFCHTLCTxId] as icxorderbook.ICXDFCHTLCInfo).toStrictEqual(
       {
         type: icxorderbook.ICXHTLCType.DFC,
         status: icxorderbook.ICXHTLCStatus.OPEN,

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_submit_ext_htlc.test.ts
@@ -4,9 +4,7 @@ import { P2WPKHTransactionBuilder } from '../../src'
 import { calculateTxid, sendTransaction } from '../test.utils'
 import { WIF } from '@defichain/jellyfish-crypto'
 import BigNumber from 'bignumber.js'
-import { OP_CODES } from '@defichain/jellyfish-transaction'
-import { ICXSubmitEXTHTLC } from '@defichain/jellyfish-transaction/script/dftx/dftx_icxorderbook'
-import { ICXEXTHTLCInfo, ICXListHTLCOptions } from '@defichain/jellyfish-api-core/category/icxorderbook'
+import { ICXSubmitEXTHTLC, OP_CODES } from '@defichain/jellyfish-transaction'
 import { Testing } from '@defichain/jellyfish-testing'
 import { icxorderbook } from '@defichain/jellyfish-api-core'
 import { RegTest } from '@defichain/jellyfish-network'
@@ -107,13 +105,13 @@ describe('submit EXT HTLC', () => {
     await testing.generate(1)
 
     // List htlc and check
-    const listHTLCOptions: ICXListHTLCOptions = {
+    const listHTLCOptions: icxorderbook.ICXListHTLCOptions = {
       offerTx: makeOfferTxId
     }
     const HTLCs = await testing.rpc.icxorderbook.listHTLCs(listHTLCOptions)
     expect(Object.keys(HTLCs).length).toStrictEqual(3) // extra entry for the warning text returned by the RPC atm.
     const EXTHTLCTxId = calculateTxid(txn)
-    expect(HTLCs[EXTHTLCTxId] as ICXEXTHTLCInfo).toStrictEqual(
+    expect(HTLCs[EXTHTLCTxId] as icxorderbook.ICXEXTHTLCInfo).toStrictEqual(
       {
         type: icxorderbook.ICXHTLCType.EXTERNAL,
         status: icxorderbook.ICXHTLCStatus.OPEN,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,8 @@
 {
   "compilerOptions": {
-    "lib": ["es2020"],
+    "lib": [
+      "es2020"
+    ],
     "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,7 +4,7 @@
     "composite": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
+    "sourceMap": true
   },
   "files": [],
   "references": [
@@ -15,6 +15,7 @@
     {"path": "./packages/jellyfish-crypto/tsconfig.build.json"},
     {"path": "./packages/jellyfish-json/tsconfig.build.json"},
     {"path": "./packages/jellyfish-network/tsconfig.build.json"},
+    {"path": "./packages/jellyfish-oracle/tsconfig.build.json"},
     {"path": "./packages/jellyfish-testing/tsconfig.build.json"},
     {"path": "./packages/jellyfish-transaction/tsconfig.build.json"},
     {"path": "./packages/jellyfish-transaction-builder/tsconfig.build.json"},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
       "@defichain/jellyfish-crypto": ["jellyfish-crypto/src"],
       "@defichain/jellyfish-json": ["jellyfish-json/src"],
       "@defichain/jellyfish-network": ["jellyfish-network/src"],
+      "@defichain/jellyfish-oracle": ["jellyfish-oracle/src"],
       "@defichain/jellyfish-testing": ["jellyfish-testing/src"],
       "@defichain/jellyfish-transaction": ["jellyfish-transaction/src"],
       "@defichain/jellyfish-transaction-builder": ["jellyfish-transaction-builder/src"],
@@ -20,24 +21,6 @@
       "@defichain/jellyfish-wallet-mnemonic": ["jellyfish-wallet-mnemonic/src"],
       "@defichain/testcontainers": ["testcontainers/src"],
       "@defichain/testing": ["testing/src"],
-
-      "@defichain/jellyfish-address/*": ["jellyfish-address/src/*"],
-      "@defichain/jellyfish-api-core/*": ["jellyfish-api-core/src/*"],
-      "@defichain/jellyfish-api-jsonrpc/*": ["jellyfish-api-jsonrpc/src/*"],
-      "@defichain/jellyfish-buffer/*": ["jellyfish-buffer/src/*"],
-      "@defichain/jellyfish-crypto/*": ["jellyfish-crypto/src/*"],
-      "@defichain/jellyfish-json/*": ["jellyfish-json/src/*"],
-      "@defichain/jellyfish-network/*": ["jellyfish-network/src/*"],
-      "@defichain/jellyfish-testing/*": ["jellyfish-testing/src/*"],
-      "@defichain/jellyfish-transaction/*": ["jellyfish-transaction/src/*"],
-      "@defichain/jellyfish-transaction-builder/*": ["jellyfish-transaction-builder/src/*"],
-      "@defichain/jellyfish-transaction-signature/*": ["jellyfish-transaction-signature/src/*"],
-      "@defichain/jellyfish-wallet/*": ["jellyfish-wallet/src/*"],
-      "@defichain/jellyfish-wallet-classic/*": ["jellyfish-wallet-classic/src/*"],
-      "@defichain/jellyfish-wallet-encrypted/*": ["jellyfish-wallet-encrypted/src/*"],
-      "@defichain/jellyfish-wallet-mnemonic/*": ["jellyfish-wallet-mnemonic/src/*"],
-      "@defichain/testcontainers/*": ["testcontainers/src/*"],
-      "@defichain/testing/*": ["testing/src/*"],
     }
   }
 }

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -24,9 +24,8 @@ maintained in this repo are published with the same version tag and follows the 
 
 [![npm](https://img.shields.io/npm/v/@defichain/jellyfish)](https://www.npmjs.com/package/@defichain/jellyfish/v/latest)
 
-Package                                            | Description 
+Package                                            | Description
 ---------------------------------------------------|-------------
-`@defichain/jellyfish`                             | Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts
 `@defichain/jellyfish-address`                     | Provide address builder, parser, validator utility library for DeFi Blockchain.
 `@defichain/jellyfish-api-core`                    | A protocol agnostic DeFi Blockchain client interfaces, with a "foreign function interface" design.
 `@defichain/jellyfish-api-jsonrpc`                 | Implements the [JSON-RPC 1.0](https://www.jsonrpc.org/specification_v1) specification for api-core.
@@ -35,6 +34,7 @@ Package                                            | Description
 `@defichain/jellyfish-json`                        | Allows parsing of JSON with 'lossless', 'bignumber' and 'number' numeric precision.
 `@defichain/jellyfish-network`                     | Contains DeFi Blockchain various network configuration for mainnet, testnet and regtest.
 `@defichain/jellyfish-testing`                     | Provides many abstractions for various commonly used setup pattern for DeFi Blockchain.
+`@defichain/jellyfish-oracle`                      | DeFiChain oracle adapter core
 `@defichain/jellyfish-transaction`                 | Dead simple modern stateless raw transaction composer for the DeFi Blockchain.
 `@defichain/jellyfish-transaction-builder`         | Provides a high-high level abstraction for constructing transaction ready to be broadcast for DeFi Blockchain.
 `@defichain/jellyfish-transaction-signature`       | Stateless utility library to perform transaction signing.
@@ -43,4 +43,5 @@ Package                                            | Description
 `@defichain/jellyfish-wallet-encrypted`            | Library to encrypt MnemonicHdNode as EncryptedMnemonicHdNode. Able to perform as MnemonicHdNode with passphrase known.
 `@defichain/jellyfish-wallet-mnemonic`             | MnemonicHdNode implements the WalletHdNode from jellyfish-wallet; a CoinType-agnostic HD Wallet for noncustodial DeFi.
 `@defichain/testcontainers`                        | Provides a lightweight, throw away instances for DeFiD node provisioned automatically in a Docker container.
-~~@defichain/testing~~                             | Provides rich test fixture setup functions for effective and effortless testing.
+~~@defichain/jellyfish~~                           | (deprecated) ~~Library bundled usage entrypoint with conventional defaults for 4 bundles: umd, esm, cjs and d.ts~~
+~~@defichain/testing~~                             | (deprecated) ~~Provides rich test fixture setup functions for effective and effortless testing.~~


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

This commit set up the governance automation for jellyfish-oracle; the DeFiChain oracle provider, adapter, publisher adapter core. 

This project provides an "adapter core" with templating code for DeFiChain oracles. Implementors of the adapter just has to provide a price feed through the `PriceProvider` function.

`PriceProvider` maps prices into an `Adapter | Mapper` via a chain of responsibility design and publish to DeFiChain.



