### PR TITLE
Changes priceFeedId value from oracle txid to token/currency pair

### DIFF
--- a/packages/jellyfish-api-core/__tests__/category/loan/getCollateralToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/getCollateralToken.test.ts
@@ -93,7 +93,6 @@ describe('Loan getCollateralToken with parameters token or height', () => {
   const testing = Testing.create(container)
 
   let collateralTokenId: string
-  let priceFeedId: string
 
   beforeAll(async () => {
     await testing.container.start()
@@ -102,7 +101,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -111,7 +110,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
     collateralTokenId = await testing.container.call('setcollateraltoken', [{
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: 'AAPL/USD',
       activateAfterBlock: 120
     }])
     await testing.generate(1)
@@ -131,7 +130,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
         [collateralTokenId]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: new BigNumber(120)
         }
       })
@@ -162,7 +161,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
         [collateralTokenId]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: new BigNumber(120)
         }
       })
@@ -189,7 +188,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
           [collateralTokenId]: {
             token: 'AAPL',
             factor: new BigNumber(0.5),
-            priceFeedId,
+            priceFeedId: 'AAPL/USD',
             activateAfterBlock: new BigNumber(120)
           }
         })
@@ -206,7 +205,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
         [collateralTokenId]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: new BigNumber(120)
         }
       })
@@ -223,7 +222,7 @@ describe('Loan getCollateralToken with parameters token or height', () => {
         [collateralTokenId]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: new BigNumber(120)
         }
       })

--- a/packages/jellyfish-api-core/__tests__/category/loan/getCollateralToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/getCollateralToken.test.ts
@@ -19,7 +19,7 @@ describe('Loan getCollateralToken', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    const priceFeedId1 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -28,7 +28,7 @@ describe('Loan getCollateralToken', () => {
     const collateralTokenId1 = await testing.container.call('setcollateraltoken', [{
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId: priceFeedId1
+      priceFeedId: 'AAPL/USD'
     }]) // Activate at next block
     await testing.generate(1)
     const blockCount = new BigNumber(await testing.container.getBlockCount())
@@ -36,7 +36,7 @@ describe('Loan getCollateralToken', () => {
     await testing.token.create({ symbol: 'TSLA' })
     await testing.generate(1)
 
-    const priceFeedId2 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'TSLA',
       currency: 'USD'
     }], 1])
@@ -45,7 +45,7 @@ describe('Loan getCollateralToken', () => {
     const collateralTokenId2 = await testing.container.call('setcollateraltoken', [{
       token: 'TSLA',
       factor: new BigNumber(1),
-      priceFeedId: priceFeedId2,
+      priceFeedId: 'TSLA/USD',
       activateAfterBlock: 120
     }])
     await testing.generate(1)
@@ -57,7 +57,7 @@ describe('Loan getCollateralToken', () => {
         [collateralTokenId1]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId: priceFeedId1,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: blockCount
         }
       })
@@ -73,13 +73,13 @@ describe('Loan getCollateralToken', () => {
         [collateralTokenId1]: {
           token: 'AAPL',
           factor: new BigNumber(0.5),
-          priceFeedId: priceFeedId1,
+          priceFeedId: 'AAPL/USD',
           activateAfterBlock: blockCount
         },
         [collateralTokenId2]: {
           token: 'TSLA',
           factor: new BigNumber(1),
-          priceFeedId: priceFeedId2,
+          priceFeedId: 'TSLA/USD',
           activateAfterBlock: new BigNumber(120)
         }
       }

--- a/packages/jellyfish-api-core/__tests__/category/loan/listCollateralTokens.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listCollateralTokens.test.ts
@@ -25,13 +25,13 @@ describe('Loan listCollateralTokens', () => {
     await testing.token.create({ symbol: 'TSLA' })
     await testing.generate(1)
 
-    const priceFeedId1 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
-    const priceFeedId2 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'TSLA',
       currency: 'USD'
     }], 1])
@@ -44,14 +44,14 @@ describe('Loan listCollateralTokens', () => {
     const collateralTokenId1 = await testing.container.call('setcollateraltoken', [{
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId: priceFeedId1
+      priceFeedId: 'AAPL/USD'
     }])
     await testing.generate(1)
 
     const collateralTokenId2 = await testing.container.call('setcollateraltoken', [{
       token: 'TSLA',
       factor: new BigNumber(1),
-      priceFeedId: priceFeedId2,
+      priceFeedId: 'TSLA/USD',
       activateAfterBlock: 130
     }])
     await testing.generate(1)
@@ -59,8 +59,8 @@ describe('Loan listCollateralTokens', () => {
     const data = await testing.rpc.loan.listCollateralTokens()
     expect(data).toStrictEqual({
       // activateAfterBlock = 122, which is the next block after setcollateraltoken executed
-      [collateralTokenId1]: { activateAfterBlock: new BigNumber(122), factor: new BigNumber(0.5), priceFeedId: priceFeedId1, token: 'AAPL' },
-      [collateralTokenId2]: { activateAfterBlock: new BigNumber(130), factor: new BigNumber(1), priceFeedId: priceFeedId2, token: 'TSLA' }
+      [collateralTokenId1]: { activateAfterBlock: new BigNumber(122), factor: new BigNumber(0.5), priceFeedId: 'AAPL/USD', token: 'AAPL' },
+      [collateralTokenId2]: { activateAfterBlock: new BigNumber(130), factor: new BigNumber(1), priceFeedId: 'TSLA/USD', token: 'TSLA' }
     })
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/loan/listLoanTokens.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listLoanTokens.test.ts
@@ -21,7 +21,7 @@ describe('Loan', () => {
       expect(data).toStrictEqual({})
     }
 
-    const priceFeedId1 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -30,7 +30,7 @@ describe('Loan', () => {
     const loanTokenId1 = await testing.container.call('setloantoken', [{
       symbol: 'AAPL',
       name: 'APPLE',
-      priceFeedId: priceFeedId1,
+      priceFeedId: 'AAPL/USD',
       mintable: true,
       interest: new BigNumber(0.01)
     }])
@@ -38,7 +38,7 @@ describe('Loan', () => {
 
     const height1 = new BigNumber(await testing.container.getBlockCount())
 
-    const priceFeedId2 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'TSLA',
       currency: 'USD'
     }], 1])
@@ -47,7 +47,7 @@ describe('Loan', () => {
     const loanTokenId2 = await testing.container.call('setloantoken', [{
       symbol: 'TSLA',
       name: 'TESLA',
-      priceFeedId: priceFeedId2,
+      priceFeedId: 'TSLA/USD',
       mintable: false,
       interest: new BigNumber(0.02)
     }])
@@ -80,7 +80,7 @@ describe('Loan', () => {
               tradeable: true
             }
           },
-          priceFeedId: priceFeedId1,
+          priceFeedId: 'AAPL/USD',
           interest: new BigNumber(0.01)
         },
         [loanTokenId2]: {
@@ -105,7 +105,7 @@ describe('Loan', () => {
               tradeable: true
             }
           },
-          priceFeedId: priceFeedId2,
+          priceFeedId: 'TSLA/USD',
           interest: new BigNumber(0.02)
         }
       }

--- a/packages/jellyfish-api-core/__tests__/category/loan/loan_container.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/loan_container.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer, StartOptions } from '@defichain/testcontain
 
 export class LoanMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor () {
-    super(undefined, 'defi/defichain:HEAD-2689214')
+    super(undefined, 'defi/defichain:HEAD-fffc8dd')
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/jellyfish-api-core/__tests__/category/loan/loan_container.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/loan_container.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer, StartOptions } from '@defichain/testcontain
 
 export class LoanMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor () {
-    super(undefined, 'defi/defichain:HEAD-3882db7')
+    super(undefined, 'defi/defichain:HEAD-2689214')
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
@@ -61,7 +61,7 @@ describe('Loan setCollateralToken', () => {
     await expect(promise).rejects.toThrow('RpcApiError: \'Amount out of range\', code: -3, method: setcollateraltoken')
   })
 
-  it('should not setCollateralToken if oracleId does not exist', async () => {
+  it('should not setCollateralToken if priceFeedId does not belong to any oracle', async () => {
     const promise = testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),

--- a/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
@@ -7,8 +7,6 @@ describe('Loan setCollateralToken', () => {
   const container = new LoanMasterNodeRegTestContainer()
   const testing = Testing.create(container)
 
-  let priceFeedId: string
-
   beforeAll(async () => {
     await testing.container.start()
     await testing.container.waitForWalletCoinbaseMaturity()
@@ -16,7 +14,7 @@ describe('Loan setCollateralToken', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -31,7 +29,7 @@ describe('Loan setCollateralToken', () => {
     const collateralTokenId = await testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId
+      priceFeedId: 'AAPL/USD'
     })
     expect(typeof collateralTokenId).toStrictEqual('string')
     expect(collateralTokenId.length).toStrictEqual(64)
@@ -42,52 +40,61 @@ describe('Loan setCollateralToken', () => {
       [collateralTokenId]: {
         token: 'AAPL',
         factor: 0.5,
-        priceFeedId,
+        priceFeedId: 'AAPL/USD',
         activateAfterBlock: await testing.container.getBlockCount()
       }
     })
   })
 
   it('should not setCollateralToken if token does not exist', async () => {
-    const promise = testing.rpc.loan.setCollateralToken({ token: 'TSLA', factor: new BigNumber(0.5), priceFeedId })
+    const promise = testing.rpc.loan.setCollateralToken({ token: 'TSLA', factor: new BigNumber(0.5), priceFeedId: 'AAPL/USD' })
     await expect(promise).rejects.toThrow('RpcApiError: \'Token TSLA does not exist!\', code: -8, method: setcollateraltoken')
   })
 
   it('should not setCollateralToken if factor is greater than 1', async () => {
-    const promise = testing.rpc.loan.setCollateralToken({ token: 'AAPL', factor: new BigNumber(1.01), priceFeedId })
+    const promise = testing.rpc.loan.setCollateralToken({ token: 'AAPL', factor: new BigNumber(1.01), priceFeedId: 'AAPL/USD' })
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nsetCollateralToken factor must be lower or equal than 1.00000000!\', code: -32600, method: setcollateraltoken')
   })
 
   it('should not setCollateralToken if factor is less than 0', async () => {
-    const promise = testing.rpc.loan.setCollateralToken({ token: 'AAPL', factor: new BigNumber(-0.01), priceFeedId })
+    const promise = testing.rpc.loan.setCollateralToken({ token: 'AAPL', factor: new BigNumber(-0.01), priceFeedId: 'AAPL/USD' })
     await expect(promise).rejects.toThrow('RpcApiError: \'Amount out of range\', code: -3, method: setcollateraltoken')
-  })
-
-  it('should not setCollateralToken if oracle does not contain USD price', async () => {
-    await testing.token.create({ symbol: 'TSLA' })
-    await testing.generate(1)
-
-    const priceFeedId: string = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'TSLA',
-      currency: 'SGD'
-    }], 1])
-    await testing.generate(1)
-
-    const promise = testing.rpc.loan.setCollateralToken({
-      token: 'TSLA',
-      factor: new BigNumber(0.5),
-      priceFeedId
-    })
-    await expect(promise).rejects.toThrow(`RpcApiError: 'Test LoanSetCollateralTokenTx execution failed:\noracle (${priceFeedId}) does not contain USD price for this token!', code: -32600, method: setcollateraltoken`)
   })
 
   it('should not setCollateralToken if oracleId does not exist', async () => {
     const promise = testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId: '944d7ce67a0bd6d18e7ba7cbd3ec12ac81a13aa92876cb697ec0b33bf50652f5'
+      priceFeedId: 'MFST/USD'
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\noracle (944d7ce67a0bd6d18e7ba7cbd3ec12ac81a13aa92876cb697ec0b33bf50652f5) does not exist!\', code: -32600, method: setcollateraltoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nPrice feed MFST/USD does not belong to any oracle\', code: -32600, method: setcollateraltoken')
+  })
+
+  it('should not setLoanToken if priceFeedId is not in correct format', async () => {
+    const promise = testing.rpc.loan.setCollateralToken({
+      token: 'AAPL',
+      factor: new BigNumber(0.5),
+      priceFeedId: 'X'
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'price feed not in valid format - token/currency!\', code: -8, method: setcollateraltoken')
+  })
+
+  it('should not setLoanToken if priceFeedId is an empty string', async () => {
+    const promise = testing.rpc.loan.setCollateralToken({
+      token: 'AAPL',
+      factor: new BigNumber(0.5),
+      priceFeedId: ''
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid parameters, argument "priceFeedId" must be non-null\', code: -8, method: setcollateraltoken')
+  })
+
+  it('should not setLoanToken if token/currency of priceFeedId contains empty string', async () => {
+    const promise = testing.rpc.loan.setCollateralToken({
+      token: 'AAPL',
+      factor: new BigNumber(0.5),
+      priceFeedId: '/'
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'token/currency contains empty string\', code: -8, method: setcollateraltoken')
   })
 
   it('should setCollateralToken with utxos', async () => {
@@ -95,7 +102,7 @@ describe('Loan setCollateralToken', () => {
     const collateralTokenId = await testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId
+      priceFeedId: 'AAPL/USD'
     }, [{ txid, vout }])
     expect(typeof collateralTokenId).toStrictEqual('string')
     expect(collateralTokenId.length).toStrictEqual(64)
@@ -110,7 +117,7 @@ describe('Loan setCollateralToken', () => {
       [collateralTokenId]: {
         token: 'AAPL',
         factor: 0.5,
-        priceFeedId,
+        priceFeedId: 'AAPL/USD',
         activateAfterBlock: await testing.container.getBlockCount()
       }
     })
@@ -121,7 +128,7 @@ describe('Loan setCollateralToken', () => {
     const promise = testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId
+      priceFeedId: 'AAPL/USD'
     }, [utxo])
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setcollateraltoken')
   })
@@ -144,7 +151,7 @@ describe('Loan setCollateralToken with activateAfterBlock', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -157,7 +164,7 @@ describe('Loan setCollateralToken with activateAfterBlock', () => {
     const collateralTokenId = await testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: 'AAPL/USD',
       activateAfterBlock: 120
     })
     expect(typeof collateralTokenId).toStrictEqual('string')
@@ -169,7 +176,7 @@ describe('Loan setCollateralToken with activateAfterBlock', () => {
       [collateralTokenId]: {
         token: 'AAPL',
         factor: 0.5,
-        priceFeedId,
+        priceFeedId: 'AAPL/USD',
         activateAfterBlock: 120
       }
     })
@@ -193,7 +200,7 @@ describe('Loan setCollateralToken with activateAfterBlock less than the current 
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -206,7 +213,7 @@ describe('Loan setCollateralToken with activateAfterBlock less than the current 
     const promise = testing.rpc.loan.setCollateralToken({
       token: 'AAPL',
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: 'AAPL/USD',
       activateAfterBlock: 109
     })
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nactivateAfterBlock cannot be less than current height!\', code: -32600, method: setcollateraltoken')

--- a/packages/jellyfish-api-core/__tests__/category/loan/setLoanToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/setLoanToken.test.ts
@@ -17,7 +17,7 @@ describe('Loan', () => {
   })
 
   it('should setLoanToken', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token1',
       currency: 'USD'
     }], 1])
@@ -25,7 +25,7 @@ describe('Loan', () => {
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
       symbol: 'Token1',
-      priceFeedId
+      priceFeedId: 'Token1/USD'
     })
     expect(typeof loanTokenId).toStrictEqual('string')
     expect(loanTokenId.length).toStrictEqual(64)
@@ -55,14 +55,14 @@ describe('Loan', () => {
             collateralAddress: expect.any(String)
           }
         },
-        priceFeedId,
+        priceFeedId: 'Token1/USD',
         interest: 0
       }
     })
   })
 
   it('should setLoanToken if symbol is more than 8 letters', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'x'.repeat(8),
       currency: 'USD'
     }], 1])
@@ -70,7 +70,7 @@ describe('Loan', () => {
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
       symbol: 'x'.repeat(9), // 9 letters
-      priceFeedId
+      priceFeedId: 'Token1/USD'
     })
     await testing.generate(1)
 
@@ -80,7 +80,7 @@ describe('Loan', () => {
   })
 
   it('should not setLoanToken if symbol is an empty string', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token2',
       currency: 'USD'
     }], 1])
@@ -88,13 +88,13 @@ describe('Loan', () => {
 
     const promise = testing.rpc.loan.setLoanToken({
       symbol: '',
-      priceFeedId
+      priceFeedId: 'Token2/USD'
     })
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntoken symbol should be non-empty and starts with a letter\', code: -32600, method: setloantoken')
   })
 
   it('should not setLoanToken if token with same symbol was created before', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token3',
       currency: 'USD'
     }], 1])
@@ -102,50 +102,60 @@ describe('Loan', () => {
 
     await testing.rpc.loan.setLoanToken({
       symbol: 'Token3',
-      priceFeedId
+      priceFeedId: 'Token3/USD'
     })
     await testing.generate(1)
 
     const promise = testing.rpc.loan.setLoanToken({
       symbol: 'Token3',
-      priceFeedId
+      priceFeedId: 'Token3/USD'
     })
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntoken \'Token3\' already exists!\', code: -32600, method: setloantoken')
   })
 
-  it('should not setLoanToken if priceFeedId does not contain USD price', async () => {
-    const priceFeedId: string = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token4',
-      currency: 'Token4'
-    }], 1])
-    await testing.generate(1)
-
+  it('should not setLoanToken if priceFeedId does not belong to any oracle', async () => {
     const promise = testing.rpc.loan.setLoanToken({
       symbol: 'Token4',
-      priceFeedId
+      priceFeedId: 'Token4/USD'
     })
-    await expect(promise).rejects.toThrow(`RpcApiError: 'Test LoanSetLoanTokenTx execution failed:\noracle (${priceFeedId}) does not contain USD price for this token!', code: -32600, method: setloantoken`)
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\nPrice feed Token4/USD does not belong to any oracle\', code: -32600, method: setloantoken')
   })
 
-  it('should not setLoanToken if priceFeedId is invalid', async () => {
+  it('should not setLoanToken if priceFeedId is not in correct format', async () => {
     const promise = testing.rpc.loan.setLoanToken({
       symbol: 'Token5',
-      priceFeedId: 'e40775f8bb396cd3d94429843453e66e68b1c7625d99b0b4c505ab004506697b'
+      priceFeedId: 'X'// Must be in token/currency format
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\noracle (e40775f8bb396cd3d94429843453e66e68b1c7625d99b0b4c505ab004506697b) does not exist or not valid oracle!\', code: -32600, method: setloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'price feed not in valid format - token/currency!\', code: -8, method: setloantoken')
+  })
+
+  it('should not setLoanToken if priceFeedId is an empty string', async () => {
+    const promise = testing.rpc.loan.setLoanToken({
+      symbol: 'Token6',
+      priceFeedId: ''
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid parameters, argument "priceFeedId" must be non-null\', code: -8, method: setloantoken')
+  })
+
+  it('should not setLoanToken if token/currency of priceFeedId contains empty string', async () => {
+    const promise = testing.rpc.loan.setLoanToken({
+      symbol: 'Token7',
+      priceFeedId: '/'
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'token/currency contains empty string\', code: -8, method: setloantoken')
   })
 
   it('should setLoanToken with the given name', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token6',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token8',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token6',
+      symbol: 'Token8',
       name: '',
-      priceFeedId
+      priceFeedId: 'Token8/USD'
     })
     await testing.generate(1)
 
@@ -155,16 +165,16 @@ describe('Loan', () => {
   })
 
   it('should setLoanToken if name is more than 128 letters', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token7',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token9',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token7',
+      symbol: 'Token9',
       name: 'x'.repeat(129), // 129 letters
-      priceFeedId
+      priceFeedId: 'Token9/USD'
     })
     await testing.generate(1)
 
@@ -174,29 +184,29 @@ describe('Loan', () => {
   })
 
   it('should setLoanToken if two loan tokens have the same name', async () => {
-    const priceFeedId1 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token8',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token10',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     await testing.rpc.loan.setLoanToken({
-      symbol: 'Token8',
+      symbol: 'Token10',
       name: 'TokenX',
-      priceFeedId: priceFeedId1
+      priceFeedId: 'Token10/USD'
     })
     await testing.generate(1)
 
-    const priceFeedId2 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token9',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token11',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token9',
+      symbol: 'Token11',
       name: 'TokenX',
-      priceFeedId: priceFeedId2
+      priceFeedId: 'Token11/USD'
     })
     await testing.generate(1)
 
@@ -206,15 +216,15 @@ describe('Loan', () => {
   })
 
   it('should setLoanToken if mintable is false', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token10',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token12',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token10',
-      priceFeedId,
+      symbol: 'Token12',
+      priceFeedId: 'Token12/USD',
       mintable: false
     })
     expect(typeof loanTokenId).toStrictEqual('string')
@@ -223,15 +233,15 @@ describe('Loan', () => {
   })
 
   it('should setLoanToken if interest number is greater than 0 and has less than 9 digits in the fractional part', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token11',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token13',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token11',
-      priceFeedId,
+      symbol: 'Token13',
+      priceFeedId: 'Token13/USD',
       interest: new BigNumber(15.12345678) // 8 digits in the fractional part
     })
     expect(typeof loanTokenId).toStrictEqual('string')
@@ -240,37 +250,7 @@ describe('Loan', () => {
   })
 
   it('should not setLoanToken if interest number is greater than 0 and has more than 8 digits in the fractional part', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token12',
-      currency: 'USD'
-    }], 1])
-    await testing.generate(1)
-
-    const promise = testing.rpc.loan.setLoanToken({
-      symbol: 'Token12',
-      priceFeedId,
-      interest: new BigNumber(15.123456789) // 9 digits in the fractional part
-    })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid amount\', code: -3, method: setloantoken')
-  })
-
-  it('should not setLoanToken if interest number is less than 0', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token13',
-      currency: 'USD'
-    }], 1])
-    await testing.generate(1)
-
-    const promise = testing.rpc.loan.setLoanToken({
-      symbol: 'Token13',
-      priceFeedId,
-      interest: new BigNumber(-15.12345678)
-    })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Amount out of range\', code: -3, method: setloantoken')
-  })
-
-  it('should not setLoanToken if interest number is greater than 1200000000', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token14',
       currency: 'USD'
     }], 1])
@@ -278,23 +258,53 @@ describe('Loan', () => {
 
     const promise = testing.rpc.loan.setLoanToken({
       symbol: 'Token14',
-      priceFeedId,
+      priceFeedId: 'Token14/USD',
+      interest: new BigNumber(15.123456789) // 9 digits in the fractional part
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'Invalid amount\', code: -3, method: setloantoken')
+  })
+
+  it('should not setLoanToken if interest number is less than 0', async () => {
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token15',
+      currency: 'USD'
+    }], 1])
+    await testing.generate(1)
+
+    const promise = testing.rpc.loan.setLoanToken({
+      symbol: 'Token15',
+      priceFeedId: 'Token15/USD',
+      interest: new BigNumber(-15.12345678)
+    })
+    await expect(promise).rejects.toThrow('RpcApiError: \'Amount out of range\', code: -3, method: setloantoken')
+  })
+
+  it('should not setLoanToken if interest number is greater than 1200000000', async () => {
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token16',
+      currency: 'USD'
+    }], 1])
+    await testing.generate(1)
+
+    const promise = testing.rpc.loan.setLoanToken({
+      symbol: 'Token16',
+      priceFeedId: 'Token16/USD',
       interest: new BigNumber('1200000000').plus('0.00000001')
     })
     await expect(promise).rejects.toThrow('RpcApiError: \'Amount out of range\', code: -3, method: setloantoken')
   })
 
   it('should setLoanToken with utxos', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token15',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token17',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const { txid, vout } = await testing.container.fundAddress(GenesisKeys[0].owner.address, 10)
     const loanTokenId = await testing.rpc.loan.setLoanToken({
-      symbol: 'Token15',
-      priceFeedId
+      symbol: 'Token17',
+      priceFeedId: 'Token17/USD'
     }, [{ txid, vout }])
     expect(typeof loanTokenId).toStrictEqual('string')
     expect(loanTokenId.length).toStrictEqual(64)
@@ -306,21 +316,21 @@ describe('Loan', () => {
 
     const data = await testing.container.call('listloantokens', [])
     const index = Object.keys(data).indexOf(loanTokenId) + 1
-    expect(data[loanTokenId].token[index].symbol).toStrictEqual('Token15')
+    expect(data[loanTokenId].token[index].symbol).toStrictEqual('Token17')
     expect(data[loanTokenId].token[index].name).toStrictEqual('')
   })
 
   it('should not setLoanToken with utxos not from foundation member', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token16',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token18',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const utxo = await testing.container.fundAddress(await testing.generateAddress(), 10)
     const promise = testing.rpc.loan.setLoanToken({
-      symbol: 'Token16',
-      priceFeedId
+      symbol: 'Token18',
+      priceFeedId: 'Token18/USD'
     }, [utxo])
     await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setloantoken')
   })

--- a/packages/jellyfish-buffer/src/composer.ts
+++ b/packages/jellyfish-buffer/src/composer.ts
@@ -533,28 +533,6 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
-   * VarUInt1 helper method, 1 - 9 bytes
-   *
-   * @param getter to read from to buffer
-   * @param setter to set to from buffer
-   * @param asC map single object into ComposableBuffer Object
-   */
-  static varUInt1<T> (
-    getter: () => T,
-    setter: (data: T) => void,
-    asC: (data: SmartBuffer | T) => ComposableBuffer<T>
-  ): BufferComposer {
-    return {
-      fromBuffer: (buffer: SmartBuffer): void => {
-        setter(asC(buffer).data)
-      },
-      toBuffer: (buffer: SmartBuffer): void => {
-        asC(getter()).toBuffer(buffer)
-      }
-    }
-  }
-
-  /**
    * Imposing mask over bits method, 1 byte
    *
    * @param length of the input array to read/set

--- a/packages/jellyfish-buffer/src/composer.ts
+++ b/packages/jellyfish-buffer/src/composer.ts
@@ -533,6 +533,28 @@ export abstract class ComposableBuffer<T> implements BufferComposer {
   }
 
   /**
+   * VarUInt1 helper method, 1 - 9 bytes
+   *
+   * @param getter to read from to buffer
+   * @param setter to set to from buffer
+   * @param asC map single object into ComposableBuffer Object
+   */
+  static varUInt1<T> (
+    getter: () => T,
+    setter: (data: T) => void,
+    asC: (data: SmartBuffer | T) => ComposableBuffer<T>
+  ): BufferComposer {
+    return {
+      fromBuffer: (buffer: SmartBuffer): void => {
+        setter(asC(buffer).data)
+      },
+      toBuffer: (buffer: SmartBuffer): void => {
+        asC(getter()).toBuffer(buffer)
+      }
+    }
+  }
+
+  /**
    * Imposing mask over bits method, 1 byte
    *
    * @param length of the input array to read/set

--- a/packages/jellyfish-transaction-builder/__tests__/txn/loan_container.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/loan_container.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer, StartOptions } from '@defichain/testcontain
 
 export class LoanMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor () {
-    super(undefined, 'defi/defichain:HEAD-2689214')
+    super(undefined, 'defi/defichain:HEAD-fffc8dd')
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/loan_container.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/loan_container.ts
@@ -2,7 +2,7 @@ import { MasterNodeRegTestContainer, StartOptions } from '@defichain/testcontain
 
 export class LoanMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor () {
-    super(undefined, 'defi/defichain:HEAD-3882db7')
+    super(undefined, 'defi/defichain:HEAD-2689214')
   }
 
   protected getCmd (opts: StartOptions): string[] {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
@@ -103,7 +103,7 @@ describe('loan.setCollateralToken()', () => {
     await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: setCollateralToken factor must be lower or equal than 1.00000000! (code 16)\', code: -26')
   })
 
-  it('should not setCollateralToken if oracleId does not exist', async () => {
+  it('should not setCollateralToken if priceFeedId does not belong to any oracle', async () => {
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setCollateralToken({
       token: 1,

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
@@ -15,8 +15,6 @@ describe('loan.setCollateralToken()', () => {
   let providers: MockProviders
   let builder: P2WPKHTransactionBuilder
 
-  let priceFeedId: string
-
   beforeAll(async () => {
     await testing.container.start()
     await testing.container.waitForWalletCoinbaseMaturity()
@@ -32,7 +30,7 @@ describe('loan.setCollateralToken()', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -46,13 +44,13 @@ describe('loan.setCollateralToken()', () => {
   it('should setCollateralToken', async () => {
     // Fund 10 DFI UTXO
     await fundEllipticPair(testing.container, providers.ellipticPair, 10)
-    await providers.setupMocks() // required to move utxos
+    await providers.setupMocks() // Required to move utxos
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setCollateralToken({
       token: 1,
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: { token: 'AAPL', currency: 'USD' },
       activateAfterBlock: 0
     }, script)
 
@@ -75,7 +73,7 @@ describe('loan.setCollateralToken()', () => {
       [collateralTokenId]: {
         token: 'AAPL',
         factor: 0.5,
-        priceFeedId,
+        priceFeedId: 'AAPL/USD',
         activateAfterBlock: await testing.container.getBlockCount()
       }
     })
@@ -86,7 +84,7 @@ describe('loan.setCollateralToken()', () => {
     const txn = await builder.loans.setCollateralToken({
       token: 2,
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: { token: 'AAPL', currency: 'USD' },
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
@@ -98,32 +96,11 @@ describe('loan.setCollateralToken()', () => {
     const txn = await builder.loans.setCollateralToken({
       token: 1,
       factor: new BigNumber(1.01),
-      priceFeedId,
+      priceFeedId: { token: 'AAPL', currency: 'USD' },
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
     await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: setCollateralToken factor must be lower or equal than 1.00000000! (code 16)\', code: -26')
-  })
-
-  it('should not setCollateralToken if oracle does not contain USD price', async () => {
-    await testing.token.create({ symbol: 'TSLA' })
-    await testing.generate(1)
-
-    const priceFeedId: string = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'TSLA',
-      currency: 'SGD'
-    }], 1])
-    await testing.generate(1)
-
-    const script = await providers.elliptic.script()
-    const txn = await builder.loans.setCollateralToken({
-      token: 1,
-      factor: new BigNumber(0.5),
-      priceFeedId,
-      activateAfterBlock: 0
-    }, script)
-    const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow(`DeFiDRpcError: 'LoanSetCollateralTokenTx: oracle (${priceFeedId}) does not contain USD price for this token! (code 16)', code: -26`)
   })
 
   it('should not setCollateralToken if oracleId does not exist', async () => {
@@ -131,11 +108,11 @@ describe('loan.setCollateralToken()', () => {
     const txn = await builder.loans.setCollateralToken({
       token: 1,
       factor: new BigNumber(0.5),
-      priceFeedId: '944d7ce67a0bd6d18e7ba7cbd3ec12ac81a13aa92876cb697ec0b33bf50652f5',
+      priceFeedId: { token: 'MFST', currency: 'USD' },
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: oracle (944d7ce67a0bd6d18e7ba7cbd3ec12ac81a13aa92876cb697ec0b33bf50652f5) does not exist! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
   })
 })
 
@@ -163,7 +140,7 @@ describe('loan.setCollateralToken() with activateAfterBlock', () => {
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -178,7 +155,7 @@ describe('loan.setCollateralToken() with activateAfterBlock', () => {
     const txn = await builder.loans.setCollateralToken({
       token: 1,
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: { token: 'AAPL', currency: 'USD' },
       activateAfterBlock: 160
     }, script)
     await sendTransaction(testing.container, txn)
@@ -188,7 +165,7 @@ describe('loan.setCollateralToken() with activateAfterBlock', () => {
       [collateralTokenId]: {
         token: 'AAPL',
         factor: 0.5,
-        priceFeedId,
+        priceFeedId: 'AAPL/USD',
         activateAfterBlock: 160
       }
     })
@@ -219,7 +196,7 @@ describe('loan.setCollateralToken() with activateAfterBlock below current height
     await testing.token.create({ symbol: 'AAPL' })
     await testing.generate(1)
 
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'AAPL',
       currency: 'USD'
     }], 1])
@@ -237,7 +214,7 @@ describe('loan.setCollateralToken() with activateAfterBlock below current height
     const txn = await builder.loans.setCollateralToken({
       token: 1,
       factor: new BigNumber(0.5),
-      priceFeedId,
+      priceFeedId: { token: 'AAPL', currency: 'USD' },
       activateAfterBlock: 149
     }, script)
     const promise = sendTransaction(testing.container, txn)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
@@ -35,7 +35,7 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should setLoanToken', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token1',
       currency: 'USD'
     }], 1])
@@ -45,7 +45,7 @@ describe('loan.setLoanToken()', () => {
     const txn = await builder.loans.setLoanToken({
       symbol: 'Token1',
       name: 'Token1',
-      priceFeedId,
+      priceFeedId: { token: 'Token1', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(0.5)
     }, script)
@@ -82,14 +82,14 @@ describe('loan.setLoanToken()', () => {
             collateralAddress: expect.any(String)
           }
         },
-        priceFeedId,
+        priceFeedId: 'Token1/USD',
         interest: 0.5
       }
     })
   })
 
   it('should setLoanToken if symbol is more than 8 letters', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'x'.repeat(8),
       currency: 'USD'
     }], 1])
@@ -99,7 +99,7 @@ describe('loan.setLoanToken()', () => {
     const txn = await builder.loans.setLoanToken({
       symbol: 'x'.repeat(9), // 9 letters
       name: 'x'.repeat(9),
-      priceFeedId,
+      priceFeedId: { token: 'x'.repeat(8), currency: 'USD' },
       mintable: true,
       interest: new BigNumber(1.5)
     }, script)
@@ -113,7 +113,7 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should not setLoanToken if symbol is an empty string', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token2',
       currency: 'USD'
     }], 1])
@@ -123,7 +123,7 @@ describe('loan.setLoanToken()', () => {
     const txn = await builder.loans.setLoanToken({
       symbol: '',
       name: '',
-      priceFeedId,
+      priceFeedId: { token: 'Token2', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(2.5)
     }, script)
@@ -133,7 +133,7 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should not setLoanToken if token with same symbol was created before', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
       token: 'Token3',
       currency: 'USD'
     }], 1])
@@ -141,7 +141,7 @@ describe('loan.setLoanToken()', () => {
 
     await testing.rpc.loan.setLoanToken({
       symbol: 'Token3',
-      priceFeedId
+      priceFeedId: 'Token3/USD'
     })
     await testing.generate(1)
 
@@ -153,7 +153,7 @@ describe('loan.setLoanToken()', () => {
     const txn = await builder.loans.setLoanToken({
       symbol: 'Token3',
       name: 'Token3',
-      priceFeedId,
+      priceFeedId: { token: 'Token3', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(3.5)
     }, script)
@@ -162,52 +162,32 @@ describe('loan.setLoanToken()', () => {
     await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: token \'Token3\' already exists! (code 16)\', code: -26')
   })
 
-  it('should not setLoanToken if priceFeedId does not contain USD price', async () => {
-    const priceFeedId: string = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token4',
-      currency: 'Token4'
-    }], 1])
-    await testing.generate(1)
-
+  it('should not setLoanToken if oracleId does not exist', async () => {
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
       symbol: 'Token4',
       name: 'Token4',
-      priceFeedId,
+      priceFeedId: { token: 'MFST', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(4.5)
     }, script)
     const promise = sendTransaction(testing.container, txn)
 
-    await expect(promise).rejects.toThrow(`DeFiDRpcError: 'LoanSetLoanTokenTx: oracle (${priceFeedId}) does not contain USD price for this token! (code 16)', code: -26`)
-  })
-
-  it('should not setLoanToken if priceFeedId is invalid', async () => {
-    const script = await providers.elliptic.script()
-    const txn = await builder.loans.setLoanToken({
-      symbol: 'Token5',
-      name: 'Token5',
-      priceFeedId: 'e40775f8bb396cd3d94429843453e66e68b1c7625d99b0b4c505ab004506697b',
-      mintable: true,
-      interest: new BigNumber(5.5)
-    }, script)
-
-    const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: oracle (e40775f8bb396cd3d94429843453e66e68b1c7625d99b0b4c505ab004506697b) does not exist or not valid oracle! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
   })
 
   it('should setLoanToken with the given name', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token6',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token5',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
-      symbol: 'Token6',
-      name: 'Token6',
-      priceFeedId,
+      symbol: 'Token5',
+      name: 'Token5',
+      priceFeedId: { token: 'Token5', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(6.5)
     }, script)
@@ -217,21 +197,21 @@ describe('loan.setLoanToken()', () => {
 
     const data = await testing.container.call('listloantokens', [])
     const index = Object.keys(data).indexOf(loanTokenId) + 1
-    expect(data[loanTokenId].token[index].name).toStrictEqual('Token6')
+    expect(data[loanTokenId].token[index].name).toStrictEqual('Token5')
   })
 
   it('should setLoanToken if name is more than 128 letters', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token7',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token6',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
-      symbol: 'Token7',
+      symbol: 'Token6',
       name: 'x'.repeat(129), // 129 letters
-      priceFeedId,
+      priceFeedId: { token: 'Token6', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(7.5)
     }, script)
@@ -245,30 +225,30 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should setLoanToken if two loan tokens have the same name', async () => {
-    const priceFeedId1 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token8',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token7',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     await testing.rpc.loan.setLoanToken({
-      symbol: 'Token8',
+      symbol: 'Token7',
       name: 'TokenX',
-      priceFeedId: priceFeedId1
+      priceFeedId: 'Token7/USD'
     })
     await testing.generate(1)
 
-    const priceFeedId2 = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token9',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token8',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
-      symbol: 'Token9',
+      symbol: 'Token8',
       name: 'TokenX',
-      priceFeedId: priceFeedId2,
+      priceFeedId: { token: 'Token8', currency: 'USD' },
       mintable: true,
       interest: new BigNumber(8.5)
     }, script)
@@ -280,17 +260,17 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should setLoanToken if mintable is false', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token10',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token9',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
-      symbol: 'Token10',
-      name: 'Token10',
-      priceFeedId,
+      symbol: 'Token9',
+      name: 'Token9',
+      priceFeedId: { token: 'Token9', currency: 'USD' },
       mintable: false,
       interest: new BigNumber(9.5)
     }, script)
@@ -302,17 +282,17 @@ describe('loan.setLoanToken()', () => {
   })
 
   it('should setLoanToken if interest number is greater than 0', async () => {
-    const priceFeedId = await testing.container.call('appointoracle', [await testing.generateAddress(), [{
-      token: 'Token11',
+    await testing.container.call('appointoracle', [await testing.generateAddress(), [{
+      token: 'Token10',
       currency: 'USD'
     }], 1])
     await testing.generate(1)
 
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
-      symbol: 'Token11',
-      name: 'Token11',
-      priceFeedId,
+      symbol: 'Token10',
+      name: 'Token10',
+      priceFeedId: { token: 'Token10', currency: 'USD' },
       mintable: false,
       interest: new BigNumber(15.12345678)
     }, script)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
@@ -162,7 +162,7 @@ describe('loan.setLoanToken()', () => {
     await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: token \'Token3\' already exists! (code 16)\', code: -26')
   })
 
-  it('should not setLoanToken if oracleId does not exist', async () => {
+  it('should not setLoanToken if priceFeedId does not belong to any oracle', async () => {
     const script = await providers.elliptic.script()
     const txn = await builder.loans.setLoanToken({
       symbol: 'Token4',

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/SetCollateralToken.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/SetCollateralToken.test.ts
@@ -14,29 +14,29 @@ it('should bi-directional buffer-object-buffer', () => {
      * loan : {
      *    token: '1',
      *    factor: new BigNumber(0.1),
-     *    priceFeedId: 1aebaa5def9093a82dabeeb34f3ec29cc41db50229fd24a2793d5b8dfbc2e8b3
-     *    activateAfterBlock: new BigNumber(0)
+     *    priceFeedId: {token: 'Token1', currency: 'USD'}
+     *    activateAfterBlock: 0
      * }
      */
-    '6a324466547863018096980000000000b3e8c2fb8d5b3d79a224fd2902b51dc49cc23e4fb3eeab2da89390ef5daaeb1a00000000',
+    '6a1d446654786301809698000000000006546f6b656e310355534400000000',
     /**
      * loan : {
      *    token: '1',
      *    factor: new BigNumber(0.1),
-     *    priceFeedId: 1aebaa5def9093a82dabeeb34f3ec29cc41db50229fd24a2793d5b8dfbc2e8b3
-     *    activateAfterBlock: new BigNumber(130)
+     *    priceFeedId: {token: 'Token1', currency: 'USD'}
+     *    activateAfterBlock: 130
      * }
      */
-    '6a324466547863018096980000000000b3e8c2fb8d5b3d79a224fd2902b51dc49cc23e4fb3eeab2da89390ef5daaeb1a82000000',
+    '6a1d446654786301809698000000000006546f6b656e310355534482000000',
     /**
      * loan : {
      *    token: '2',
      *    factor: new BigNumber(0.2),
-     *    priceFeedId: 9f93d1d056c79082d8fee54079d38b986ca78654f84c90a97335a71df390e50d
-     *    activateAfterBlock: new BigNumber(140)
+     *    priceFeedId: {token: 'Token2', currency: 'USD'}
+     *    activateAfterBlock: 140
      * }
      */
-    '6a32446654786302002d3101000000000de590f31da73573a9904cf85486a76c988bd37940e5fed88290c756d0d1939f8c000000'
+    '6a1d446654786302002d31010000000006546f6b656e32035553448c000000'
   ]
 
   fixtures.forEach(hex => {
@@ -50,16 +50,16 @@ it('should bi-directional buffer-object-buffer', () => {
 })
 
 describe('SetCollateralToken', () => {
-  const header = '6a324466547863' // OP_RETURN(0x6a) (length 32 = 0x20) CDfTx.SIGNATURE(0x44665478) CSetCollateralToken.OP_CODE(0x63)
+  const header = '6a1d4466547863' // OP_RETURN(0x6a) (length 29 = 0x1d) CDfTx.SIGNATURE(0x44665478) CSetCollateralToken.OP_CODE(0x63)
   // SetCollateralToken.token[LE](01)
   // SetCollateralToken.factor[LE](8096980000000000)
-  // SetCollateralToken.priceFeedId[LE] (b3e8c2fb8d5b3d79a224fd2902b51dc49cc23e4fb3eeab2da89390ef5daaeb1a)
+  // SetCollateralToken.priceFeedId[BE] (06546f6b656e3103555344)
   // SetCollateralToken.activateAfterBlock[LE] (82000000)
-  const data = '018096980000000000b3e8c2fb8d5b3d79a224fd2902b51dc49cc23e4fb3eeab2da89390ef5daaeb1a82000000'
+  const data = '01809698000000000006546f6b656e310355534482000000'
   const setCollateralToken: SetCollateralToken = {
     token: 1,
-    factor: new BigNumber('0.1'),
-    priceFeedId: '1aebaa5def9093a82dabeeb34f3ec29cc41db50229fd24a2793d5b8dfbc2e8b3',
+    factor: new BigNumber(0.1),
+    priceFeedId: { token: 'Token1', currency: 'USD' },
     activateAfterBlock: 130
   }
 

--- a/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/SetLoanToken.test.ts
+++ b/packages/jellyfish-transaction/__tests__/script/dftx/dftx_loans/SetLoanToken.test.ts
@@ -14,32 +14,32 @@ it('should bi-directional buffer-object-buffer', () => {
      * loan : {
      *    symbol: 'Token1',
      *    name: 'Token1',
-     *    priceFeedId: 6d98cfa8b62b9ebe7cfbdf9f533949bea5bd18a8fd3d33d6aa49c1ad6bec15ce
+     *    priceFeedId: {token: 'Token1', currency: 'USD'},
      *    mintable: true,
      *    interest: new BigNumber(0)
      * }
      */
-    '6a3c446654786706546f6b656e3106546f6b656e31ce15ec6badc149aad6333dfda818bda5be4939539fdffb7cbe9e2bb6a8cf986d010000000000000000',
+    '6a27446654786706546f6b656e3106546f6b656e3106546f6b656e3103555344010000000000000000',
     /**
      * loan : {
      *    symbol: 'Token2',
      *    name: 'Token2',
-     *    priceFeedId: 6d98cfa8b62b9ebe7cfbdf9f533949bea5bd18a8fd3d33d6aa49c1ad6bec15ce
+     *    priceFeedId: {token: 'Token2', currency: 'USD'},
      *    mintable: false,
      *    interest: new BigNumber(0)
      * }
      */
-    '6a3c446654786706546f6b656e3206546f6b656e32ce15ec6badc149aad6333dfda818bda5be4939539fdffb7cbe9e2bb6a8cf986d000000000000000000',
+    '6a27446654786706546f6b656e3206546f6b656e3206546f6b656e3203555344000000000000000000',
     /**
      * loan : {
      *    symbol: 'Token3',
      *    name: 'Token3',
-     *    priceFeedId：6d98cfa8b62b9ebe7cfbdf9f533949bea5bd18a8fd3d33d6aa49c1ad6bec15ce
+     *    priceFeedId: {token: 'Token3', currency: 'USD'},
      *    mintable: true,
      *    interest: new BigNumber(12.345678)
      * }
      */
-    '6a3c446654786706546f6b656e3306546f6b656e33ce15ec6badc149aad6333dfda818bda5be4939539fdffb7cbe9e2bb6a8cf986d017802964900000000'
+    '6a27446654786706546f6b656e3306546f6b656e3306546f6b656e3303555344017802964900000000'
   ]
 
   fixtures.forEach(hex => {
@@ -52,18 +52,18 @@ it('should bi-directional buffer-object-buffer', () => {
   })
 })
 
-const header = '6a3c4466547867' // OP_RETURN(0x6a) (length 60 = 0x3c) CDfTx.SIGNATURE(0x44665478) CSetLoanToken.OP_CODE(0x67)
-const data = '06546f6b656e3306546f6b656e33ce15ec6badc149aad6333dfda818bda5be4939539fdffb7cbe9e2bb6a8cf986d017802964900000000'
+const header = '6a274466547867' // OP_RETURN(0x6a) (length 39 = 0x27) CDfTx.SIGNATURE(0x44665478) CSetLoanToken.OP_CODE(0x67)
+const data = '06546f6b656e3306546f6b656e3306546f6b656e3303555344017802964900000000'
 // SetLoanToken.symbol[BE](06546f6b656e33)
 // SetLoanToken.name[BE](06546f6b656e33)
-// SetLoanToken.priceFeedId[LE] (ce15ec6badc149aad6333dfda818bda5be4939539fdffb7cbe9e2bb6a8cf986d)
+// SetLoanToken.priceFeedId[BE] (06546f6b656e3303555344)
 // SetLoanToken.mintable(01)
 // SetLoanToken.interest[LE](7802964900000000)
 
 const setLoanToken: SetLoanToken = {
   symbol: 'Token3',
   name: 'Token3',
-  priceFeedId: '6d98cfa8b62b9ebe7cfbdf9f533949bea5bd18a8fd3d33d6aa49c1ad6bec15ce',
+  priceFeedId: { token: 'Token3', currency: 'USD' },
   mintable: true,
   interest: new BigNumber(12.345678)
 }

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_loans.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_loans.ts
@@ -129,7 +129,7 @@ export class CSetCollateralToken extends ComposableBuffer<SetCollateralToken> {
     return [
       ComposableBuffer.varUInt(() => sct.token, v => sct.token = v),
       ComposableBuffer.satoshiAsBigNumber(() => sct.factor, v => sct.factor = v),
-      ComposableBuffer.varUInt1(() => sct.priceFeedId, v => sct.priceFeedId = v, sct => new CCurrencyPair(sct)),
+      ComposableBuffer.single(() => sct.priceFeedId, v => sct.priceFeedId = v, sct => new CCurrencyPair(sct)),
       ComposableBuffer.uInt32(() => sct.activateAfterBlock, v => sct.activateAfterBlock = v)
     ]
   }
@@ -147,7 +147,7 @@ export class CSetLoanToken extends ComposableBuffer<SetLoanToken> {
     return [
       ComposableBuffer.varUIntUtf8BE(() => slt.symbol, v => slt.symbol = v),
       ComposableBuffer.varUIntUtf8BE(() => slt.name, v => slt.name = v),
-      ComposableBuffer.varUInt1(() => slt.priceFeedId, v => slt.priceFeedId = v, v => new CCurrencyPair(v)),
+      ComposableBuffer.single(() => slt.priceFeedId, v => slt.priceFeedId = v, v => new CCurrencyPair(v)),
       ComposableBuffer.uBool8(() => slt.mintable, v => slt.mintable = v),
       ComposableBuffer.satoshiAsBigNumber(() => slt.interest, v => slt.interest = v)
     ]

--- a/packages/jellyfish-transaction/src/script/dftx/dftx_loans.ts
+++ b/packages/jellyfish-transaction/src/script/dftx/dftx_loans.ts
@@ -35,7 +35,7 @@ export interface SetDefaultLoanScheme {
 export interface SetCollateralToken {
   token: number // ----------------| VarUInt{1-9 bytes}, Symbol or id of collateral token
   factor: BigNumber // ------------| 8 bytes unsigned, Collateralization factor
-  priceFeedId: CurrencyPair // ----| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string, token/currency pair to use for price of token
+  priceFeedId: CurrencyPair // ----| priceFeedId: CurrencyPair // ----| c1 = VarUInt{1-9 bytes} + c1 bytes UTF encoded string for token + c2 = VarUInt{1-9 bytes} + c2 bytes UTF encoded string for currency, token/currency pair to use for price of token
   activateAfterBlock: number // ---| 4 bytes unsigned, Changes will be active after the block height
 }
 
@@ -45,7 +45,7 @@ export interface SetCollateralToken {
 export interface SetLoanToken {
   symbol: string // -------------| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string, Symbol or id of collateral token
   name: string // ---------------| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string, Token's name, no longer than 128 characters
-  priceFeedId: CurrencyPair // --| c = VarUInt{1-9 bytes}, + c bytes UTF encoded string, token/currency pair to use for price of token
+  priceFeedId: CurrencyPair // --| priceFeedId: CurrencyPair // ----| c1 = VarUInt{1-9 bytes} + c1 bytes UTF encoded string for token + c2 = VarUInt{1-9 bytes} + c2 bytes UTF encoded string for currency, token/currency pair to use for price of token
   mintable: boolean // ----------| 1 byte, mintable, Token's 'Mintable' property
   interest: BigNumber // --------| 8 bytes unsigned, interest rate
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
The latest code in the epic/loan branch (See DeFiCh/ain#742) breaks the existing code in the main branch.
The priceFeedId value is no longer an oracle TXID. It is a string with token/currency format.

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #669 

#### Additional comments?:
