### PR TITLE
Disable docker pruning

### DIFF
--- a/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
@@ -104,14 +104,14 @@ export class ContainerGroup {
    * Stop container group and all containers associated with it
    */
   async stop (): Promise<void> {
-    const containerIds = this.containers.map(c => c.id)
     for (const container of this.containers) {
       await this.requireNetwork().disconnect({ Container: container.id })
       await container.stop()
     }
     await this.requireNetwork().remove()
-    for (const id of containerIds) {
-      await this.docker.pruneContainers({ Container: id })
-    }
+    // NOTE: for anyone have RPC timeout issue, esp newer version docker, v3.6.x / v4.x.x
+    // enable the following line to ensure docker network pruned correctly between tests
+    // global containers prune may cause multithreaded tests clashing each other
+    // await this.docker.pruneContainers()
   }
 }

--- a/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
@@ -104,11 +104,14 @@ export class ContainerGroup {
    * Stop container group and all containers associated with it
    */
   async stop (): Promise<void> {
+    const containerIds = this.containers.map(c => c.id)
     for (const container of this.containers) {
       await this.requireNetwork().disconnect({ Container: container.id })
       await container.stop()
     }
     await this.requireNetwork().remove()
-    await this.docker.pruneContainers()
+    for (const id of containerIds) {
+      await this.docker.pruneContainers({ Container: id })
+    }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:
multiple test cases prune container clashing each other
Base on multiple occurrences in our test case, hypothesis made: Dockerode prune API is singleton, one execution at one time regardless the option is specifying particular container.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
