### PR TITLE
Bump LoanContainer to 2.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,6 +49,14 @@
       "rules": {
         "no-return-assign": "off"
       }
+    },
+    {
+      "files": [
+        "**/__tests__/**/*.test.ts"
+      ],
+      "rules": {
+        "@typescript-eslint/no-non-null-assertion": "off"
+      }
     }
   ]
 }

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,7 @@
       <option name="SPACE_BEFORE_GENERATOR_MULT" value="true" />
       <option name="USE_DOUBLE_QUOTES" value="false" />
       <option name="FORCE_QUOTE_STYlE" value="true" />
-      <option name="OBJECT_LITERAL_WRAP" value="2" />
+      <option name="OBJECT_LITERAL_WRAP" value="4" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </JSCodeStyleSettings>
@@ -17,7 +17,7 @@
       <option name="SPACE_BEFORE_GENERATOR_MULT" value="true" />
       <option name="USE_DOUBLE_QUOTES" value="false" />
       <option name="FORCE_QUOTE_STYlE" value="true" />
-      <option name="OBJECT_LITERAL_WRAP" value="2" />
+      <option name="OBJECT_LITERAL_WRAP" value="4" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </TypeScriptCodeStyleSettings>

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -32,12 +32,16 @@
       <w>checksig</w>
       <w>checksigverify</w>
       <w>clarkequayheight</w>
+      <w>closevault</w>
       <w>codeclimate</w>
       <w>codeseparator</w>
+      <w>collateralization</w>
+      <w>createloanscheme</w>
       <w>createmasternode</w>
       <w>createpoolpair</w>
       <w>createrawtransaction</w>
       <w>createtoken</w>
+      <w>createvault</w>
       <w>createwallet</w>
       <w>currentblocktx</w>
       <w>currentblockweight</w>
@@ -48,9 +52,11 @@
       <w>defich</w>
       <w>defichain</w>
       <w>defid</w>
+      <w>deposittovault</w>
       <w>descendantcount</w>
       <w>descendantfees</w>
       <w>descendantsize</w>
+      <w>destroyloanscheme</w>
       <w>devnet</w>
       <w>dftx</w>
       <w>dockerode</w>
@@ -74,6 +80,10 @@
       <w>getblockcount</w>
       <w>getblockhash</w>
       <w>getburninfo</w>
+      <w>getcollateraltoken</w>
+      <w>getinterest</w>
+      <w>getloanscheme</w>
+      <w>getloantoken</w>
       <w>getmintinginfo</w>
       <w>getnetworkhashps</w>
       <w>getnewaddress</w>
@@ -85,6 +95,7 @@
       <w>gettransaction</w>
       <w>gettxout</w>
       <w>getunconfirmedbalance</w>
+      <w>getvault</w>
       <w>getwalletinfo</w>
       <w>ghcr</w>
       <w>greaterthan</w>
@@ -99,6 +110,7 @@
       <w>importprivkey</w>
       <w>infima</w>
       <w>initialblockdownload</w>
+      <w>interestrate</w>
       <w>invalidopcode</w>
       <w>ischange</w>
       <w>iscompressed</w>
@@ -121,9 +133,13 @@
       <w>listaccounts</w>
       <w>listaddressgroupings</w>
       <w>listburnhistory</w>
+      <w>listcollateraltokens</w>
+      <w>listloanschemes</w>
+      <w>listloantokens</w>
       <w>listpoolpairs</w>
       <w>listpoolshares</w>
       <w>listunspent</w>
+      <w>listvaults</w>
       <w>locktime</w>
       <w>logtimemicros</w>
       <w>lshift</w>
@@ -136,6 +152,7 @@
       <w>mediantime</w>
       <w>mempool</w>
       <w>merkleroot</w>
+      <w>mincolratio</w>
       <w>mintable</w>
       <w>mintedblocks</w>
       <w>minttokens</w>
@@ -152,6 +169,7 @@
       <w>numequal</w>
       <w>numequalverify</w>
       <w>numnotequal</w>
+      <w>paybackloan</w>
       <w>paytxfee</w>
       <w>pooledtx</w>
       <w>poolpair</w>
@@ -183,6 +201,9 @@
       <w>sendrawtransaction</w>
       <w>sendtoaddress</w>
       <w>sendtokenstoaddress</w>
+      <w>setcollateraltoken</w>
+      <w>setdefaultloanscheme</w>
+      <w>setloantoken</w>
       <w>setwalletflag</w>
       <w>sighash</w>
       <w>sighashtype</w>
@@ -195,6 +216,7 @@
       <w>spentby</w>
       <w>strippedsize</w>
       <w>surangap</w>
+      <w>takeloan</w>
       <w>testcontainers</w>
       <w>testmempoolaccept</w>
       <w>thedoublejay</w>
@@ -209,6 +231,8 @@
       <w>txns</w>
       <w>uacomment</w>
       <w>unpkg</w>
+      <w>updateloanscheme</w>
+      <w>updateloantoken</w>
       <w>utxo</w>
       <w>utxos</w>
       <w>utxostoaccount</w>

--- a/docs/node/RPC Category/16-loan.md
+++ b/docs/node/RPC Category/16-loan.md
@@ -356,7 +356,7 @@ Returns information about vault.
 
 ```ts title="client.loan.getVault()"
 interface loan {
-  getVault (vaultId: string): Promise<VaultDetails>
+  getVault (vaultId: string): Promise<VaultActive | VaultLiquidation>
 }
 
 enum VaultState {
@@ -367,28 +367,32 @@ enum VaultState {
   MAY_LIQUIDATE = 'mayLiquidate',
 }
 
-interface VaultDetails {
-  // list and get both returns
+interface Vault {
   vaultId: string
   loanSchemeId: string
   ownerAddress: string
   state: VaultState
-  // get only returns
-  liquidationHeight?: number
-  liquidationPenalty?: number
-  batchCount?: number
-  batches?: AuctionBatchDetails[]
-  collateralAmounts?: string[]
-  loanAmounts?: string[]
-  interestAmounts?: string[]
-  collateralValue?: BigNumber
-  loanValue?: BigNumber
-  interestValue?: BigNumber
-  collateralRatio?: number
-  informativeRatio?: BigNumber
 }
 
-interface AuctionBatchDetails {
+interface VaultActive extends Vault {
+  collateralAmounts: string[]
+  loanAmounts: string[]
+  interestAmounts: string[]
+  collateralValue: BigNumber
+  loanValue: BigNumber
+  interestValue: BigNumber
+  collateralRatio: number
+  informativeRatio: BigNumber
+}
+
+interface VaultLiquidation extends Vault {
+  liquidationHeight: number
+  liquidationPenalty: number
+  batchCount: number
+  batches: VaultLiquidationBatch[]
+}
+
+interface VaultLiquidationBatch {
   index: BigNumber
   collaterals: string[]
   loan: string
@@ -401,31 +405,43 @@ List all available vaults.
 
 ```ts title="client.loan.listVaults()"
 interface loan {
-  listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<ListVaultDetails[]>
+  listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<Array<Vault | VaultActive | VaultLiquidation>>
 }
 
-interface VaultDetails {
-  // list and get both returns
+enum VaultState {
+  UNKNOWN = 'unknown',
+  ACTIVE = 'active',
+  IN_LIQUIDATION = 'inLiquidation',
+  FROZEN = 'frozen',
+  MAY_LIQUIDATE = 'mayLiquidate',
+}
+
+interface Vault {
   vaultId: string
   loanSchemeId: string
   ownerAddress: string
   state: VaultState
-  // get only returns
-  liquidationHeight?: number
-  liquidationPenalty?: number
-  batchCount?: number
-  batches?: AuctionBatchDetails[]
-  collateralAmounts?: string[]
-  loanAmounts?: string[]
-  interestAmounts?: string[]
-  collateralValue?: BigNumber
-  loanValue?: BigNumber
-  interestValue?: BigNumber
-  collateralRatio?: number
-  informativeRatio?: BigNumber
 }
 
-interface AuctionBatchDetails {
+interface VaultActive extends Vault {
+  collateralAmounts: string[]
+  loanAmounts: string[]
+  interestAmounts: string[]
+  collateralValue: BigNumber
+  loanValue: BigNumber
+  interestValue: BigNumber
+  collateralRatio: number
+  informativeRatio: BigNumber
+}
+
+interface VaultLiquidation extends Vault {
+  liquidationHeight: number
+  liquidationPenalty: number
+  batchCount: number
+  batches: VaultLiquidationBatch[]
+}
+
+interface VaultLiquidationBatch {
   index: BigNumber
   collaterals: string[]
   loan: string
@@ -435,6 +451,7 @@ interface ListVaultOptions {
   ownerAddress?: string
   loanSchemeId?: string
   state?: VaultState
+  verbose?: boolean
 }
 
 interface VaultPagination {

--- a/packages/jellyfish-api-core/__tests__/category/loan/depositToVault.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/depositToVault.test.ts
@@ -132,7 +132,8 @@ describe('Loan depositToVault', () => {
     await tGroup.waitForSync()
   }
 
-  it('should be failed as first deposit must be DFI', async () => {
+  // TODO: Logic moved to take loan (need to test it on take loan side instead)
+  it.skip('should be failed as first deposit must be DFI', async () => {
     const promise = tGroup.get(0).rpc.loan.depositToVault({
       vaultId: vaultId, from: collateralAddress, amount: '1@BTC'
     })
@@ -300,7 +301,8 @@ describe('Loan depositToVault', () => {
     await expect(promise).rejects.toThrow('tx must have at least one input from token owner')
   })
 
-  it('should be failed as vault must contain min 50% of DFI', async () => {
+  // TODO: Logic moved to take loan (need to test it on take loan side instead)
+  it.skip('should be failed as vault must contain min 50% of DFI', async () => {
     await tGroup.get(0).rpc.loan.depositToVault({
       vaultId: vaultId1, from: collateralAddress, amount: '1000@DFI'
     })

--- a/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
@@ -1,7 +1,7 @@
 import { LoanMasterNodeRegTestContainer } from './loan_container'
 import { Testing } from '@defichain/jellyfish-testing'
 import BigNumber from 'bignumber.js'
-import { VaultDetails, VaultState } from '../../../src/category/loan'
+import { VaultState } from '../../../src/category/loan'
 
 describe('Loan listVaults', () => {
   const container = new LoanMasterNodeRegTestContainer()
@@ -29,9 +29,15 @@ describe('Loan listVaults', () => {
     oracleId = await testing.rpc.oracle.appointOracle(addr, priceFeeds, { weightage: 1 })
     await testing.generate(1)
     const timestamp = Math.floor(new Date().getTime() / 1000)
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '1@DFI', currency: 'USD' }] })
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }] })
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '2@AAPL', currency: 'USD' }] })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '1@DFI', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@AAPL', currency: 'USD' }]
+    })
     await testing.generate(1)
 
     // collateral tokens
@@ -100,7 +106,9 @@ describe('Loan listVaults', () => {
     await testing.generate(1)
     // make vault enter under liquidation state by a price hike of the loan token
     const timestamp = Math.floor(new Date().getTime() / 1000)
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '1000@AAPL', currency: 'USD' }] })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '1000@AAPL', currency: 'USD' }]
+    })
     await testing.generate(1)
 
     // List vaults
@@ -147,7 +155,10 @@ describe('Loan listVaults with options and pagination', () => {
     await testing.container.start()
     await testing.container.waitForWalletCoinbaseMaturity()
     collateralAddress = await testing.generateAddress()
-    await testing.token.dfi({ address: collateralAddress, amount: 40000 })
+    await testing.token.dfi({
+      address: collateralAddress,
+      amount: 40000
+    })
 
     // loan scheme
     await testing.container.call('createloanscheme', [100, 1, 'default'])
@@ -164,10 +175,18 @@ describe('Loan listVaults with options and pagination', () => {
     oracleId = await testing.rpc.oracle.appointOracle(addr, priceFeeds, { weightage: 1 })
     await testing.generate(1)
     const timestamp = Math.floor(new Date().getTime() / 1000)
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '1@DFI', currency: 'USD' }] })
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }] })
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '2@AAPL', currency: 'USD' }] })
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '4@GOOGL', currency: 'USD' }] })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '1@DFI', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '2@AAPL', currency: 'USD' }]
+    })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{ tokenAmount: '4@GOOGL', currency: 'USD' }]
+    })
     await testing.generate(1)
 
     // collateral tokens
@@ -230,7 +249,9 @@ describe('Loan listVaults with options and pagination', () => {
     await testing.generate(1)
     // make vault enter under liquidation state by a price hike of the loan token
     const timestamp2 = Math.floor(new Date().getTime() / 1000)
-    await testing.rpc.oracle.setOracleData(oracleId, timestamp2, { prices: [{ tokenAmount: '1000@AAPL', currency: 'USD' }] })
+    await testing.rpc.oracle.setOracleData(oracleId, timestamp2, {
+      prices: [{ tokenAmount: '1000@AAPL', currency: 'USD' }]
+    })
     await testing.generate(12) // Wait for 12 blocks which are equivalent to 2 hours (1 block = 10 minutes) in order to liquidate the vault
   })
 
@@ -311,12 +332,18 @@ describe('Loan listVaults with options and pagination', () => {
     expect(vaults.length).toStrictEqual(2)
 
     // fetch the second page
-    const vaultsSecondPage = await testing.rpc.loan.listVaults({ including_start: false, start: vaults[vaults.length - 1].vaultId })
+    const vaultsSecondPage = await testing.rpc.loan.listVaults({
+      including_start: false,
+      start: vaults[vaults.length - 1].vaultId
+    })
     // should be 2 entries
     expect(vaultsSecondPage.length).toStrictEqual(2) // total 4, started at index[2], listing 2
 
     // fetch the second page with including_start = true
-    const vaultsSecondPageIncludingStart = await testing.rpc.loan.listVaults({ including_start: true, start: vaults[vaults.length - 1].vaultId })
+    const vaultsSecondPageIncludingStart = await testing.rpc.loan.listVaults({
+      including_start: true,
+      start: vaults[vaults.length - 1].vaultId
+    })
     // should be 3 entries
     expect(vaultsSecondPageIncludingStart.length).toStrictEqual(3) // total 4, including_start, started at index[1], listing 3
 
@@ -370,7 +397,10 @@ describe('Loan listVaults with options and pagination', () => {
     ]))
 
     // fetch the second page
-    const vaultsSecondPage = await testing.rpc.loan.listVaults({ including_start: false, start: vaults[Object.keys(vaults).length - 1].vaultId }, { ownerAddress: ownerAddress1 })
+    const vaultsSecondPage = await testing.rpc.loan.listVaults({
+      including_start: false,
+      start: vaults[Object.keys(vaults).length - 1].vaultId
+    }, { ownerAddress: ownerAddress1 })
     // should be no more entries
     expect(Object.keys(vaultsSecondPage).length).toStrictEqual(0)
   })
@@ -390,7 +420,10 @@ describe('Loan listVaults with options and pagination', () => {
     ])
 
     // fetch the second page
-    const vaultsSecondPage = await testing.rpc.loan.listVaults({ including_start: false, start: vaults[Object.keys(vaults).length - 1].vaultId }, { loanSchemeId: 'scheme' })
+    const vaultsSecondPage = await testing.rpc.loan.listVaults({
+      including_start: false,
+      start: vaults[Object.keys(vaults).length - 1].vaultId
+    }, { loanSchemeId: 'scheme' })
     // should be no more entries
     expect(Object.keys(vaultsSecondPage).length).toStrictEqual(0)
   })
@@ -402,7 +435,10 @@ describe('Loan listVaults with options and pagination', () => {
     expect(Object.keys(vaults).length).toStrictEqual(2)
 
     // fetch the second page
-    const vaultsSecondPage = await testing.rpc.loan.listVaults({ including_start: false, start: vaults[Object.keys(vaults).length - 1].vaultId }, { state: VaultState.ACTIVE })
+    const vaultsSecondPage = await testing.rpc.loan.listVaults({
+      including_start: false,
+      start: vaults[Object.keys(vaults).length - 1].vaultId
+    }, { state: VaultState.ACTIVE })
     // should be one more entry
     expect(Object.keys(vaultsSecondPage).length).toStrictEqual(1)
   })
@@ -413,16 +449,31 @@ describe('Loan listVaults with options and pagination', () => {
     expect(activeVaults.every(vault => vault.state === VaultState.ACTIVE))
 
     const ts = Math.floor(new Date().getTime() / 1000)
-    const vaultId = await testing.rpc.loan.createVault({ ownerAddress: await testing.generateAddress(), loanSchemeId: 'scheme' })
+    const vaultId = await testing.rpc.loan.createVault({
+      ownerAddress: await testing.generateAddress(),
+      loanSchemeId: 'scheme'
+    })
     await testing.generate(1)
-    await testing.rpc.loan.depositToVault({ vaultId: vaultId, from: collateralAddress, amount: '10000@DFI' })
+    await testing.rpc.loan.depositToVault({
+      vaultId: vaultId,
+      from: collateralAddress,
+      amount: '10000@DFI'
+    })
     await testing.generate(1)
-    await testing.rpc.loan.takeLoan({ vaultId: vaultId, amounts: '30@GOOGL' })
+    await testing.rpc.loan.takeLoan({
+      vaultId: vaultId,
+      amounts: '30@GOOGL'
+    })
     await testing.generate(1)
     await testing.rpc.oracle.setOracleData(
       oracleId,
       ts,
-      { prices: [{ tokenAmount: '8@GOOGL', currency: 'USD' }] }
+      {
+        prices: [{
+          tokenAmount: '8@GOOGL',
+          currency: 'USD'
+        }]
+      }
     )
     // do frozen vault
     await testing.generate(6)
@@ -446,14 +497,14 @@ describe('Loan listVaults with options and pagination', () => {
 
     const liqVaults = await testing.rpc.loan.listVaults({}, { state: VaultState.IN_LIQUIDATION })
     expect(liqVaults.length).toBeGreaterThan(0)
-    const liqVault = liqVaults.find(vault => vault.vaultId === vaultId) as VaultDetails
+    const liqVault = liqVaults.find(vault => vault.vaultId === vaultId)!
     expect(liqVault?.state).toStrictEqual(VaultState.IN_LIQUIDATION)
 
     // end the auction
     await testing.generate(36)
 
     const vaults = await testing.rpc.loan.listVaults()
-    const theLiqVault = vaults.find(vault => vault.vaultId === vaultId) as VaultDetails
+    const theLiqVault = vaults.find(vault => vault.vaultId === vaultId)!
     expect(theLiqVault.state).toStrictEqual(VaultState.MAY_LIQUIDATE)
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
@@ -259,6 +259,56 @@ describe('Loan listVaults with options and pagination', () => {
     await testing.container.stop()
   })
 
+  it('should listVaults verbose', async () => {
+    // List vaults
+    const vaults = await testing.rpc.loan.listVaults({}, { verbose: true })
+
+    const activeTemplate = {
+      collateralAmounts: expect.any(Array),
+      loanAmounts: expect.any(Array),
+      interestAmounts: expect.any(Array),
+      collateralValue: expect.any(BigNumber),
+      loanValue: expect.any(BigNumber),
+      interestValue: expect.any(BigNumber),
+      collateralRatio: expect.any(Number),
+      informativeRatio: expect.any(BigNumber)
+    }
+
+    expect(vaults).toStrictEqual(expect.arrayContaining([
+      {
+        vaultId: vaultId1,
+        ownerAddress: ownerAddress1,
+        loanSchemeId: 'default',
+        state: VaultState.ACTIVE,
+        ...activeTemplate
+      },
+      {
+        vaultId: vaultId2,
+        ownerAddress: ownerAddress2,
+        loanSchemeId: 'default',
+        state: VaultState.ACTIVE,
+        ...activeTemplate
+      },
+      {
+        vaultId: vaultId3,
+        ownerAddress: ownerAddress3,
+        loanSchemeId: 'scheme',
+        state: VaultState.ACTIVE,
+        ...activeTemplate
+      },
+      {
+        vaultId: vaultId4,
+        ownerAddress: ownerAddress4,
+        loanSchemeId: 'default',
+        state: VaultState.IN_LIQUIDATION,
+        liquidationHeight: expect.any(Number),
+        liquidationPenalty: expect.any(Number),
+        batchCount: expect.any(Number),
+        batches: expect.any(Array)
+      }
+    ]))
+  })
+
   it('should listVaults with ownerAddress', async () => {
     // List vaults
     const vaults = await testing.rpc.loan.listVaults({}, { ownerAddress: ownerAddress1 })
@@ -291,7 +341,7 @@ describe('Loan listVaults with options and pagination', () => {
     ])
   })
 
-  it('should listVaults with state inLiquidation', async () => {
+  it('should listVaults with Active|IN_LIQUIDATION', async () => {
     // List vaults
     const nonLiquidatedVaults = await testing.rpc.loan.listVaults({}, { state: VaultState.ACTIVE })
     expect(nonLiquidatedVaults).toStrictEqual(expect.arrayContaining([

--- a/packages/jellyfish-api-core/__tests__/category/loan/paybackLoan.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/paybackLoan.test.ts
@@ -3,6 +3,7 @@ import { GenesisKeys } from '@defichain/testcontainers'
 import BigNumber from 'bignumber.js'
 import { TestingGroup } from '@defichain/jellyfish-testing'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
+import { VaultActive } from '../../../src/category/loan'
 
 const tGroup = TestingGroup.create(2, i => new LoanMasterNodeRegTestContainer(GenesisKeys[i]))
 const alice = tGroup.get(0)
@@ -612,7 +613,7 @@ describe('paybackLoan failed', () => {
   })
 
   it('should not paybackLoan while insufficient amount', async () => {
-    const vault = await bob.rpc.loan.getVault(bobVaultId)
+    const vault = await bob.rpc.loan.getVault(bobVaultId) as VaultActive
     expect(vault.loanAmounts).toStrictEqual(['40.00002283@TSLA'])
 
     const bobLoanAcc = await bob.rpc.account.getAccount(bobloanAddr)

--- a/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/setCollateralToken.test.ts
@@ -56,7 +56,7 @@ describe('Loan setCollateralToken', () => {
 
   it('should not setCollateralToken if factor is greater than 1', async () => {
     const promise = testing.rpc.loan.setCollateralToken({ token: 'AAPL', factor: new BigNumber(1.01), fixedIntervalPriceId: 'AAPL/USD' })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nsetCollateralToken factor must be lower or equal than 1.00000000!\', code: -32600, method: setcollateraltoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanCollateralTokenTx execution failed:\nsetCollateralToken factor must be lower or equal than 1.00000000!\', code: -32600, method: setcollateraltoken')
   })
 
   it('should not setCollateralToken if factor is less than 0', async () => {
@@ -70,7 +70,7 @@ describe('Loan setCollateralToken', () => {
       factor: new BigNumber(0.5),
       fixedIntervalPriceId: 'MFST/USD'
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nPrice feed MFST/USD does not belong to any oracle\', code: -32600, method: setcollateraltoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanCollateralTokenTx execution failed:\nPrice feed MFST/USD does not belong to any oracle\', code: -32600, method: setcollateraltoken')
   })
 
   it('should not setLoanToken if fixedIntervalPriceId is not in correct format', async () => {
@@ -132,7 +132,7 @@ describe('Loan setCollateralToken', () => {
       factor: new BigNumber(0.5),
       fixedIntervalPriceId: 'AAPL/USD'
     }, [utxo])
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setcollateraltoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanCollateralTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setcollateraltoken')
   })
 })
 
@@ -225,6 +225,6 @@ describe('Loan setCollateralToken with activateAfterBlock less than the current 
       fixedIntervalPriceId: 'AAPL/USD',
       activateAfterBlock: 109
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetCollateralTokenTx execution failed:\nactivateAfterBlock cannot be less than current height!\', code: -32600, method: setcollateraltoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanCollateralTokenTx execution failed:\nactivateAfterBlock cannot be less than current height!\', code: -32600, method: setcollateraltoken')
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/loan/setLoanToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/setLoanToken.test.ts
@@ -103,7 +103,7 @@ describe('Loan setLoanToken', () => {
       symbol: '',
       fixedIntervalPriceId: 'Token2/USD'
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntoken symbol should be non-empty and starts with a letter\', code: -32600, method: setloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanTokenTx execution failed:\ntoken symbol should be non-empty and starts with a letter\', code: -32600, method: setloantoken')
   })
 
   it('should not setLoanToken if the symbol is used in other token', async () => {
@@ -127,7 +127,7 @@ describe('Loan setLoanToken', () => {
       symbol: 'Token3',
       fixedIntervalPriceId: 'Token3/USD'
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntoken \'Token3\' already exists!\', code: -32600, method: setloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanTokenTx execution failed:\ntoken \'Token3\' already exists!\', code: -32600, method: setloantoken')
   })
 
   it('should not setLoanToken if fixedIntervalPriceId does not belong to any oracle', async () => {
@@ -135,7 +135,7 @@ describe('Loan setLoanToken', () => {
       symbol: 'Token4',
       fixedIntervalPriceId: 'Token4/USD'
     })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\nno live oracles for specified request\', code: -32600, method: setloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanTokenTx execution failed:\nno live oracles for specified request\', code: -32600, method: setloantoken')
   })
 
   it('should not setLoanToken if fixedIntervalPriceId is not in correct format', async () => {
@@ -392,6 +392,6 @@ describe('Loan setLoanToken', () => {
       symbol: 'Token18',
       fixedIntervalPriceId: 'Token18/USD'
     }, [utxo])
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanSetLoanTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test SetLoanTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: setloantoken')
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/loan/updateLoanToken.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/updateLoanToken.test.ts
@@ -142,7 +142,7 @@ describe('Loan updateLoanToken', () => {
 
   it('should not updateLoanToken if symbol is an empty string', async () => {
     const promise = testing.rpc.loan.updateLoanToken('Token1', { symbol: '' })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanUpdateLoanTokenTx execution failed:\ntoken symbol should be non-empty and starts with a letter\', code: -32600, method: updateloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test UpdateLoanTokenTx execution failed:\ntoken symbol should be non-empty and starts with a letter\', code: -32600, method: updateloantoken')
   })
 
   it('should not updateLoanToken if the symbol is used in other token', async () => {
@@ -164,7 +164,7 @@ describe('Loan updateLoanToken', () => {
     await testing.generate(1)
 
     const promise = testing.rpc.loan.updateLoanToken('Token4', { symbol: 'Token1' }) // Same as Token1's symbol
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanUpdateLoanTokenTx execution failed:\ntoken with key \'Token1\' already exists!\', code: -32600, method: updateloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test UpdateLoanTokenTx execution failed:\ntoken with key \'Token1\' already exists!\', code: -32600, method: updateloantoken')
   })
 
   it('should updateLoanToken with the given name', async () => {
@@ -236,7 +236,7 @@ describe('Loan updateLoanToken', () => {
 
   it('should not updateLoanToken if fixedIntervalPriceId does not belong to any oracle', async () => {
     const promise = testing.rpc.loan.updateLoanToken('Token1', { symbol: 'Token2', fixedIntervalPriceId: 'X/USD' })
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanUpdateLoanTokenTx execution failed:\nPrice feed X/USD does not belong to any oracle\', code: -32600, method: updateloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test UpdateLoanTokenTx execution failed:\nPrice feed X/USD does not belong to any oracle\', code: -32600, method: updateloantoken')
   })
 
   it('should not updateLoanToken if fixedIntervalPriceId is not in correct format', async () => {
@@ -318,6 +318,6 @@ describe('Loan updateLoanToken', () => {
   it('should updateLoanToken with utxos not from foundation member', async () => {
     const utxo = await testing.container.fundAddress(await testing.generateAddress(), 10)
     const promise = testing.rpc.loan.updateLoanToken('Token1', { symbol: 'Token2' }, [utxo])
-    await expect(promise).rejects.toThrow('RpcApiError: \'Test LoanUpdateLoanTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: updateloantoken')
+    await expect(promise).rejects.toThrow('RpcApiError: \'Test UpdateLoanTokenTx execution failed:\ntx not from foundation member!\', code: -32600, method: updateloantoken')
   })
 })

--- a/packages/jellyfish-api-core/src/category/loan.ts
+++ b/packages/jellyfish-api-core/src/category/loan.ts
@@ -247,9 +247,10 @@ export class Loan {
    * @param {string} [options.ownerAddress] Address of the vault owner
    * @param {string} [options.loanSchemeId] Vault's loan scheme id
    * @param {VaultState} [options.state = VaultState.UNKNOWN] vault's state
-   * @return {Promise<Vault[]>} Array of objects including details of the vaults.
+   * @param {boolean} [options.verbose = false] true to return same information as getVault
+   * @return {Promise<Vault | VaultActive | VaultLiquidation[]>} Array of objects including details of the vaults.
    */
-  async listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<Vault[]> {
+  async listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<Array<Vault | VaultActive | VaultLiquidation>> {
     return await this.client.call(
       'listvaults',
       [options, pagination],
@@ -483,6 +484,7 @@ export interface ListVaultOptions {
   ownerAddress?: string
   loanSchemeId?: string
   state?: VaultState
+  verbose?: boolean
 }
 
 export interface CloseVault {

--- a/packages/jellyfish-api-core/src/category/loan.ts
+++ b/packages/jellyfish-api-core/src/category/loan.ts
@@ -35,9 +35,9 @@ export class Loan {
    * @param {BigNumber} scheme.interestRate Interest rate
    * @param {string} scheme.id Unique identifier of the loan scheme, max 8 chars
    * @param {number} [scheme.activateAfterBlock] Block height at which new changes take effect
-   * @param {UTXO[]} [options.utxos = []] Specific UTXOs to spend
-   * @param {string} options.utxos.txid Transaction Id
-   * @param {number} options.utxos.vout Output number
+   * @param {UTXO[]} [utxos = []] Specific UTXOs to spend
+   * @param {string} utxos.txid Transaction Id
+   * @param {number} utxos.vout Output number
    * @return {Promise<string>} Hex string of the transaction
    */
   async updateLoanScheme (scheme: UpdateLoanScheme, utxos: UTXO[] = []): Promise<string> {
@@ -145,11 +145,12 @@ export class Loan {
    * @return {Promise<string>} LoanTokenId, also the txn id for txn created to set loan token
    */
   async setLoanToken (loanToken: SetLoanToken, utxos: UTXO[] = []): Promise<string> {
-    const defaultData = {
+    const payload = {
       mintable: true,
-      interest: 0
+      interest: 0,
+      ...loanToken
     }
-    return await this.client.call('setloantoken', [{ ...defaultData, ...loanToken }, utxos], 'number')
+    return await this.client.call('setloantoken', [payload, utxos], 'number')
   }
 
   /**
@@ -226,7 +227,12 @@ export class Loan {
     return await this.client.call(
       'getvault',
       [vaultId],
-      { collateralValue: 'bignumber', loanValue: 'bignumber', interestValue: 'bignumber', informativeRatio: 'bignumber' }
+      {
+        collateralValue: 'bignumber',
+        loanValue: 'bignumber',
+        interestValue: 'bignumber',
+        informativeRatio: 'bignumber'
+      }
     )
   }
 
@@ -247,7 +253,12 @@ export class Loan {
     return await this.client.call(
       'listvaults',
       [options, pagination],
-      { collateralValue: 'bignumber', loanValue: 'bignumber', interestValue: 'bignumber', informativeRatio: 'bignumber' }
+      {
+        collateralValue: 'bignumber',
+        loanValue: 'bignumber',
+        interestValue: 'bignumber',
+        informativeRatio: 'bignumber'
+      }
     )
   }
 

--- a/packages/jellyfish-api-core/src/category/loan.ts
+++ b/packages/jellyfish-api-core/src/category/loan.ts
@@ -221,9 +221,9 @@ export class Loan {
    * Returns information about vault.
    *
    * @param {string} vaultId vault hex id
-   * @return {Promise<VaultDetails>}
+   * @return {Promise<VaultActive | VaultLiquidation>}
    */
-  async getVault (vaultId: string): Promise<VaultDetails> {
+  async getVault (vaultId: string): Promise<VaultActive | VaultLiquidation> {
     return await this.client.call(
       'getvault',
       [vaultId],
@@ -247,9 +247,9 @@ export class Loan {
    * @param {string} [options.ownerAddress] Address of the vault owner
    * @param {string} [options.loanSchemeId] Vault's loan scheme id
    * @param {VaultState} [options.state = VaultState.UNKNOWN] vault's state
-   * @return {Promise<VaultDetails[]>} Array of objects including details of the vaults.
+   * @return {Promise<Vault[]>} Array of objects including details of the vaults.
    */
-  async listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<VaultDetails[]> {
+  async listVaults (pagination: VaultPagination = {}, options: ListVaultOptions = {}): Promise<Vault[]> {
     return await this.client.call(
       'listvaults',
       [options, pagination],
@@ -419,28 +419,32 @@ export enum VaultState {
   MAY_LIQUIDATE = 'mayLiquidate',
 }
 
-export interface VaultDetails {
-  // list and get both returns
+export interface Vault {
   vaultId: string
   loanSchemeId: string
   ownerAddress: string
   state: VaultState
-  // get only returns
-  liquidationHeight?: number
-  liquidationPenalty?: number
-  batchCount?: number
-  batches?: AuctionBatchDetails[]
-  collateralAmounts?: string[]
-  loanAmounts?: string[]
-  interestAmounts?: string[]
-  collateralValue?: BigNumber
-  loanValue?: BigNumber
-  interestValue?: BigNumber
-  collateralRatio?: number
-  informativeRatio?: BigNumber
 }
 
-export interface AuctionBatchDetails {
+export interface VaultActive extends Vault {
+  collateralAmounts: string[]
+  loanAmounts: string[]
+  interestAmounts: string[]
+  collateralValue: BigNumber
+  loanValue: BigNumber
+  interestValue: BigNumber
+  collateralRatio: number
+  informativeRatio: BigNumber
+}
+
+export interface VaultLiquidation extends Vault {
+  liquidationHeight: number
+  liquidationPenalty: number
+  batchCount: number
+  batches: VaultLiquidationBatch[]
+}
+
+export interface VaultLiquidationBatch {
   index: BigNumber
   collaterals: string[]
   loan: string

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_deposit_to_vault.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_deposit_to_vault.test.ts
@@ -8,6 +8,7 @@ import { LoanMasterNodeRegTestContainer } from './loan_container'
 import { TestingGroup } from '@defichain/jellyfish-testing'
 import { RegTest } from '@defichain/jellyfish-network'
 import { P2WPKH } from '@defichain/jellyfish-address'
+import { VaultActive } from '@defichain/jellyfish-api-core/src/category/loan'
 
 describe('loans.depositToVault', () => {
   const tGroup = TestingGroup.create(2, i => new LoanMasterNodeRegTestContainer(GenesisKeys[i]))
@@ -60,9 +61,24 @@ describe('loans.depositToVault', () => {
     const oracleId = await tGroup.get(0).rpc.oracle.appointOracle(addr, priceFeeds, { weightage: 1 })
     await tGroup.get(0).generate(1)
     const timestamp = Math.floor(new Date().getTime() / 1000)
-    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '1@DFI', currency: 'USD' }] })
-    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '10000@BTC', currency: 'USD' }] })
-    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '2@TSLA', currency: 'USD' }] })
+    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{
+        tokenAmount: '1@DFI',
+        currency: 'USD'
+      }]
+    })
+    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{
+        tokenAmount: '10000@BTC',
+        currency: 'USD'
+      }]
+    })
+    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{
+        tokenAmount: '2@TSLA',
+        currency: 'USD'
+      }]
+    })
     await tGroup.get(0).generate(1)
 
     // collateral token
@@ -126,14 +142,19 @@ describe('loans.depositToVault', () => {
     await tGroup.get(0).generate(1)
 
     // liquidated: true
-    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, { prices: [{ tokenAmount: '100000@TSLA', currency: 'USD' }] })
+    await tGroup.get(0).rpc.oracle.setOracleData(oracleId, timestamp, {
+      prices: [{
+        tokenAmount: '100000@TSLA',
+        currency: 'USD'
+      }]
+    })
     await tGroup.get(0).generate(1)
     await tGroup.waitForSync()
   }
 
   it('should depositToVault', async () => {
     {
-      const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+      const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
       const script = await providers.elliptic.script()
       const txn = await builder.loans.depositToVault({
         vaultId: vaultId,
@@ -157,15 +178,15 @@ describe('loans.depositToVault', () => {
       await tGroup.get(0).generate(1)
       await tGroup.waitForSync()
 
-      const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+      const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
       // check the changes after deposit
       // calculate DFI collateral value with factor
       const dfiDeposit = 10000 * 1 * 1 // deposit 10000 DFI * priceFeed 1 USD * 1 factor
-      expect(vaultAfter.collateralValue?.minus(vaultBefore.collateralValue as BigNumber)).toStrictEqual(new BigNumber(dfiDeposit))
+      expect(vaultAfter.collateralValue.minus(vaultBefore.collateralValue)).toStrictEqual(new BigNumber(dfiDeposit))
     }
 
     {
-      const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+      const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
       const script = await providers.elliptic.script()
       const txn = await builder.loans.depositToVault({
         vaultId: vaultId,
@@ -189,16 +210,16 @@ describe('loans.depositToVault', () => {
       await tGroup.get(0).generate(1)
       await tGroup.waitForSync()
 
-      const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+      const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
       // check the changes after deposit
       // calculate BTC collateral value with factor
       const btcDeposit = 1 * 10000 * 0.5 // deposit 1 BTC * priceFeed 10000 USD * 0.5 factor
-      expect(vaultAfter.collateralValue?.minus(vaultBefore.collateralValue as BigNumber)).toStrictEqual(new BigNumber(btcDeposit))
+      expect(vaultAfter.collateralValue.minus(vaultBefore.collateralValue)).toStrictEqual(new BigNumber(btcDeposit))
     }
   })
 
   it('should be able to depositToVault by anyone', async () => {
-    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
 
     // test node1 deposits to vault
     const newProviders = await getProviders(tGroup.get(1).container)
@@ -236,11 +257,11 @@ describe('loans.depositToVault', () => {
     await tGroup.get(1).generate(1)
     await tGroup.waitForSync()
 
-    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     // check the changes after deposit
     // calculate DFI collateral value with factor
     const dfiDeposit = 2 * 1 * 1 // deposit 2 DFI * priceFeed 1 USD * 1 factor
-    expect(vaultAfter.collateralValue?.minus(vaultBefore.collateralValue as BigNumber)).toStrictEqual(new BigNumber(dfiDeposit))
+    expect(vaultAfter.collateralValue.minus(vaultBefore.collateralValue)).toStrictEqual(new BigNumber(dfiDeposit))
   })
 
   it('should be failed as first deposit must be DFI', async () => {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_deposit_to_vault.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_deposit_to_vault.test.ts
@@ -264,7 +264,8 @@ describe('loans.depositToVault', () => {
     expect(vaultAfter.collateralValue.minus(vaultBefore.collateralValue)).toStrictEqual(new BigNumber(dfiDeposit))
   })
 
-  it('should be failed as first deposit must be DFI', async () => {
+  // TODO: Logic moved to take loan (need to test it on take loan side instead)
+  it.skip('should be failed as first deposit must be DFI', async () => {
     const vaultId = await tGroup.get(0).rpc.loan.createVault({
       ownerAddress: await tGroup.get(0).generateAddress(),
       loanSchemeId: 'scheme'
@@ -331,7 +332,8 @@ describe('loans.depositToVault', () => {
     await expect(promise).rejects.toThrow(`Vault <${'0'.repeat(64)}> not found`)
   })
 
-  it('should be failed as vault must contain min 50% of DFI', async () => {
+  // TODO: Logic moved to take loan (need to test it on take loan side instead)
+  it.skip('should be failed as vault must contain min 50% of DFI', async () => {
     const vaultId = await tGroup.get(0).rpc.loan.createVault({
       ownerAddress: await tGroup.get(0).generateAddress(),
       loanSchemeId: 'scheme'

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_payback_loan.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_payback_loan.test.ts
@@ -9,6 +9,7 @@ import { TestingGroup } from '@defichain/jellyfish-testing'
 import { RegTest, RegTestGenesisKeys } from '@defichain/jellyfish-network'
 import { P2WPKH } from '@defichain/jellyfish-address'
 import { Script } from '@defichain/jellyfish-transaction'
+import { VaultActive } from '@defichain/jellyfish-api-core/src/category/loan'
 
 const tGroup = TestingGroup.create(2, i => new LoanMasterNodeRegTestContainer(RegTestGenesisKeys[i]))
 const alice = tGroup.get(0)
@@ -746,7 +747,7 @@ describe('paybackLoan failed #2', () => {
   })
 
   it('should not paybackLoan while insufficient amount', async () => {
-    const vault = await bob.rpc.loan.getVault(bobVaultId)
+    const vault = await bob.rpc.loan.getVault(bobVaultId) as VaultActive
     expect(vault.loanAmounts).toStrictEqual(['40.00002283@TSLA'])
 
     const bobLoanAcc = await bob.rpc.account.getAccount(bobColAddr)

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_collateral_token.test.ts
@@ -91,7 +91,7 @@ describe('loan.setCollateralToken()', () => {
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: token 2 does not exist! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanCollateralTokenTx: token 2 does not exist! (code 16)\', code: -26')
   })
 
   it('should not setCollateralToken if factor is greater than 1', async () => {
@@ -103,7 +103,7 @@ describe('loan.setCollateralToken()', () => {
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: setCollateralToken factor must be lower or equal than 1.00000000! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanCollateralTokenTx: setCollateralToken factor must be lower or equal than 1.00000000! (code 16)\', code: -26')
   })
 
   it('should not setCollateralToken if currencyPair does not belong to any oracle', async () => {
@@ -115,7 +115,7 @@ describe('loan.setCollateralToken()', () => {
       activateAfterBlock: 0
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanCollateralTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
   })
 })
 
@@ -225,6 +225,6 @@ describe('loan.setCollateralToken() with activateAfterBlock below current height
       activateAfterBlock: 149
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetCollateralTokenTx: activateAfterBlock cannot be less than current height! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanCollateralTokenTx: activateAfterBlock cannot be less than current height! (code 16)\', code: -26')
   })
 })

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_set_loan_token.test.ts
@@ -145,7 +145,7 @@ describe('loan.setLoanToken()', () => {
     }, script)
 
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('LoanSetLoanTokenTx: token symbol should be non-empty and starts with a letter (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('SetLoanTokenTx: token symbol should be non-empty and starts with a letter (code 16)\', code: -26')
   })
 
   it('should not setLoanToken if the symbol is used in other token', async () => {
@@ -179,7 +179,7 @@ describe('loan.setLoanToken()', () => {
     }, script)
 
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: token \'Token3\' already exists! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanTokenTx: token \'Token3\' already exists! (code 16)\', code: -26')
   })
 
   it('should not setLoanToken if currencyPair does not belong to any oracle', async () => {
@@ -193,7 +193,7 @@ describe('loan.setLoanToken()', () => {
     }, script)
     const promise = sendTransaction(testing.container, txn)
 
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanSetLoanTokenTx: no live oracles for specified request (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'SetLoanTokenTx: no live oracles for specified request (code 16)\', code: -26')
   })
 
   it('should setLoanToken with the given name', async () => {

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_take_loan.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_take_loan.test.ts
@@ -8,6 +8,7 @@ import { LoanMasterNodeRegTestContainer } from './loan_container'
 import { TestingGroup } from '@defichain/jellyfish-testing'
 import { RegTest } from '@defichain/jellyfish-network'
 import { P2WPKH } from '@defichain/jellyfish-address'
+import { VaultActive } from '@defichain/jellyfish-api-core/src/category/loan'
 
 describe('loans.takeLoan', () => {
   const tGroup = TestingGroup.create(2, i => new LoanMasterNodeRegTestContainer(GenesisKeys[i]))
@@ -194,7 +195,7 @@ describe('loans.takeLoan', () => {
     // fund if UTXO is not available for fees
     await fundForFeesIfUTXONotAvailable(10)
 
-    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const script = await providers.elliptic.script()
     const txn = await builder.loans.takeLoan({
       vaultId: vaultId,
@@ -218,12 +219,12 @@ describe('loans.takeLoan', () => {
     await tGroup.get(0).generate(1)
     await tGroup.waitForSync()
 
-    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const interestAfter = await tGroup.get(0).rpc.loan.getInterest('scheme', 'TSLA')
 
-    const vaultBeforeLoanTSLAAcc = vaultBefore.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'TSLA')
+    const vaultBeforeLoanTSLAAcc = vaultBefore.loanAmounts.find((amt: string) => amt.split('@')[1] === 'TSLA')
     const vaultBeforeLoanTSLAAmount = vaultBeforeLoanTSLAAcc !== undefined ? Number(vaultBeforeLoanTSLAAcc?.split('@')[0]) : 0
-    const vaultAfterLoanTSLAAcc = vaultAfter.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'TSLA')
+    const vaultAfterLoanTSLAAcc = vaultAfter.loanAmounts.find((amt: string) => amt.split('@')[1] === 'TSLA')
     const vaultAfterLoanTSLAAmount = Number(vaultAfterLoanTSLAAcc?.split('@')[0])
 
     const interestAfterTSLA = interestAfter.find((interest: { 'token': string }) => interest.token === 'TSLA')
@@ -254,7 +255,7 @@ describe('loans.takeLoan', () => {
     // fund if UTXO is not available for fees
     await fundForFeesIfUTXONotAvailable(10)
 
-    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const script = await providers.elliptic.script()
     const toAddress = await tGroup.get(1).generateAddress()
     const txn = await builder.loans.takeLoan({
@@ -279,12 +280,12 @@ describe('loans.takeLoan', () => {
     await tGroup.get(0).generate(1)
     await tGroup.waitForSync()
 
-    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const interestAfter = await tGroup.get(0).rpc.loan.getInterest('scheme', 'CAT')
 
-    const vaultBeforeLoanTSLAAcc = vaultBefore.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'CAT')
+    const vaultBeforeLoanTSLAAcc = vaultBefore.loanAmounts.find((amt: string) => amt.split('@')[1] === 'CAT')
     const vaultBeforeLoanTSLAAmount = vaultBeforeLoanTSLAAcc !== undefined ? Number(vaultBeforeLoanTSLAAcc?.split('@')[0]) : 0
-    const vaultAfterLoanTSLAAcc = vaultAfter.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'CAT')
+    const vaultAfterLoanTSLAAcc = vaultAfter.loanAmounts.find((amt: string) => amt.split('@')[1] === 'CAT')
     const vaultAfterLoanTSLAAmount = Number(vaultAfterLoanTSLAAcc?.split('@')[0])
 
     const interestAfterTSLA = interestAfter.find((interest: { 'token': string }) => interest.token === 'CAT')
@@ -316,7 +317,7 @@ describe('loans.takeLoan', () => {
     // fund if UTXO is not available for fees
     await fundForFeesIfUTXONotAvailable(10)
 
-    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultBefore = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const script = await providers.elliptic.script()
     const txn = await builder.loans.takeLoan({
       vaultId: vaultId,
@@ -340,17 +341,17 @@ describe('loans.takeLoan', () => {
     await tGroup.get(0).generate(1)
     await tGroup.waitForSync()
 
-    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId)
+    const vaultAfter = await tGroup.get(0).rpc.loan.getVault(vaultId) as VaultActive
     const interestAfter = await tGroup.get(0).rpc.loan.getInterest('scheme')
 
-    const vaultBeforeLoanAMZNAcc = vaultBefore.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'AMZN')
+    const vaultBeforeLoanAMZNAcc = vaultBefore.loanAmounts.find((amt: string) => amt.split('@')[1] === 'AMZN')
     const vaultBeforeLoanAMZNAmount = vaultBeforeLoanAMZNAcc !== undefined ? Number(vaultBeforeLoanAMZNAcc?.split('@')[0]) : 0
-    const vaultBeforeLoanUBERAcc = vaultBefore.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'UBER')
+    const vaultBeforeLoanUBERAcc = vaultBefore.loanAmounts.find((amt: string) => amt.split('@')[1] === 'UBER')
     const vaultBeforeLoanUBERAmount = vaultBeforeLoanUBERAcc !== undefined ? Number(vaultBeforeLoanUBERAcc?.split('@')[0]) : 0
 
-    const vaultAfterLoanAMZNAcc = vaultAfter.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'AMZN')
+    const vaultAfterLoanAMZNAcc = vaultAfter.loanAmounts.find((amt: string) => amt.split('@')[1] === 'AMZN')
     const vaultAfterLoanAMZNAmount = Number(vaultAfterLoanAMZNAcc?.split('@')[0])
-    const vaultAfterLoanUBERAcc = vaultAfter.loanAmounts?.find((amt: string) => amt.split('@')[1] === 'UBER')
+    const vaultAfterLoanUBERAcc = vaultAfter.loanAmounts.find((amt: string) => amt.split('@')[1] === 'UBER')
     const vaultAfterLoanUBERAmount = Number(vaultAfterLoanUBERAcc?.split('@')[0])
 
     const interestAfterAMZN = interestAfter.find((interest: { 'token': string }) => interest.token === 'AMZN')

--- a/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_update_loan_token.test.ts
+++ b/packages/jellyfish-transaction-builder/__tests__/txn/txn_builder_loan_update_loan_token.test.ts
@@ -187,7 +187,7 @@ describe('loan.updateLoanToken()', () => {
       tokenTx: loanTokenId
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanUpdateLoanTokenTx: token symbol should be non-empty and starts with a letter (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'UpdateLoanTokenTx: token symbol should be non-empty and starts with a letter (code 16)\', code: -26')
   })
 
   it('should not updateLoanToken if the symbol is used in other token', async () => {
@@ -223,7 +223,7 @@ describe('loan.updateLoanToken()', () => {
       tokenTx: loanTokenId
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanUpdateLoanTokenTx: token with key \'Token1\' already exists! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'UpdateLoanTokenTx: token with key \'Token1\' already exists! (code 16)\', code: -26')
   })
 
   it('should updateLoanToken if name is more than 128 letters', async () => {
@@ -293,7 +293,7 @@ describe('loan.updateLoanToken()', () => {
       tokenTx: loanTokenId
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanUpdateLoanTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'UpdateLoanTokenTx: Price feed MFST/USD does not belong to any oracle (code 16)\', code: -26')
   })
 
   it('should not updateLoanToken if tokenTx does not exist', async () => {
@@ -307,6 +307,6 @@ describe('loan.updateLoanToken()', () => {
       tokenTx: 'd6e157b66957dda2297947e31ac2a1d0c92eae515f35bc1ebad9478d06efa3c0'
     }, script)
     const promise = sendTransaction(testing.container, txn)
-    await expect(promise).rejects.toThrow('DeFiDRpcError: \'LoanUpdateLoanTokenTx: Loan token (d6e157b66957dda2297947e31ac2a1d0c92eae515f35bc1ebad9478d06efa3c0) does not exist! (code 16)\', code: -26')
+    await expect(promise).rejects.toThrow('DeFiDRpcError: \'UpdateLoanTokenTx: Loan token (d6e157b66957dda2297947e31ac2a1d0c92eae515f35bc1ebad9478d06efa3c0) does not exist! (code 16)\', code: -26')
   })
 })

--- a/packages/testcontainers/src/containers/RegTestContainer/LoanContainer.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/LoanContainer.ts
@@ -4,7 +4,7 @@ import { MasterNodeRegTestContainer } from './Masternode'
 
 export class LoanMasterNodeRegTestContainer extends MasterNodeRegTestContainer {
   constructor (masternodeKey: MasterNodeKey = RegTestFoundationKeys[0]) {
-    super(masternodeKey, 'defi/defichain:master-da0bbfa')
+    super(masternodeKey, 'defi/defichain:2.0.0')
   }
 
   protected getCmd (opts: StartOptions): string[] {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

- Bump LoanContainer to `2.0.0`
- Updated `.eslintrc` and `.idea/` for better DX
- Refactor `loan.getVault` and `loan.listVault` interfaces in jellyfish-api-core to match different Vault states:
  - `Vault` for empty states
  - `VaultActive` for active state
  - `VaultLiquation` for liquating state
- Added new verbose flag for `loan.listVault`
- Some internal DeFiD `DfTx` naming convention has been updated, this has been updated to reflect the changes to fix failing tests that rely on them.

#### Breaking Changes

> https://github.com/DeFiCh/jellyfish/issues/802 

Deposit to Vault 50% DFI requirements has been moved from `depositToVault` to `takeLoan`, additional testing needs to be done on TakeLoan.

```ts
// TODO: Logic moved to take loan (need to test it on take loan side instead)
it.skip('should be failed as first deposit must be DFI', async () => {
```

```ts
// TODO: Logic moved to take loan (need to test it on take loan side instead)
it.skip('should be failed as vault must contain min 50% of DFI', async () => {
```
