### PR TITLE
Add waitForNewBlock and waitForBlockHeight RPC

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -84,6 +84,7 @@
       <w>getinterest</w>
       <w>getloanscheme</w>
       <w>getloantoken</w>
+      <w>getmempoolinfo</w>
       <w>getmintinginfo</w>
       <w>getnetworkhashps</w>
       <w>getnewaddress</w>
@@ -245,6 +246,8 @@
       <w>vernotif</w>
       <w>vout</w>
       <w>vsize</w>
+      <w>waitforblockheight</w>
+      <w>waitfornewblock</w>
       <w>walletname</w>
       <w>walletversion</w>
       <w>wpkh</w>

--- a/docs/node/RPC Category/01-blockchain.md
+++ b/docs/node/RPC Category/01-blockchain.md
@@ -341,3 +341,33 @@ interface blockchain {
   getBestBlockHash (): Promise<string>
 }
 ```
+
+## waitForNewBlock
+
+Wait for any new block
+
+```ts title="client.blockchain.waitForNewBlock()"
+interface blockchain {
+  waitForNewBlock (timeout: number = 30000): Promise<WaitBlockResult>
+}
+
+interface WaitBlockResult {
+  hash: string
+  height: number
+}
+```
+
+## waitForBlockHeight
+
+Waits for block height equal or higher than provided and returns the height and hash of the current tip.
+
+```ts title="client.blockchain.waitForBlockHeight()"
+interface blockchain {
+  waitForBlockHeight (height: number, timeout: number = 30000): Promise<waitForBlockHeight>
+}
+
+interface WaitBlockResult {
+  hash: string
+  height: number
+}
+```

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
@@ -4,7 +4,7 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 const container = new MasterNodeRegTestContainer()
 const client = new ContainerAdapterClient(container)
 
-describe('new block', () => {
+describe('new block height 10', () => {
   beforeAll(async () => {
     await container.start()
   })
@@ -13,28 +13,28 @@ describe('new block', () => {
     await container.stop()
   })
 
-  it('should wait for new block', async () => {
+  it('should wait for new block height', async () => {
     {
       const count = await client.blockchain.getBlockCount()
       expect(count).toStrictEqual(0)
     }
 
     {
-      const promise = client.blockchain.waitForNewBlock()
-      await container.generate(1)
+      const promise = client.blockchain.waitForBlockHeight(10)
+      await container.generate(10)
 
       expect(await promise).toStrictEqual({
-        height: 1,
+        height: 10,
         hash: expect.stringMatching(/^[0-f]{64}$/)
       })
 
       const count = await client.blockchain.getBlockCount()
-      expect(count).toStrictEqual(1)
+      expect(count).toStrictEqual(10)
     }
   })
 })
 
-describe('new block but expire', () => {
+describe('new block height 2 but expire', () => {
   beforeAll(async () => {
     await container.start()
   })
@@ -44,7 +44,7 @@ describe('new block but expire', () => {
   })
 
   it('should wait for new block with timeout and expire', async () => {
-    const result = await client.blockchain.waitForNewBlock(1000)
+    const result = await client.blockchain.waitForBlockHeight(2, 3000)
     expect(result).toStrictEqual({
       height: 0,
       hash: expect.stringMatching(/^[0-f]{64}$/)

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
@@ -1,0 +1,53 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+const container = new MasterNodeRegTestContainer()
+const client = new ContainerAdapterClient(container)
+
+describe('new block', () => {
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should wait for new block', async () => {
+    {
+      const count = await client.blockchain.getBlockCount()
+      expect(count).toStrictEqual(0)
+    }
+
+    {
+      const promise = client.blockchain.waitForNewBlock()
+      await container.generate(1)
+
+      expect(await promise).toStrictEqual({
+        height: 1,
+        hash: expect.stringMatching(/^[0-f]{64}$/)
+      })
+
+      const count = await client.blockchain.getBlockCount()
+      expect(count).toStrictEqual(1)
+    }
+  })
+})
+
+describe('new block but expire', () => {
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should wait for new block with timeout and expire', async () => {
+    const result = await client.blockchain.waitForNewBlock(1000)
+    expect(result).toStrictEqual({
+      height: 0,
+      hash: expect.stringMatching(/^[0-f]{64}$/)
+    })
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/waitForBlockHeight.test.ts
@@ -1,10 +1,11 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ContainerAdapterClient } from '../../container_adapter_client'
+import { TestingGroup } from '@defichain/jellyfish-testing'
 
-const container = new MasterNodeRegTestContainer()
-const client = new ContainerAdapterClient(container)
+describe('wait for block height 10', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
 
-describe('new block height 10', () => {
   beforeAll(async () => {
     await container.start()
   })
@@ -34,7 +35,27 @@ describe('new block height 10', () => {
   })
 })
 
-describe('new block height 2 but expire', () => {
+describe('wait for block height 10 on multiple nodes', () => {
+  const group = TestingGroup.create(2)
+
+  beforeAll(async () => {
+    await group.start()
+  })
+
+  afterAll(async () => {
+    await group.stop()
+  })
+
+  it('should wait for new block height of 10 on another node', async () => {
+    await group.get(0).container.generate(10)
+    await group.get(1).rpc.blockchain.waitForBlockHeight(10)
+  })
+})
+
+describe('wait for block height 2 but expire', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
   beforeAll(async () => {
     await container.start()
   })

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/waitForNewBlock.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/waitForNewBlock.test.ts
@@ -1,0 +1,53 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+const container = new MasterNodeRegTestContainer()
+const client = new ContainerAdapterClient(container)
+
+describe('new block height 10', () => {
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should wait for new block height', async () => {
+    {
+      const count = await client.blockchain.getBlockCount()
+      expect(count).toStrictEqual(0)
+    }
+
+    {
+      const promise = client.blockchain.waitForBlockHeight(10)
+      await container.generate(10)
+
+      expect(await promise).toStrictEqual({
+        height: 10,
+        hash: expect.stringMatching(/^[0-f]{64}$/)
+      })
+
+      const count = await client.blockchain.getBlockCount()
+      expect(count).toStrictEqual(10)
+    }
+  })
+})
+
+describe('new block height 2 but expire', () => {
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should wait for new block with timeout and expire', async () => {
+    const result = await client.blockchain.waitForBlockHeight(2, 3000)
+    expect(result).toStrictEqual({
+      height: 0,
+      hash: expect.stringMatching(/^[0-f]{64}$/)
+    })
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/blockchain/waitForNewBlock.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/blockchain/waitForNewBlock.test.ts
@@ -4,7 +4,7 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 const container = new MasterNodeRegTestContainer()
 const client = new ContainerAdapterClient(container)
 
-describe('new block height 10', () => {
+describe('new block', () => {
   beforeAll(async () => {
     await container.start()
   })
@@ -13,28 +13,28 @@ describe('new block height 10', () => {
     await container.stop()
   })
 
-  it('should wait for new block height', async () => {
+  it('should wait for new block', async () => {
     {
       const count = await client.blockchain.getBlockCount()
       expect(count).toStrictEqual(0)
     }
 
     {
-      const promise = client.blockchain.waitForBlockHeight(10)
-      await container.generate(10)
+      const promise = client.blockchain.waitForNewBlock()
+      await container.generate(1)
 
       expect(await promise).toStrictEqual({
-        height: 10,
+        height: 1,
         hash: expect.stringMatching(/^[0-f]{64}$/)
       })
 
       const count = await client.blockchain.getBlockCount()
-      expect(count).toStrictEqual(10)
+      expect(count).toStrictEqual(1)
     }
   })
 })
 
-describe('new block height 2 but expire', () => {
+describe('new block but expire', () => {
   beforeAll(async () => {
     await container.start()
   })
@@ -44,7 +44,7 @@ describe('new block height 2 but expire', () => {
   })
 
   it('should wait for new block with timeout and expire', async () => {
-    const result = await client.blockchain.waitForBlockHeight(2, 3000)
+    const result = await client.blockchain.waitForNewBlock(1000)
     expect(result).toStrictEqual({
       height: 0,
       hash: expect.stringMatching(/^[0-f]{64}$/)

--- a/packages/jellyfish-api-core/src/category/blockchain.ts
+++ b/packages/jellyfish-api-core/src/category/blockchain.ts
@@ -192,6 +192,28 @@ export class Blockchain {
   async getMempoolInfo (): Promise<MempoolInfo> {
     return await this.client.call('getmempoolinfo', [], { mempoolminfee: 'bignumber', minrelaytxfee: 'bignumber' })
   }
+
+  /**
+   * Wait for any new block
+   *
+   * @param {number} [timeout=30000] in millis
+   * @return Promise<WaitBlockResult> the current block on timeout or exit
+   */
+  async waitForNewBlock (timeout: number = 30000): Promise<WaitBlockResult> {
+    return await this.client.call('waitfornewblock', [timeout], 'number')
+  }
+
+  /**
+   * Waits for block height equal or higher than provided and returns the height and hash of the current tip.
+   *
+   *
+   * @param {number} height
+   * @param {number} [timeout=30000] in millis
+   * @return Promise<WaitBlockResult> the current block on timeout or exit
+   */
+  async waitForBlockHeight (height: number, timeout: number = 30000): Promise<WaitBlockResult> {
+    return await this.client.call('waitforblockheight', [height, timeout], 'number')
+  }
 }
 
 /**
@@ -387,4 +409,9 @@ export interface MempoolInfo {
   maxmempool: number
   mempoolminfee: BigNumber
   minrelaytxfee: BigNumber
+}
+
+export interface WaitBlockResult {
+  hash: string
+  height: number
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind feature

#### What this PR does / why we need it:

Add waitForNewBlock and waitForBlockHeight RPC, these 2 method is Node internal implementation to wait for the block. It does not fail when a new block doesn't come in. 

These 2 RPC interface is typed and added for downstream testing convenience. They are not very useful within the jellyfish context as the container wait function has auto-generate feature.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #48
