### PR TITLE
turn off no-lone-blocks eslint check in testing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,7 +55,8 @@
         "**/__tests__/**/*.test.ts"
       ],
       "rules": {
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "no-lone-blocks": "off"
       }
     }
   ]

--- a/packages/jellyfish-api-core/__tests__/category/loan/withdrawFromVault.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/withdrawFromVault.test.ts
@@ -81,7 +81,6 @@ describe('Loan', () => {
     await tGroup.get(0).generate(1)
     vaultOwner = await tGroup.get(0).generateAddress()
 
-    /* eslint-disable no-lone-blocks */
     {
       // vault1: 2 types of collateral token, no loan taken
       vaultId1 = await tGroup.get(0).rpc.loan.createVault({
@@ -101,7 +100,6 @@ describe('Loan', () => {
       await tGroup.get(0).generate(1)
     }
 
-    /* eslint-disable no-lone-blocks */
     {
       // vault2: single collateral token, loan taken, ease ratio control
       vaultId2 = await tGroup.get(0).rpc.loan.createVault({
@@ -123,7 +121,6 @@ describe('Loan', () => {
       await tGroup.get(0).generate(1)
     }
 
-    /* eslint-disable no-lone-blocks */
     {
       // vault3: 2 types of collateral token, loan taken, to be liquidated
       vaultId3 = await tGroup.get(0).rpc.loan.createVault({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

Turn off eslint check `no-lone-blocks` in `__tests__/*` as it's cleaner to write tests in lone block to scope context.