### PR TITLE
allow peer dependency to use ^ for jellyfish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -34,7 +34,7 @@ jobs:
       - name: find and replace peerDependencies # because lerna doesn't update peers deps
         # TODO(fuxingloh): add ocean/*/package.json when enabled
         run: |
-          find packages/*/package.json -type f -exec sed -i 's#    "defichain": "0.0.0"#    "defichain": "${{ steps.version.outputs.result }}"#g' {} \;
+          find packages/*/package.json -type f -exec sed -i 's#    "defichain": "^0.0.0"#    "defichain": "^${{ steps.version.outputs.result }}"#g' {} \;
 
       - name: Publish
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -12041,9 +12041,9 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
         "bech32": "^2.0.0",
         "bs58": "^4.0.1"
       },
@@ -12052,7 +12052,7 @@
         "@types/bs58": "^4.0.1"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-api-core": {
@@ -12060,10 +12060,10 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-json": "0.0.0"
+        "@defichain/jellyfish-json": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-api-jsonrpc": {
@@ -12071,7 +12071,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "0.0.0",
+        "@defichain/jellyfish-api-core": "^0.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.4"
       },
@@ -12079,7 +12079,7 @@
         "nock": "^13.1.4"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-block": {
@@ -12087,12 +12087,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
         "smart-buffer": "^4.2.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-buffer": {
@@ -12104,7 +12104,7 @@
         "smart-buffer": "^4.2.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-crypto": {
@@ -12130,7 +12130,7 @@
         "@types/wif": "^2.0.2"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-json": {
@@ -12143,7 +12143,7 @@
         "lossless-json": "^1.0.5"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-network": {
@@ -12151,7 +12151,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-testing": {
@@ -12159,14 +12159,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
+        "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/testcontainers": "^0.0.0",
         "cross-fetch": "^3.1.4"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-transaction": {
@@ -12174,11 +12174,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0"
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-transaction-builder": {
@@ -12186,12 +12186,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-transaction-signature": "0.0.0"
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-transaction-signature": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-transaction-signature": {
@@ -12199,12 +12199,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0"
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-wallet": {
@@ -12212,13 +12212,13 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-address": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0"
+        "@defichain/jellyfish-address": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-wallet-classic": {
@@ -12226,11 +12226,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-wallet": "0.0.0"
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-wallet-encrypted": {
@@ -12238,11 +12238,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-wallet-mnemonic": "0.0.0",
+        "@defichain/jellyfish-wallet-mnemonic": "^0.0.0",
         "scrypt-js": "^3.0.1"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/jellyfish-wallet-mnemonic": {
@@ -12250,8 +12250,8 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-wallet": "0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
         "create-hmac": "^1.1.7"
@@ -12260,7 +12260,7 @@
         "@types/create-hmac": "^1.1.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/testcontainers": {
@@ -12268,7 +12268,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-network": "0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
         "cross-fetch": "^3.1.4",
         "dockerode": "^3.3.1"
       },
@@ -12276,7 +12276,7 @@
         "@types/dockerode": "^3.2.7"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     },
     "packages/testing": {
@@ -12284,13 +12284,13 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@defichain/jellyfish-api-core": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/testcontainers": "0.0.0"
+        "@defichain/jellyfish-api-core": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/testcontainers": "^0.0.0"
       },
       "peerDependencies": {
-        "defichain": "0.0.0"
+        "defichain": "^0.0.0"
       }
     }
   },
@@ -12660,9 +12660,9 @@
     "@defichain/jellyfish-address": {
       "version": "file:packages/jellyfish-address",
       "requires": {
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
         "@types/bech32": "^1.1.2",
         "@types/bs58": "^4.0.1",
         "bech32": "^2.0.0",
@@ -12672,13 +12672,13 @@
     "@defichain/jellyfish-api-core": {
       "version": "file:packages/jellyfish-api-core",
       "requires": {
-        "@defichain/jellyfish-json": "0.0.0"
+        "@defichain/jellyfish-json": "^0.0.0"
       }
     },
     "@defichain/jellyfish-api-jsonrpc": {
       "version": "file:packages/jellyfish-api-jsonrpc",
       "requires": {
-        "@defichain/jellyfish-api-core": "0.0.0",
+        "@defichain/jellyfish-api-core": "^0.0.0",
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.4",
         "nock": "^13.1.4"
@@ -12687,8 +12687,8 @@
     "@defichain/jellyfish-block": {
       "version": "file:packages/jellyfish-block",
       "requires": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
         "smart-buffer": "^4.2.0"
       }
     },
@@ -12733,64 +12733,64 @@
     "@defichain/jellyfish-testing": {
       "version": "file:packages/jellyfish-testing",
       "requires": {
-        "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/testcontainers": "0.0.0",
+        "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/testcontainers": "^0.0.0",
         "cross-fetch": "^3.1.4"
       }
     },
     "@defichain/jellyfish-transaction": {
       "version": "file:packages/jellyfish-transaction",
       "requires": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0"
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0"
       }
     },
     "@defichain/jellyfish-transaction-builder": {
       "version": "file:packages/jellyfish-transaction-builder",
       "requires": {
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-transaction-signature": "0.0.0"
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-transaction-signature": "^0.0.0"
       }
     },
     "@defichain/jellyfish-transaction-signature": {
       "version": "file:packages/jellyfish-transaction-signature",
       "requires": {
-        "@defichain/jellyfish-buffer": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0"
+        "@defichain/jellyfish-buffer": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0"
       }
     },
     "@defichain/jellyfish-wallet": {
       "version": "file:packages/jellyfish-wallet",
       "requires": {
-        "@defichain/jellyfish-address": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/jellyfish-transaction": "0.0.0"
+        "@defichain/jellyfish-address": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0"
       }
     },
     "@defichain/jellyfish-wallet-classic": {
       "version": "file:packages/jellyfish-wallet-classic",
       "requires": {
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-wallet": "0.0.0"
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0"
       }
     },
     "@defichain/jellyfish-wallet-encrypted": {
       "version": "file:packages/jellyfish-wallet-encrypted",
       "requires": {
-        "@defichain/jellyfish-wallet-mnemonic": "0.0.0",
+        "@defichain/jellyfish-wallet-mnemonic": "^0.0.0",
         "scrypt-js": "^3.0.1"
       }
     },
     "@defichain/jellyfish-wallet-mnemonic": {
       "version": "file:packages/jellyfish-wallet-mnemonic",
       "requires": {
-        "@defichain/jellyfish-transaction": "0.0.0",
-        "@defichain/jellyfish-wallet": "0.0.0",
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
         "@types/create-hmac": "^1.1.0",
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
@@ -12800,7 +12800,7 @@
     "@defichain/testcontainers": {
       "version": "file:packages/testcontainers",
       "requires": {
-        "@defichain/jellyfish-network": "0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
         "@types/dockerode": "^3.2.7",
         "cross-fetch": "^3.1.4",
         "dockerode": "^3.3.1"
@@ -12809,10 +12809,10 @@
     "@defichain/testing": {
       "version": "file:packages/testing",
       "requires": {
-        "@defichain/jellyfish-api-core": "0.0.0",
-        "@defichain/jellyfish-crypto": "0.0.0",
-        "@defichain/jellyfish-network": "0.0.0",
-        "@defichain/testcontainers": "0.0.0"
+        "@defichain/jellyfish-api-core": "^0.0.0",
+        "@defichain/jellyfish-crypto": "^0.0.0",
+        "@defichain/jellyfish-network": "^0.0.0",
+        "@defichain/testcontainers": "^0.0.0"
       }
     },
     "@eslint/eslintrc": {
@@ -15914,9 +15914,9 @@
         "@defichain/jellyfish-address": {
           "version": "file:packages/jellyfish-address",
           "requires": {
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-network": "0.0.0",
-            "@defichain/jellyfish-transaction": "0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-network": "^0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0",
             "@types/bech32": "^1.1.2",
             "@types/bs58": "^4.0.1",
             "bech32": "^2.0.0",
@@ -15926,13 +15926,13 @@
         "@defichain/jellyfish-api-core": {
           "version": "file:packages/jellyfish-api-core",
           "requires": {
-            "@defichain/jellyfish-json": "0.0.0"
+            "@defichain/jellyfish-json": "^0.0.0"
           }
         },
         "@defichain/jellyfish-api-jsonrpc": {
           "version": "file:packages/jellyfish-api-jsonrpc",
           "requires": {
-            "@defichain/jellyfish-api-core": "0.0.0",
+            "@defichain/jellyfish-api-core": "^0.0.0",
             "abort-controller": "^3.0.0",
             "cross-fetch": "^3.1.4",
             "nock": "^13.1.4"
@@ -15941,8 +15941,8 @@
         "@defichain/jellyfish-block": {
           "version": "file:packages/jellyfish-block",
           "requires": {
-            "@defichain/jellyfish-buffer": "0.0.0",
-            "@defichain/jellyfish-transaction": "0.0.0",
+            "@defichain/jellyfish-buffer": "^0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0",
             "smart-buffer": "^4.2.0"
           }
         },
@@ -15987,64 +15987,64 @@
         "@defichain/jellyfish-testing": {
           "version": "file:packages/jellyfish-testing",
           "requires": {
-            "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-network": "0.0.0",
-            "@defichain/testcontainers": "0.0.0",
+            "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-network": "^0.0.0",
+            "@defichain/testcontainers": "^0.0.0",
             "cross-fetch": "^3.1.4"
           }
         },
         "@defichain/jellyfish-transaction": {
           "version": "file:packages/jellyfish-transaction",
           "requires": {
-            "@defichain/jellyfish-buffer": "0.0.0",
-            "@defichain/jellyfish-crypto": "0.0.0"
+            "@defichain/jellyfish-buffer": "^0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0"
           }
         },
         "@defichain/jellyfish-transaction-builder": {
           "version": "file:packages/jellyfish-transaction-builder",
           "requires": {
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-transaction": "0.0.0",
-            "@defichain/jellyfish-transaction-signature": "0.0.0"
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-transaction-signature": "^0.0.0"
           }
         },
         "@defichain/jellyfish-transaction-signature": {
           "version": "file:packages/jellyfish-transaction-signature",
           "requires": {
-            "@defichain/jellyfish-buffer": "0.0.0",
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-transaction": "0.0.0"
+            "@defichain/jellyfish-buffer": "^0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0"
           }
         },
         "@defichain/jellyfish-wallet": {
           "version": "file:packages/jellyfish-wallet",
           "requires": {
-            "@defichain/jellyfish-address": "0.0.0",
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-network": "0.0.0",
-            "@defichain/jellyfish-transaction": "0.0.0"
+            "@defichain/jellyfish-address": "^0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-network": "^0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0"
           }
         },
         "@defichain/jellyfish-wallet-classic": {
           "version": "file:packages/jellyfish-wallet-classic",
           "requires": {
-            "@defichain/jellyfish-transaction": "0.0.0",
-            "@defichain/jellyfish-wallet": "0.0.0"
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-wallet": "^0.0.0"
           }
         },
         "@defichain/jellyfish-wallet-encrypted": {
           "version": "file:packages/jellyfish-wallet-encrypted",
           "requires": {
-            "@defichain/jellyfish-wallet-mnemonic": "0.0.0",
+            "@defichain/jellyfish-wallet-mnemonic": "^0.0.0",
             "scrypt-js": "^3.0.1"
           }
         },
         "@defichain/jellyfish-wallet-mnemonic": {
           "version": "file:packages/jellyfish-wallet-mnemonic",
           "requires": {
-            "@defichain/jellyfish-transaction": "0.0.0",
-            "@defichain/jellyfish-wallet": "0.0.0",
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-wallet": "^0.0.0",
             "@types/create-hmac": "^1.1.0",
             "bip32": "^2.0.6",
             "bip39": "^3.0.4",
@@ -16054,7 +16054,7 @@
         "@defichain/testcontainers": {
           "version": "file:packages/testcontainers",
           "requires": {
-            "@defichain/jellyfish-network": "0.0.0",
+            "@defichain/jellyfish-network": "^0.0.0",
             "@types/dockerode": "^3.2.7",
             "cross-fetch": "^3.1.4",
             "dockerode": "^3.3.1"
@@ -16063,10 +16063,10 @@
         "@defichain/testing": {
           "version": "file:packages/testing",
           "requires": {
-            "@defichain/jellyfish-api-core": "0.0.0",
-            "@defichain/jellyfish-crypto": "0.0.0",
-            "@defichain/jellyfish-network": "0.0.0",
-            "@defichain/testcontainers": "0.0.0"
+            "@defichain/jellyfish-api-core": "^0.0.0",
+            "@defichain/jellyfish-crypto": "^0.0.0",
+            "@defichain/jellyfish-network": "^0.0.0",
+            "@defichain/testcontainers": "^0.0.0"
           }
         },
         "@eslint/eslintrc": {

--- a/packages/jellyfish-address/package.json
+++ b/packages/jellyfish-address/package.json
@@ -22,14 +22,14 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/jellyfish-network": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/jellyfish-network": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0",
     "bech32": "^2.0.0",
     "bs58": "^4.0.1"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   },
   "devDependencies": {
     "@types/bech32": "^1.1.2",

--- a/packages/jellyfish-api-core/package.json
+++ b/packages/jellyfish-api-core/package.json
@@ -22,9 +22,9 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-json": "0.0.0"
+    "@defichain/jellyfish-json": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-api-jsonrpc/package.json
+++ b/packages/jellyfish-api-jsonrpc/package.json
@@ -22,12 +22,12 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-api-core": "0.0.0",
+    "@defichain/jellyfish-api-core": "^0.0.0",
     "abort-controller": "^3.0.0",
     "cross-fetch": "^3.1.4"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   },
   "devDependencies": {
     "nock": "^13.1.4"

--- a/packages/jellyfish-block/package.json
+++ b/packages/jellyfish-block/package.json
@@ -22,11 +22,11 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-buffer": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0",
+    "@defichain/jellyfish-buffer": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0",
     "smart-buffer": "^4.2.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-buffer/package.json
+++ b/packages/jellyfish-buffer/package.json
@@ -26,6 +26,6 @@
     "smart-buffer": "^4.2.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-crypto/package.json
+++ b/packages/jellyfish-crypto/package.json
@@ -32,7 +32,7 @@
     "wif": "^2.0.6"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   },
   "devDependencies": {
     "@types/bech32": "^1.1.2",

--- a/packages/jellyfish-json/package.json
+++ b/packages/jellyfish-json/package.json
@@ -27,6 +27,6 @@
     "lossless-json": "^1.0.5"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-network/package.json
+++ b/packages/jellyfish-network/package.json
@@ -22,6 +22,6 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-testing/package.json
+++ b/packages/jellyfish-testing/package.json
@@ -22,13 +22,13 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-api-jsonrpc": "0.0.0",
-    "@defichain/jellyfish-network": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/testcontainers": "0.0.0",
+    "@defichain/jellyfish-api-jsonrpc": "^0.0.0",
+    "@defichain/jellyfish-network": "^0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/testcontainers": "^0.0.0",
     "cross-fetch": "^3.1.4"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-transaction-builder/package.json
+++ b/packages/jellyfish-transaction-builder/package.json
@@ -22,11 +22,11 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0",
-    "@defichain/jellyfish-transaction-signature": "0.0.0"
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0",
+    "@defichain/jellyfish-transaction-signature": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-transaction-signature/package.json
+++ b/packages/jellyfish-transaction-signature/package.json
@@ -22,11 +22,11 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-buffer": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0"
+    "@defichain/jellyfish-buffer": "^0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-transaction/package.json
+++ b/packages/jellyfish-transaction/package.json
@@ -22,10 +22,10 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-buffer": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0"
+    "@defichain/jellyfish-buffer": "^0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-wallet-classic/package.json
+++ b/packages/jellyfish-wallet-classic/package.json
@@ -22,10 +22,10 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-wallet": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0"
+    "@defichain/jellyfish-wallet": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-wallet-encrypted/package.json
+++ b/packages/jellyfish-wallet-encrypted/package.json
@@ -22,10 +22,10 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-wallet-mnemonic": "0.0.0",
+    "@defichain/jellyfish-wallet-mnemonic": "^0.0.0",
     "scrypt-js": "^3.0.1"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/jellyfish-wallet-mnemonic/package.json
+++ b/packages/jellyfish-wallet-mnemonic/package.json
@@ -22,14 +22,14 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-wallet": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0",
+    "@defichain/jellyfish-wallet": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0",
     "bip32": "^2.0.6",
     "bip39": "^3.0.4",
     "create-hmac": "^1.1.7"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   },
   "devDependencies": {
     "@types/create-hmac": "^1.1.0"

--- a/packages/jellyfish-wallet/package.json
+++ b/packages/jellyfish-wallet/package.json
@@ -22,12 +22,12 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-address": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/jellyfish-network": "0.0.0",
-    "@defichain/jellyfish-transaction": "0.0.0"
+    "@defichain/jellyfish-address": "^0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/jellyfish-network": "^0.0.0",
+    "@defichain/jellyfish-transaction": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -22,12 +22,12 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-network": "0.0.0",
+    "@defichain/jellyfish-network": "^0.0.0",
     "dockerode": "^3.3.1",
     "cross-fetch": "^3.1.4"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   },
   "devDependencies": {
     "@types/dockerode": "^3.2.7"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -22,12 +22,12 @@
     "build": "tsc -b ./tsconfig.build.json"
   },
   "dependencies": {
-    "@defichain/jellyfish-api-core": "0.0.0",
-    "@defichain/jellyfish-network": "0.0.0",
-    "@defichain/jellyfish-crypto": "0.0.0",
-    "@defichain/testcontainers": "0.0.0"
+    "@defichain/jellyfish-api-core": "^0.0.0",
+    "@defichain/jellyfish-network": "^0.0.0",
+    "@defichain/jellyfish-crypto": "^0.0.0",
+    "@defichain/testcontainers": "^0.0.0"
   },
   "peerDependencies": {
-    "defichain": "0.0.0"
+    "defichain": "^0.0.0"
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind chore

#### What this PR does / why we need it:

This allows peer dependency to resolve automatically. 

This forces us to us use semantic versioning with `major.minor.patch`. Major as breaking, minor as any new non-breaking feature, patch to fix any non-breaking issue.