### PR TITLE
add missing required dependencies for jellyfish-wallet

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -10,6 +10,7 @@
       <w>ancestorcount</w>
       <w>ancestorfees</w>
       <w>ancestorsize</w>
+      <w>anchorquorum</w>
       <w>anyonecanpay</w>
       <w>bayfrontgardensheight</w>
       <w>bayfrontheight</w>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12231,7 +12231,9 @@
         "@defichain/jellyfish-address": "^0.0.0",
         "@defichain/jellyfish-crypto": "^0.0.0",
         "@defichain/jellyfish-network": "^0.0.0",
-        "@defichain/jellyfish-transaction": "^0.0.0"
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-transaction-builder": "^0.0.0",
+        "@defichain/jellyfish-transaction-signature": "^0.0.0"
       },
       "peerDependencies": {
         "defichain": "^0.0.0"
@@ -12785,7 +12787,9 @@
         "@defichain/jellyfish-address": "^0.0.0",
         "@defichain/jellyfish-crypto": "^0.0.0",
         "@defichain/jellyfish-network": "^0.0.0",
-        "@defichain/jellyfish-transaction": "^0.0.0"
+        "@defichain/jellyfish-transaction": "^0.0.0",
+        "@defichain/jellyfish-transaction-builder": "^0.0.0",
+        "@defichain/jellyfish-transaction-signature": "^0.0.0"
       }
     },
     "@defichain/jellyfish-wallet-classic": {
@@ -16040,7 +16044,9 @@
             "@defichain/jellyfish-address": "^0.0.0",
             "@defichain/jellyfish-crypto": "^0.0.0",
             "@defichain/jellyfish-network": "^0.0.0",
-            "@defichain/jellyfish-transaction": "^0.0.0"
+            "@defichain/jellyfish-transaction": "^0.0.0",
+            "@defichain/jellyfish-transaction-builder": "^0.0.0",
+            "@defichain/jellyfish-transaction-signature": "^0.0.0"
           }
         },
         "@defichain/jellyfish-wallet-classic": {

--- a/packages/jellyfish-wallet/package.json
+++ b/packages/jellyfish-wallet/package.json
@@ -25,7 +25,9 @@
     "@defichain/jellyfish-address": "^0.0.0",
     "@defichain/jellyfish-crypto": "^0.0.0",
     "@defichain/jellyfish-network": "^0.0.0",
-    "@defichain/jellyfish-transaction": "^0.0.0"
+    "@defichain/jellyfish-transaction": "^0.0.0",
+    "@defichain/jellyfish-transaction-builder": "^0.0.0",
+    "@defichain/jellyfish-transaction-signature": "^0.0.0"
   },
   "peerDependencies": {
     "defichain": "^0.0.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind dependencies

#### What this PR does / why we need it:

`jellyfish-wallet` should include transaction-signature and transaction-builder dependencies by default.
