### PR TITLE
The return type of listAuctions RPC should be VaultLiquidation object

### DIFF
--- a/docs/node/RPC Category/16-loan.md
+++ b/docs/node/RPC Category/16-loan.md
@@ -608,7 +608,15 @@ List all available auctions.
 
 ```ts title="client.loan.listAuctions()"
 interface loan {
-  listAuctions (pagination: AuctionPagination = {}): Promise<AuctionDetail[]>
+  listAuctions (pagination: AuctionPagination = {}): Promise<VaultLiquidation[]>
+}
+
+enum VaultState {
+  UNKNOWN = 'unknown',
+  ACTIVE = 'active',
+  IN_LIQUIDATION = 'inLiquidation',
+  FROZEN = 'frozen',
+  MAY_LIQUIDATE = 'mayLiquidate',
 }
 
 interface AuctionPagination {
@@ -622,15 +630,18 @@ interface AuctionPaginationStart {
   height?: number
 }
 
-interface AuctionDetail {
+interface Vault {
   vaultId: string
-  batchCount: number
-  liquidationPenalty: number
-  liquidationHeight: number
-  batches: VaultLiquidationBatch[]
   loanSchemeId: string
   ownerAddress: string
-  state: string
+  state: VaultState
+}
+
+interface VaultLiquidation extends Vault {
+  liquidationHeight: number
+  liquidationPenalty: number
+  batchCount: number
+  batches: VaultLiquidationBatch[]
 }
 
 interface VaultLiquidationBatch {

--- a/packages/jellyfish-api-core/__tests__/category/loan/listAuctons.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listAuctons.test.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js'
 import { Testing } from '@defichain/jellyfish-testing'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
-import { AuctionDetail } from '../../../src/category/loan'
+import { VaultLiquidation } from '../../../src/category/loan'
 
 describe('Loan listAuctions', () => {
   const container = new MasterNodeRegTestContainer()
@@ -318,10 +318,10 @@ describe('Loan listAuctions', () => {
   })
 
   describe('listAuctions with pagination', () => {
-    let auction1: AuctionDetail
-    let auction2: AuctionDetail
-    let auction3: AuctionDetail
-    let auction4: AuctionDetail
+    let auction1: VaultLiquidation
+    let auction2: VaultLiquidation
+    let auction3: VaultLiquidation
+    let auction4: VaultLiquidation
 
     beforeAll(async () => {
       [auction1, auction2, auction3, auction4] = await testing.rpc.loan.listAuctions()

--- a/packages/jellyfish-api-core/src/category/loan.ts
+++ b/packages/jellyfish-api-core/src/category/loan.ts
@@ -388,9 +388,9 @@ export class Loan {
    * @param {number} [pagination.start.height]
    * @param {boolean} [pagination.including_start]
    * @param {number} [pagination.limit=100]
-   * @return {Promise<AuctionDetail[]>}
+   * @return {Promise<VaultLiquidation[]>}
    */
-  async listAuctions (pagination: AuctionPagination = {}): Promise<AuctionDetail[]> {
+  async listAuctions (pagination: AuctionPagination = {}): Promise<VaultLiquidation[]> {
     const defaultPagination = {
       limit: 100
     }
@@ -602,17 +602,6 @@ export interface AuctionPagination {
 export interface AuctionPaginationStart {
   vaultId?: string
   height?: number
-}
-
-export interface AuctionDetail {
-  vaultId: string
-  batchCount: number
-  liquidationPenalty: number
-  liquidationHeight: number
-  batches: VaultLiquidationBatch[]
-  loanSchemeId: string
-  ownerAddress: string
-  state: string
 }
 
 export interface VaultLiquidationBatch {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind refactor

#### What this PR does / why we need it:

AuctionDetail object, the current return type of listAuction RPC is redundant. Should use the existing VaultLiquidation object

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
