### PR TITLE
Add highestBid object to listVaults, getVault and listAuctions RPCs

### DIFF
--- a/docs/node/CATEGORIES/16-loan.md
+++ b/docs/node/CATEGORIES/16-loan.md
@@ -450,6 +450,12 @@ interface VaultLiquidationBatch {
   index: number
   collaterals: string[]
   loan: string
+  highestBid?: HighestBid
+}
+
+interface HighestBid {
+  amount: string // amount@symbol
+  owner: string
 }
 ```
 
@@ -499,6 +505,12 @@ interface VaultLiquidationBatch {
   index: number
   collaterals: string[]
   loan: string
+  highestBid?: HighestBid
+}
+
+interface HighestBid {
+  amount: string // amount@symbol
+  owner: string
 }
 
 interface ListVaultOptions {
@@ -682,6 +694,12 @@ interface VaultLiquidationBatch {
   index: number
   collaterals: string[]
   loan: string
+  highestBid?: HighestBid
+}
+
+interface HighestBid {
+  amount: string // amount@symbol
+  owner: string
 }
 ```
 ## listAuctionHistory

--- a/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/listVaults.test.ts
@@ -567,7 +567,7 @@ describe('Loan listVaults with options and pagination', () => {
       ts,
       { prices: [{ tokenAmount: '800@GOOGL', currency: 'USD' }] }
     )
-    await testing.generate(12)
+    await testing.container.waitForActivePrice('GOOGL/USD', '800')
 
     const liqVaults = await testing.rpc.loan.listVaults({}, { state: VaultState.IN_LIQUIDATION })
     expect(liqVaults.length).toBeGreaterThan(0)

--- a/packages/jellyfish-api-core/src/category/loan.ts
+++ b/packages/jellyfish-api-core/src/category/loan.ts
@@ -644,6 +644,12 @@ export interface VaultLiquidationBatch {
   index: number
   collaterals: string[]
   loan: string
+  highestBid?: HighestBid
+}
+
+export interface HighestBid {
+  amount: string // amount@symbol
+  owner: string
 }
 
 export interface ListAuctionHistoryPagination {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

If an auction bid is made, display highestBid object that is returned from listVaults, getVault and listAuctions RPCs

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Additional comments?:
