### PR TITLE
chore(workflow): project governance improvements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,5 @@
 <!--  Thanks for sending a pull request! -->
 
-#### What kind of PR is this?:
-<!-- Use one of the following kinds:
-/kind feature
-/kind fix
-/kind chore
-/kind docs
-/kind refactor
-/kind dependencies
--->
-
-/kind
-
 #### What this PR does / why we need it:
 
 #### Which issue(s) does this PR fixes?:

--- a/.github/governance.yml
+++ b/.github/governance.yml
@@ -35,34 +35,31 @@ issue:
 
     - prefix: area
       list:
-        - core
         - workflow
-        - website
+        - apps
+        - docs
         - examples
-        - jellyfish-address
-        - jellyfish-api-core
-        - jellyfish-api-jsonrpc
-        - jellyfish-block
-        - jellyfish-buffer
-        - jellyfish-crypto
-        - jellyfish-json
-        - jellyfish-network
-        - jellyfish-testing
-        - jellyfish-transaction
-        - jellyfish-transaction-builder
-        - jellyfish-transaction-signature
-        - jellyfish-wallet
-        - jellyfish-wallet-classic
-        - jellyfish-wallet-encrypted
-        - jellyfish-wallet-mnemonic
-        - testcontainers
-        - testing
+        - modules
+        - packages
       multiple: true
       needs:
         comment: |
           @$AUTHOR: There are no 'area' labels on this issue. Adding an appropriate label will greatly expedite the process for us. You can add as many area as you see fit. **If you are unsure what to do you can ignore this!**
 
           You can add area labels by leaving a `/area` comment.
+      author_association:
+        author: true
+        collaborator: true
+        member: true
+        owner: true
+
+    - prefix: sig
+      list:
+        - blockchain
+        - ecosystem
+        - wallet
+        - product
+      multiple: true
       author_association:
         author: true
         collaborator: true
@@ -116,65 +113,6 @@ issue:
 
     - cmd: /assign
       type: assign
-      author_association:
-        collaborator: true
-        member: true
-        owner: true
-
-pull_request:
-  labels:
-    - prefix: kind
-      multiple: false
-      list:
-        - feature
-        - fix
-        - chore
-        - docs
-        - refactor
-        - dependencies
-      needs:
-        comment: |
-          @$AUTHOR: There are no 'kind' label on this PR. You need a 'kind' label to generate the release automatically.
-
-          * `/kind feature`
-          * `/kind fix`
-          * `/kind chore`
-          * `/kind docs`
-          * `/kind refactor`
-          * `/kind dependencies`
-        status:
-          context: "Governance / Kind Label"
-          description:
-            success: Ready for review & merge.
-            failure: Missing 'kind' label for release generation.
-      author_association:
-        author: true
-        collaborator: true
-        member: true
-        owner: true
-
-    - prefix: priority
-      multiple: false
-      list: [ "urgent-now", "important-soon" ]
-      author_association:
-        collaborator: true
-        member: true
-        owner: true
-
-  chat_ops:
-    - cmd: /close
-      type: close
-      author_association:
-        author: true
-        collaborator: true
-        member: true
-        owner: true
-
-    - cmd: /cc
-      type: none
-
-    - cmd: /request
-      type: review
       author_association:
         collaborator: true
         member: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,22 +2,27 @@ version: v1
 
 labels:
   - label: kind/feature
+    sync: true
     matcher:
       title: "^feat\\(.+\\): .+"
 
   - label: kind/fix
+    sync: true
     matcher:
       title: "^fix\\(.+\\): .+"
 
   - label: kind/chore
+    sync: true
     matcher:
       title: "^chore\\(.+\\): .+"
 
   - label: kind/refactor
+    sync: true
     matcher:
       title: "^refactor\\(.+\\): .+"
 
   - label: kind/docs
+    sync: true
     matcher:
       title: "^docs\\(.+\\): .+"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,102 +1,61 @@
 version: v1
 
 labels:
+  - label: kind/feature
+    matcher:
+      title: "^feat\\(.+\\): .+"
+
+  - label: kind/fix
+    matcher:
+      title: "^fix\\(.+\\): .+"
+
+  - label: kind/chore
+    matcher:
+      title: "^chore\\(.+\\): .+"
+
+  - label: kind/refactor
+    matcher:
+      title: "^refactor\\(.+\\): .+"
+
+  - label: kind/docs
+    matcher:
+      title: "^docs\\(.+\\): .+"
+
   - label: area/workflow
     sync: true
     matcher:
       files: ".github/**"
 
-  - label: area/website
+  - label: area/apps
     sync: true
     matcher:
-      files: "website/**"
+      files: "apps/**"
 
   - label: area/examples
     sync: true
     matcher:
       files: "examples/**"
 
-  - label: area/jellyfish-address
+  - label: area/modules
     sync: true
     matcher:
-      files: "packages/jellyfish-address/**"
+      files: "modules/**"
 
-  - label: area/jellyfish-api-core
+  - label: area/packages
     sync: true
     matcher:
-      files: "packages/jellyfish-api-core/**"
+      files: "packages/**"
 
-  - label: area/jellyfish-api-jsonrpc
-    sync: true
-    matcher:
-      files: "packages/jellyfish-api-jsonrpc/**"
-
-  - label: area/jellyfish-block
-    sync: true
-    matcher:
-      files: "packages/jellyfish-block/**"
-
-  - label: area/jellyfish-buffer
-    sync: true
-    matcher:
-      files: "packages/jellyfish-buffer/**"
-
-  - label: area/jellyfish-crypto
-    sync: true
-    matcher:
-      files: "packages/jellyfish-crypto/**"
-
-  - label: area/jellyfish-json
-    sync: true
-    matcher:
-      files: "packages/jellyfish-json/**"
-
-  - label: area/jellyfish-network
-    sync: true
-    matcher:
-      files: "packages/jellyfish-network/**"
-
-  - label: area/jellyfish-testing
-    sync: true
-    matcher:
-      files: "packages/jellyfish-testing/**"
-
-  - label: area/jellyfish-transaction
-    sync: true
-    matcher:
-      files: "packages/jellyfish-transaction/**"
-
-  - label: area/jellyfish-transaction-builder
-    sync: true
-    matcher:
-      files: "packages/jellyfish-transaction-builder/**"
-
-  - label: area/jellyfish-transaction-signature
-    sync: true
-    matcher:
-      files: "packages/jellyfish-transaction-signature/**"
-
-  - label: area/jellyfish-wallet-encrypted
-    sync: true
-    matcher:
-      files: "packages/jellyfish-wallet-encrypted/**"
-
-  - label: area/jellyfish-wallet-classic
-    sync: true
-    matcher:
-      files: "packages/jellyfish-wallet-classic/**"
-
-  - label: area/jellyfish-wallet-mnemonic
-    sync: true
-    matcher:
-      files: "packages/jellyfish-wallet-mnemonic/**"
-
-  - label: area/testcontainers
-    sync: true
-    matcher:
-      files: "packages/testcontainers/**"
-
-  - label: area/testing
-    sync: true
-    matcher:
-      files: "packages/testing/**"
+checks:
+  - context: "Semantic Pull Request"
+    url: "https://github.com/DeFiCh/jellyfish/blob/main/.github/labeler.yml"
+    description:
+      success: Ready for review & merge.
+      failure: Missing semantic title or label for merge.
+    labels:
+      any:
+        - kind/feature
+        - kind/fix
+        - kind/chore
+        - kind/refactor
+        - kind/docs

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -51,7 +51,7 @@ checks:
     url: "https://github.com/DeFiCh/jellyfish/blob/main/.github/labeler.yml"
     description:
       success: Ready for review & merge.
-      failure: Missing semantic title or label for merge.
+      failure: "Missing semantic title or label for merge [kind(directory): title]"
     labels:
       any:
         - kind/feature

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -49,51 +49,29 @@
   name: kind/dependencies
   description: Pull requests that update a dependency file
 
+# Special Interest Group
+- color: 8d5253
+  name: sig/blockchain
+- color: 8d5253
+  name: sig/ecosystem
+- color: 8d5253
+  name: sig/wallet
+- color: 8d5253
+  name: sig/product
+
 # Area
-- color: fbca04
-  name: area/core
 - color: fbca04
   name: area/workflow
 - color: fbca04
-  name: area/website
+  name: area/apps
+- color: fbca04
+  name: area/docs
 - color: fbca04
   name: area/examples
 - color: fbca04
-  name: area/jellyfish-address
+  name: area/modules
 - color: fbca04
-  name: area/jellyfish-api-core
-- color: fbca04
-  name: area/jellyfish-api-jsonrpc
-- color: fbca04
-  name: area/jellyfish-block
-- color: fbca04
-  name: area/jellyfish-buffer
-- color: fbca04
-  name: area/jellyfish-crypto
-- color: fbca04
-  name: area/jellyfish-json
-- color: fbca04
-  name: area/jellyfish-network
-- color: fbca04
-  name: area/jellyfish-testing
-- color: fbca04
-  name: area/jellyfish-transaction
-- color: fbca04
-  name: area/jellyfish-transaction-builder
-- color: fbca04
-  name: area/jellyfish-transaction-signature
-- color: fbca04
-  name: area/jellyfish-wallet
-- color: fbca04
-  name: area/jellyfish-wallet-classic
-- color: fbca04
-  name: area/jellyfish-wallet-encrypted
-- color: fbca04
-  name: area/jellyfish-wallet-mnemonic
-- color: fbca04
-  name: area/testcontainers
-- color: fbca04
-  name: area/testing
+  name: area/packages
 
 # Priority
 - color: d93f0b

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,13 +1,13 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
-  - title: '🚀 Features'
+  - title: 'Features'
     labels:
       - 'kind/feature'
-  - title: '🐛 Bug Fixes'
+  - title: 'Fixes'
     labels:
       - 'kind/fix'
-  - title: 'Maintenance'
+  - title: 'Chore & Maintenance'
     labels:
       - 'kind/refactor'
       - 'kind/chore'
@@ -24,6 +24,4 @@ version-resolver:
   default: patch
 prerelease: false
 template: |
-  ## What’s Changed
-
   $CHANGES

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -1,7 +1,7 @@
 name: Governance
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ synchronize, opened, labeled, unlabeled ]
   issues:
     types: [ opened, labeled, unlabeled ]

--- a/.github/workflows/oss-governance-bot.yml
+++ b/.github/workflows/oss-governance-bot.yml
@@ -1,7 +1,7 @@
 name: Governance
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ synchronize, opened, labeled, unlabeled ]
   issues:
     types: [ opened, labeled, unlabeled ]

--- a/.github/workflows/oss-governance-labeler.yml
+++ b/.github/workflows/oss-governance-labeler.yml
@@ -1,8 +1,8 @@
 name: Governance
 
 on:
-  pull_request:
-    types: [ opened, edited, synchronize, ready_for_review ]
+  pull_request_target:
+    types: [ opened, edited, synchronize ]
 
 jobs:
   labeler:

--- a/.github/workflows/oss-governance-labeler.yml
+++ b/.github/workflows/oss-governance-labeler.yml
@@ -2,7 +2,7 @@ name: Governance
 
 on:
   pull_request:
-    types: [ synchronize, opened ]
+    types: [ opened, edited, synchronize, ready_for_review ]
 
 jobs:
   labeler:

--- a/.github/workflows/oss-governance-labeler.yml
+++ b/.github/workflows/oss-governance-labeler.yml
@@ -1,7 +1,7 @@
 name: Governance
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ synchronize, opened ]
 
 jobs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,8 +31,8 @@ jobs:
       - run: npm run build
       - run: npm run version:set ${{ steps.version.outputs.result }}
 
-      - name: find and replace peerDependencies # because lerna doesn't update peers deps
-        # TODO(fuxingloh): add ocean/*/package.json when enabled
+      # Because lerna doesn't update peers deps, although using it "wrongly" this behavior ensure all jellyfish deps are aligned.
+      - name: find and replace peerDependencies
         run: |
           find packages/*/package.json -type f -exec sed -i 's#    "defichain": "^0.0.0"#    "defichain": "^${{ steps.version.outputs.result }}"#g' {} \;
 


### PR DESCRIPTION
#### What this PR does / why we need it:

As the project evolves, we need to evolve our project governance tooling to meet the needs of this mono-repo. As a continuation of #888 where we clearly outline each directory and its special interest. This PR automate the governance of issues, Pull Request, and release.

#### For Pull Request 

Moving from chat-ops, we now using semantic pull request titles with context. E.g:
- feat(apps/website...): title
- fix(packages/jellyfish-api-core): broken interface for abc
- chore(workflow): cleanup governance workflow
- docs(ocean): add oracles documentation

These will automatically be added to release with clearly defined context making it easier for the downstream consumer to understand the change and relevancy of each release to their usage.

#### For Issues

We are cutting down on maintenance of labels to just a few high-level `sig/*` and `area/*` labels.

Special Interest Group:
- /sig blockchain
- /sig wallet
- /sig ecosystem
- /sig product

Area of concern: (Also the directories of concerns, automatically labeled for PR)
- /area workflow
- /area apps
- /area examples
- /area modules
- /area packages

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #416

