### PR TITLE
chore(workflow): add labels for dependabot.yml to reduce labels pollution

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    labels:
+      - "kind/dependencies"
     ignore:
       - dependency-name: "defich"
       - dependency-name: "defichain"


### PR DESCRIPTION
#### What this PR does / why we need it:

Reduce the number of labels created by @dependabot.