### PR TITLE
chore(workflow): updated governance automation to use bump prefix instead of deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     versioning-strategy: 'increase'
     commit-message:
       include: scope
-      prefix: deps
+      prefix: bump
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,7 @@ labels:
   - label: kind/dependencies
     sync: true
     matcher:
-      title: "^deps(\\(.+\\))?: .+"
+      title: "^bump(\\(.+\\))?: .+"
 
   - label: area/workflow
     sync: true

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - run: npm run all:build
       - run: npm run all:version ${{ steps.version.outputs.result }}
 
-      # Because lerna doesn't update peers deps, although using it "wrongly" this behavior ensure all jellyfish deps are aligned.
+      # Because lerna doesn't update peers deps, although using it "wrongly" this behavior ensures all jellyfish deps are aligned.
       - name: find and replace peerDependencies
         run: |
           find packages/*/package.json -type f -exec sed -i 's#    "defichain": "^0.0.0"#    "defichain": "^${{ steps.version.outputs.result }}"#g' {} \;

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,13 +1,17 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <HTMLCodeStyleSettings>
+      <option name="HTML_SPACE_INSIDE_EMPTY_TAG" value="true" />
+      <option name="HTML_QUOTE_STYLE" value="Single" />
+    </HTMLCodeStyleSettings>
     <JSCodeStyleSettings version="0">
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
       <option name="FORCE_SEMICOLON_STYLE" value="true" />
       <option name="SPACE_BEFORE_GENERATOR_MULT" value="true" />
       <option name="USE_DOUBLE_QUOTES" value="false" />
       <option name="FORCE_QUOTE_STYlE" value="true" />
-      <option name="OBJECT_LITERAL_WRAP" value="4" />
+      <option name="OBJECT_LITERAL_WRAP" value="2" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </JSCodeStyleSettings>
@@ -17,10 +21,17 @@
       <option name="SPACE_BEFORE_GENERATOR_MULT" value="true" />
       <option name="USE_DOUBLE_QUOTES" value="false" />
       <option name="FORCE_QUOTE_STYlE" value="true" />
-      <option name="OBJECT_LITERAL_WRAP" value="4" />
+      <option name="OBJECT_LITERAL_WRAP" value="2" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
       <option name="SPACES_WITHIN_IMPORTS" value="true" />
     </TypeScriptCodeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
     <codeStyleSettings language="JavaScript">
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Instead of double `deps(deps):` prefix to use `bump(context):` instead.

