### PR TITLE
feat(ocean-api-client): add `ocean-api` client core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2473,6 +2473,10 @@
       "resolved": "packages/jellyfish-wallet-mnemonic",
       "link": true
     },
+    "node_modules/@defichain/ocean-api-client": {
+      "resolved": "packages/ocean-api-client",
+      "link": true
+    },
     "node_modules/@defichain/testcontainers": {
       "resolved": "packages/testcontainers",
       "link": true
@@ -19703,6 +19707,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "license": "MIT"
@@ -20997,6 +21006,18 @@
       },
       "devDependencies": {
         "@types/create-hmac": "^1.1.0"
+      },
+      "peerDependencies": {
+        "defichain": "^0.0.0"
+      }
+    },
+    "packages/ocean-api-client": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.4",
+        "url-search-params-polyfill": "8.1.1"
       },
       "peerDependencies": {
         "defichain": "^0.0.0"
@@ -22308,6 +22329,14 @@
         "bip32": "^2.0.6",
         "bip39": "^3.0.4",
         "create-hmac": "^1.1.7"
+      }
+    },
+    "@defichain/ocean-api-client": {
+      "version": "file:packages/ocean-api-client",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.4",
+        "url-search-params-polyfill": "8.1.1"
       }
     },
     "@defichain/testcontainers": {
@@ -26277,6 +26306,7 @@
         "@defichain/jellyfish-wallet-classic": "file:packages/jellyfish-wallet-classic",
         "@defichain/jellyfish-wallet-encrypted": "file:packages/jellyfish-wallet-encrypted",
         "@defichain/jellyfish-wallet-mnemonic": "file:packages/jellyfish-wallet-mnemonic",
+        "@defichain/ocean-api-client": "file:packages/ocean-api-client",
         "@defichain/testcontainers": "file:packages/testcontainers",
         "@defichain/testing": "file:packages/testing",
         "@types/jest": "^27.0.3",
@@ -27550,6 +27580,14 @@
             "bip32": "^2.0.6",
             "bip39": "^3.0.4",
             "create-hmac": "^1.1.7"
+          }
+        },
+        "@defichain/ocean-api-client": {
+          "version": "file:packages/ocean-api-client",
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "cross-fetch": "^3.1.4",
+            "url-search-params-polyfill": "8.1.1"
           }
         },
         "@defichain/testcontainers": {
@@ -39107,6 +39145,11 @@
             "prepend-http": "^2.0.0"
           }
         },
+        "url-search-params-polyfill": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+          "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
+        },
         "use-composed-ref": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
@@ -47821,6 +47864,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-search-params-polyfill": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz",
+      "integrity": "sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q=="
     },
     "use-composed-ref": {
       "version": "1.1.0",

--- a/packages/ocean-api-client/__tests__/ApiResponse.test.ts
+++ b/packages/ocean-api-client/__tests__/ApiResponse.test.ts
@@ -15,7 +15,7 @@ describe('ApiPagedResponse', () => {
     expect(pagination.nextToken).toStrictEqual(undefined)
   })
 
-  it('should behavior as an array', () => {
+  it('should behave as an array', () => {
     const response: ApiResponse<number[]> = {
       data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     }

--- a/packages/ocean-api-client/__tests__/ApiResponse.test.ts
+++ b/packages/ocean-api-client/__tests__/ApiResponse.test.ts
@@ -1,0 +1,80 @@
+import { ApiPagedResponse, ApiResponse } from '@defichain/ocean-api-client'
+
+describe('ApiPagedResponse', () => {
+  it('should have getter methods', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2]
+    }
+    const pagination = new ApiPagedResponse(response, 'GET', '/')
+
+    expect(pagination[0]).toStrictEqual(0)
+    expect(pagination.endpoint).toStrictEqual('/')
+    expect(pagination.method).toStrictEqual('GET')
+    expect(pagination.page).toStrictEqual(undefined)
+    expect(pagination.hasNext).toStrictEqual(false)
+    expect(pagination.nextToken).toStrictEqual(undefined)
+  })
+
+  it('should behavior as an array', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    }
+
+    const pagination = new ApiPagedResponse(response, 'GET', '/')
+
+    expect(pagination.length).toStrictEqual(10)
+    expect(pagination[0]).toStrictEqual(0)
+    expect(pagination[4]).toStrictEqual(4)
+    expect(pagination[9]).toStrictEqual(9)
+    expect(pagination[10]).toBeUndefined()
+  })
+
+  it('should have next token', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+      page: {
+        next: '9'
+      }
+    }
+
+    const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+    expect(pagination.hasNext).toStrictEqual(true)
+    expect(pagination.nextToken).toStrictEqual('9')
+  })
+
+  it('should not have next', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    }
+
+    const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+    expect(pagination.hasNext).toStrictEqual(false)
+    expect(pagination.nextToken).toBeUndefined()
+  })
+
+  it('should be able to filter', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    }
+
+    const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+    expect(pagination.filter(value => value % 2 === 0)).toStrictEqual([
+      0, 2, 4, 6, 8
+    ])
+  })
+
+  it('should be able to map', () => {
+    const response: ApiResponse<number[]> = {
+      data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    }
+
+    const pagination = new ApiPagedResponse(response, 'GET', '/items')
+
+    expect(pagination.map(value => value * 11)).toStrictEqual([
+      0, 11, 22, 33, 44, 55, 66, 77, 88, 99
+    ])
+  })
+})

--- a/packages/ocean-api-client/__tests__/OceanApiClient.test.ts
+++ b/packages/ocean-api-client/__tests__/OceanApiClient.test.ts
@@ -1,0 +1,42 @@
+import nock from 'nock'
+import { OceanApiClient } from '@defichain/ocean-api-client'
+
+const client = new OceanApiClient({
+  url: 'http://ocean-api-test.internal',
+  version: 'v0',
+  network: 'mainnet'
+})
+
+it('should requestData via GET', async () => {
+  nock('http://ocean-api-test.internal')
+    .get('/v0/mainnet/foo')
+    .reply(200, function () {
+      return {
+        data: {
+          bar: ['1', '2']
+        }
+      }
+    })
+
+  const result = await client.requestData('GET', 'foo')
+  await expect(result).toStrictEqual({
+    bar: ['1', '2']
+  })
+})
+
+it('should requestData via POST', async () => {
+  nock('http://ocean-api-test.internal')
+    .post('/v0/mainnet/bar')
+    .reply(200, function (_, body: object) {
+      return {
+        data: body
+      }
+    })
+
+  const result = await client.requestData('POST', 'bar', {
+    abc: ['a', 'b', 'c']
+  })
+  await expect(result).toStrictEqual({
+    abc: ['a', 'b', 'c']
+  })
+})

--- a/packages/ocean-api-client/__tests__/errors/ApiException.test.ts
+++ b/packages/ocean-api-client/__tests__/errors/ApiException.test.ts
@@ -1,0 +1,198 @@
+import { ApiErrorType, ApiException, ApiValidationException, ApiValidationProperty } from '@defichain/ocean-api-client'
+
+it('raiseIfError should not raise error if no error', () => {
+  ApiException.raiseIfError({ data: undefined })
+})
+
+it('raiseIfError should raise Unrecognized Error if not structured properly', () => {
+  const response = {
+    data: 'data',
+    error: 'something'
+  }
+
+  expect(() => {
+    ApiException.raiseIfError(response as any)
+  }).toThrow('Unrecognized Error: {"data":"data","error":"something"}')
+})
+
+describe('raise all error types', () => {
+  it('should raise ValidationError', () => {
+    expect.assertions(6)
+
+    const properties: ApiValidationProperty[] = [
+      {
+        property: 'a',
+        value: 'b'
+      }
+    ]
+
+    try {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 422,
+          type: ApiErrorType.ValidationError,
+          at: 1633280252888,
+          message: 'message',
+          url: '/validation',
+          payload: {
+            properties: properties
+          }
+        }
+      })
+    } catch (e) {
+      const exception = e as ApiValidationException
+      expect(exception.code).toStrictEqual(422)
+      expect(exception.type).toStrictEqual(ApiErrorType.ValidationError)
+      expect(exception.at).toStrictEqual(1633280252888)
+      expect(exception.url).toStrictEqual('/validation')
+      expect(exception.properties).toStrictEqual(properties)
+
+      expect(exception.message).toStrictEqual('422 - ValidationError (/validation) : message')
+    }
+  })
+
+  it('should raise BadRequest', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 400,
+          type: ApiErrorType.BadRequest,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('400 - BadRequest (/raise) : message')
+  })
+
+  it('should raise NotFound', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 404,
+          type: ApiErrorType.NotFound,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('404 - NotFound (/raise) : message')
+  })
+
+  it('should raise Conflict', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 409,
+          type: ApiErrorType.Conflict,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('409 - Conflict (/raise) : message')
+  })
+
+  it('should raise Forbidden', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 403,
+          type: ApiErrorType.Forbidden,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('403 - Forbidden (/raise) : message')
+  })
+
+  it('should raise Unauthorized', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 401,
+          type: ApiErrorType.Unauthorized,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('401 - Unauthorized (/raise) : message')
+  })
+
+  it('should raise BadGateway', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 502,
+          type: ApiErrorType.BadGateway,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('502 - BadGateway (/raise) : message')
+  })
+
+  it('should raise ServiceUnavailable', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 503,
+          type: ApiErrorType.ServiceUnavailable,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('503 - ServiceUnavailable (/raise) : message')
+  })
+
+  it('should raise TimeoutError', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 408,
+          type: ApiErrorType.TimeoutError,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('408 - TimeoutError (/raise) : message')
+  })
+
+  it('should raise UnknownError', () => {
+    expect(() => {
+      ApiException.raiseIfError({
+        data: undefined,
+        error: {
+          code: 500,
+          type: ApiErrorType.UnknownError,
+          at: 1633280252888,
+          message: 'message',
+          url: '/raise',
+          payload: undefined
+        }
+      })
+    }).toThrow('500 - UnknownError (/raise) : message')
+  })
+})

--- a/packages/ocean-api-client/__tests__/errors/ClientException.test.ts
+++ b/packages/ocean-api-client/__tests__/errors/ClientException.test.ts
@@ -1,0 +1,6 @@
+import { ClientException } from '@defichain/ocean-api-client'
+
+it('ClientException should format message as it is', () => {
+  const exception = new ClientException('foo')
+  expect(exception.message).toStrictEqual('foo')
+})

--- a/packages/ocean-api-client/__tests__/errors/TimeoutException.test.ts
+++ b/packages/ocean-api-client/__tests__/errors/TimeoutException.test.ts
@@ -1,0 +1,6 @@
+import { TimeoutException } from '@defichain/ocean-api-client'
+
+it('TimeoutException should format message with timeout message', () => {
+  const exception = new TimeoutException(3000)
+  expect(exception.message).toStrictEqual('request aborted due to timeout of 3000 ms')
+})

--- a/packages/ocean-api-client/package.json
+++ b/packages/ocean-api-client/package.json
@@ -1,0 +1,25 @@
+{
+  "private": false,
+  "name": "@defichain/ocean-api-client",
+  "version": "0.0.0",
+  "description": "DeFiChain Jellyfish Ecosystem",
+  "repository": "DeFiCh/jellyfish",
+  "bugs": "https://github.com/DeFiCh/jellyfish/issues",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -b ./tsconfig.build.json"
+  },
+  "dependencies": {
+    "abort-controller": "^3.0.0",
+    "cross-fetch": "^3.1.4",
+    "url-search-params-polyfill": "8.1.1"
+  },
+  "peerDependencies": {
+    "defichain": "^0.0.0"
+  }
+}

--- a/packages/ocean-api-client/src/ApiResponse.ts
+++ b/packages/ocean-api-client/src/ApiResponse.ts
@@ -1,0 +1,105 @@
+import { ApiError } from './errors/ApiException'
+
+export interface ApiResponse<T> {
+  data: T
+  page?: ApiPage
+  error?: ApiError
+}
+
+export type ApiMethod = 'POST' | 'GET'
+
+export interface ApiPage {
+  /**
+   * The next token for the next slice in the greater list.
+   * For simplicity, next token must a string or be encoded as a string.
+   * If the next token is in other formats such as bytes or number,
+   * it must be parsed by the controller.
+   */
+  next?: string
+}
+
+/**
+ * ApiPagedResponse class facilitate the ability to pagination query chaining.
+ * It extends the Array class and can be accessed like an array, `res[0]`, `res.length`.
+ *
+ * After accessing all the items in the Array, you can use the same ApiPagedResponse
+ * to query the next set of items. Hence allowing you query pagination chaining until you
+ * exhaustive all items in the list.
+ *
+ * @example
+ *   let response: ApiPagedResponse = await client.address.listToken(...)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ *
+ *   // To query next set of items:
+ *   let response = await client.pagination(response)
+ *   for (const item of response) {
+ *     console.log(item)
+ *   }
+ */
+export class ApiPagedResponse<T> extends Array<T> {
+  private readonly _paginate: {
+    page?: ApiPage
+    method: ApiMethod
+    endpoint: string
+  }
+
+  /**
+   * @param {ApiResponse} response that holds the data array and next token
+   * @param {ApiMethod} method of the REST endpoint
+   * @param {string} endpoint to paginate query
+   */
+  constructor (response: ApiResponse<T[]>, method: ApiMethod, endpoint: string) {
+    super(...response.data)
+    this._paginate = {
+      page: response.page,
+      method: method,
+      endpoint: endpoint
+    }
+  }
+
+  /**
+   * Built-in methods such as map, filter creates a new array for functional programming.
+   * It does that with the constructor found in the static Symbol.species class property.
+   * This needs to be overridden as ApiPagedResponse constructor has a different signature.
+   */
+  static get [Symbol.species] (): ArrayConstructor {
+    return Array
+  }
+
+  /**
+   * @return {string} endpoint to paginate query
+   */
+  get endpoint (): string {
+    return this._paginate.endpoint
+  }
+
+  /**
+   * @return {Method} method of the REST endpoint
+   */
+  get method (): ApiMethod {
+    return this._paginate.method
+  }
+
+  /**
+   * @return {ApiPage | undefined} page
+   */
+  get page (): ApiPage | undefined {
+    return this._paginate.page
+  }
+
+  /**
+   * @return {boolean} whether there a next set of items to paginate
+   */
+  get hasNext (): boolean {
+    return this.nextToken !== undefined
+  }
+
+  /**
+   * @return {string} next token
+   */
+  get nextToken (): string | undefined {
+    return this._paginate.page?.next
+  }
+}

--- a/packages/ocean-api-client/src/OceanApiClient.ts
+++ b/packages/ocean-api-client/src/OceanApiClient.ts
@@ -1,0 +1,169 @@
+import 'url-search-params-polyfill'
+import AbortController from 'abort-controller'
+import fetch from 'cross-fetch'
+import { ApiException, ApiMethod, ApiPagedResponse, ApiResponse, ClientException, TimeoutException } from './'
+
+/**
+ * OceanApiClient configurable options
+ */
+export interface OceanApiClientOptions {
+  url?: string
+
+  /**
+   * Millis before request is aborted.
+   * @default 60000 ms
+   */
+  timeout?: number
+
+  /**
+   * Version of API
+   * `v{major}.{minor}` or `v{major}`
+   */
+  version?: string
+
+  /**
+   * Network that ocean client is configured to
+   */
+  network?: 'mainnet' | 'testnet' | 'regtest' | string
+}
+
+/**
+ * OceanApiClient
+ */
+export class OceanApiClient {
+  // TODO(fuxingloh):
+  //  public readonly fee = new Fee(this)
+
+  constructor (
+    protected readonly options: OceanApiClientOptions
+  ) {
+    this.options = {
+      url: 'https://ocean.defichain.com',
+      timeout: 60000,
+      version: 'v1',
+      network: 'mainnet',
+      ...options
+    }
+    this.options.url = this.options.url?.replace(/\/$/, '')
+  }
+
+  /**
+   * @param {ApiPagedResponse} response from the previous request for pagination chaining
+   */
+  async paginate<T> (response: ApiPagedResponse<T>): Promise<ApiPagedResponse<T>> {
+    const token = response.nextToken
+    if (token === undefined) {
+      return new ApiPagedResponse({ data: [] }, response.method, response.endpoint)
+    }
+
+    const [path, query] = response.endpoint.split('?')
+    if (query === undefined) {
+      throw new ClientException('endpoint does not contain query params for pagination')
+    }
+
+    const params = new URLSearchParams(query)
+    params.set('next', token.toString())
+    const endpoint = `${path}?${params.toString()}`
+
+    const apiResponse = await this.requestAsApiResponse<T[]>(response.method, endpoint)
+    return new ApiPagedResponse<T>(apiResponse, response.method, endpoint)
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {number} [size] of the list
+   * @param {string} [next] token for pagination
+   * @return {ApiPagedResponse} data list in the JSON response body for pagination query
+   * @see {paginate(ApiPagedResponse)} for pagination query chaining
+   */
+  async requestList<T> (method: ApiMethod, path: string, size: number, next?: string): Promise<ApiPagedResponse<T>> {
+    const params = new URLSearchParams()
+    params.set('size', size.toString())
+
+    if (next !== undefined) {
+      params.set('next', next)
+    }
+
+    const endpoint = `${path}?${params.toString()}`
+    const response = await this.requestAsApiResponse<T[]>(method, endpoint)
+    return new ApiPagedResponse<T>(response, method, endpoint)
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {any} [object] JSON to send in request
+   * @return {T} data object in the JSON response body
+   */
+  async requestData<T> (method: ApiMethod, path: string, object?: any): Promise<T> {
+    const response = await this.requestAsApiResponse<T>(method, path, object)
+    return response.data
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [object] JSON to send in request
+   * @return {ApiResponse} parsed structured JSON response
+   */
+  async requestAsApiResponse<T> (method: ApiMethod, path: string, object?: any): Promise<ApiResponse<T>> {
+    const json = object !== undefined ? JSON.stringify(object) : undefined
+    const raw = await this.requestAsString(method, path, json)
+    const response: ApiResponse<T> = JSON.parse(raw.body)
+    ApiException.raiseIfError(response)
+    return response
+  }
+
+  /**
+   * @param {'POST|'GET'} method to request
+   * @param {string} path to request
+   * @param {object} [body] in string in request
+   * @return {ResponseAsString} as JSON string (RawResponse)
+   */
+  async requestAsString (method: ApiMethod, path: string, body?: string): Promise<ResponseAsString> {
+    const {
+      url: urlString,
+      version,
+      network,
+      timeout
+    } = this.options
+    const url = `${urlString as string}/${version as string}/${network as string}/${path}`
+
+    const controller = new AbortController()
+    const id = setTimeout(() => controller.abort(), timeout)
+
+    try {
+      const response = await _fetch(method, url, controller, body)
+      clearTimeout(id)
+      return response
+    } catch (err) {
+      if (err.type === 'aborted') {
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
+        throw new TimeoutException(timeout!)
+      }
+
+      throw err
+    }
+  }
+}
+
+export interface ResponseAsString {
+  status: number
+  body: string
+}
+
+async function _fetch (method: ApiMethod, url: string, controller: AbortController, body?: string): Promise<ResponseAsString> {
+  const response = await fetch(url, {
+    method: method,
+    headers: method !== 'GET' ? { 'Content-Type': 'application/json' } : {},
+    body: body,
+    cache: 'no-cache',
+    signal: controller.signal as any
+  })
+
+  return {
+    status: response.status,
+    body: await response.text()
+  }
+}

--- a/packages/ocean-api-client/src/errors/ApiException.ts
+++ b/packages/ocean-api-client/src/errors/ApiException.ts
@@ -1,0 +1,95 @@
+import { ApiResponse, ApiValidationException } from '../'
+
+/**
+ * Known ApiErrorType from Ocean
+ */
+export enum ApiErrorType {
+  ValidationError = 'ValidationError',
+  BadRequest = 'BadRequest',
+  NotFound = 'NotFound',
+  Conflict = 'Conflict',
+  Forbidden = 'Forbidden',
+  Unauthorized = 'Unauthorized',
+  BadGateway = 'BadGateway',
+  ServiceUnavailable = 'ServiceUnavailable',
+  TimeoutError = 'TimeoutError',
+  UnknownError = 'UnknownError',
+}
+
+export interface ApiError<T = any> {
+  /**
+   * @return {number} Status code
+   */
+  code: number
+  type: ApiErrorType
+  /**
+   * @return {number} Milliseconds since Epoch
+   */
+  at: number
+  message?: string
+  url?: string
+  payload: T
+}
+
+/**
+ * Wrapped exception from ApiError
+ */
+export class ApiException<P = any> extends Error {
+  constructor (readonly error: ApiError<P>) {
+    super(ApiException.generateMessage(error))
+  }
+
+  private static generateMessage (error: ApiError): string {
+    const url = error.url !== undefined && error.url !== null ? `(${error.url})` : ''
+    const msg = error.message !== undefined && error.message !== null ? `: ${error.message}` : ''
+    return `${error.code} - ${error.type} ${url} ${msg}`
+  }
+
+  /**
+   * @return {number} error code
+   */
+  get code (): number {
+    return this.error.code
+  }
+
+  /**
+   * @return {string} error type
+   */
+  get type (): ApiErrorType {
+    return this.error.type
+  }
+
+  /**
+   * @return {number} time that error occurred at
+   */
+  get at (): number {
+    return this.error.at
+  }
+
+  /**
+   * @return {string} url that threw this endpoint
+   */
+  get url (): string | undefined {
+    return this.error.url
+  }
+
+  /**
+   * @param {ApiResponse} response to check and raise error if any
+   * @throws {ApiException} raised error
+   */
+  static raiseIfError (response: ApiResponse<any>): void {
+    const error = response.error
+    if (error === undefined) {
+      return
+    }
+
+    if (typeof error === 'object') {
+      if (error.code === 422 && error.type === ApiErrorType.ValidationError) {
+        throw new ApiValidationException(error)
+      }
+      throw new ApiException(error)
+    }
+
+    throw new Error('Unrecognized Error: ' + JSON.stringify(response))
+  }
+}

--- a/packages/ocean-api-client/src/errors/ApiValidationException.ts
+++ b/packages/ocean-api-client/src/errors/ApiValidationException.ts
@@ -1,0 +1,23 @@
+import { ApiException } from './ApiException'
+
+/**
+ * Each property that failed constraint
+ */
+export interface ApiValidationProperty {
+  property: string
+  value?: any
+  constraints?: string[]
+  properties?: ApiValidationProperty[]
+}
+
+/**
+ * Rich constraints validation error coming from Ocean API.
+ */
+export class ApiValidationException extends ApiException<{ properties: ApiValidationProperty[] }> {
+  /**
+   * @return {ApiValidationProperty[]} that failed constraints validation
+   */
+  get properties (): ApiValidationProperty[] {
+    return this.error.payload.properties
+  }
+}

--- a/packages/ocean-api-client/src/errors/ClientException.ts
+++ b/packages/ocean-api-client/src/errors/ClientException.ts
@@ -1,0 +1,8 @@
+/**
+ * Local client exception
+ */
+export class ClientException extends Error {
+  constructor (public readonly message: string) {
+    super(message)
+  }
+}

--- a/packages/ocean-api-client/src/errors/TimeoutException.ts
+++ b/packages/ocean-api-client/src/errors/TimeoutException.ts
@@ -1,0 +1,8 @@
+/**
+ * Local client exception, due to local reason.
+ */
+export class TimeoutException extends Error {
+  constructor (public readonly timeout: number) {
+    super(`request aborted due to timeout of ${timeout} ms`)
+  }
+}

--- a/packages/ocean-api-client/src/index.ts
+++ b/packages/ocean-api-client/src/index.ts
@@ -1,0 +1,24 @@
+export * from './errors/ApiException'
+export * from './errors/ApiValidationException'
+export * from './errors/ClientException'
+export * from './errors/TimeoutException'
+
+export * from './ApiResponse'
+export * from './OceanApiClient'
+
+// TODO(fuxingloh):
+//  export * from './api/Fee'
+//  import { OceanApiClient } from '../OceanApiClient'
+//
+//  export class Fee {
+//    constructor (private readonly client: OceanApiClient) {
+//    }
+//
+//    /**
+//     * @param {number} confirmationTarget in blocks till fee get confirmed
+//     * @return {Promise<number>} fee rate per KB
+//     */
+//    async estimate (confirmationTarget: number = 10): Promise<number> {
+//      return await this.client.requestData('GET', `fee/estimate?confirmationTarget=${confirmationTarget}`)
+//    }
+//  }

--- a/packages/ocean-api-client/tsconfig.build.json
+++ b/packages/ocean-api-client/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "include": [
+    "./src/**/*"
+  ],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

DeFiChain Ocean API, next^2 generation API for building scalable Native DeFi Apps.

This is the foundational setup for Ocean API development integration into Jellyfish. Have been working on it for the past 3 weeks chipping off integration and migrating code slowly. This PR introduces 4 key concepts/packages with separation of concerns. Although the implementation example is small, they are fully featured working and tested.

#### Motivation

As part of [#580](https://github.com/DeFiCh/jellyfish/issues/580) consolidation efforts. We had multiple projects that were extensions of the jellyfish project. The separated projects allowed us to move quickly initially but proves to be a bottleneck when it comes to development.

By including Ocean API development with jellyfish, it creates a better synergy of DeFiChain open source development across concerns. Singular versioning, source of truth, documentation of entirety of defichain via [jellyfish.defichain.com](https://jellyfish.defichain.com).

#### @defichain/ocean-api-client

> Provides the protocol core for communicating between client and server. Within `ocean-api-client`, it contains a shared response and exception structure.

The official JS client for ocean-api. As the development of ocean-api client and server are closely intertwined, this allows the project to move iteratively together. With them packaged together within the same repo, the server and client can be released together. This allows us to be the consumer of our own client implementation. Testing each server endpoint directly with `ocean-api-client`, dogfooding at the maximum.