### PR TITLE
feat(testcontainers): add mockTime for waitForWalletCoinbaseMaturity to generate block faster

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -33,6 +33,7 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="JavaScript">
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_FOR" value="false" />
@@ -47,6 +48,7 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="TypeScript">
+      <option name="BLOCK_COMMENT_ADD_SPACE" value="true" />
       <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
       <option name="ALIGN_MULTILINE_FOR" value="false" />

--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -216,6 +216,7 @@
       <w>setgov</w>
       <w>setgovheight</w>
       <w>setloantoken</w>
+      <w>setmocktime</w>
       <w>setwalletflag</w>
       <w>sighash</w>
       <w>sighashtype</w>

--- a/packages/testcontainers/__tests__/containers/RegTestContainer/Coinbase.test.ts
+++ b/packages/testcontainers/__tests__/containers/RegTestContainer/Coinbase.test.ts
@@ -66,7 +66,11 @@ describe('coinbase maturity', () => {
   })
 
   it('should be able to get new address and priv/pub key for testing', async () => {
-    const { address, privKey, pubKey } = await container.newAddressKeys()
+    const {
+      address,
+      privKey,
+      pubKey
+    } = await container.newAddressKeys()
     await container.waitForWalletBalanceGTE(10)
     const { txid } = await container.fundAddress(address, 1)
 
@@ -82,5 +86,21 @@ describe('coinbase maturity', () => {
       ])
       expect(unspent[0].txid).toStrictEqual(txid)
     })
+  })
+})
+
+describe('coinbase maturity faster by time travel', () => {
+  const container = new MasterNodeRegTestContainer()
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should speed up coinbase maturity', async () => {
+    await container.waitForWalletCoinbaseMaturity()
   })
 })

--- a/packages/testcontainers/src/containers/RegTestContainer/Masternode.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/Masternode.ts
@@ -80,7 +80,7 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    * Wait for block height by minting towards the target
    *
    * @param {number} height to wait for
-   * @param {number} [timeout=90000] in ms
+   * @param {number} [timeout=590000] in ms
    */
   async waitForBlockHeight (height: number, timeout = 590000): Promise<void> {
     return await waitForCondition(async () => {
@@ -101,9 +101,24 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
    * un-spendable (in the event the mined block moves out of the active chain due to a fork).
    *
    * @param {number} [timeout=180000] in ms
+   * @param {boolean} [mockTime=true] to generate blocks faster
    */
-  async waitForWalletCoinbaseMaturity (timeout = 180000): Promise<void> {
-    return await this.waitForBlockHeight(100, timeout)
+  async waitForWalletCoinbaseMaturity (timeout: number = 180000, mockTime: boolean = true): Promise<void> {
+    if (!mockTime) {
+      return await this.waitForBlockHeight(100, timeout)
+    }
+
+    let fakeTime: number = 1579045065
+    await this.call('setmocktime', [fakeTime])
+
+    const intervalId = setInterval(() => {
+      void this.call('setmocktime', [fakeTime++])
+    }, 200)
+
+    await this.waitForBlockHeight(100, timeout)
+
+    clearInterval(intervalId)
+    await this.call('setmocktime', [0])
   }
 
   /**

--- a/packages/testcontainers/src/containers/RegTestContainer/Masternode.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/Masternode.ts
@@ -112,7 +112,8 @@ export class MasterNodeRegTestContainer extends RegTestContainer {
     await this.call('setmocktime', [fakeTime])
 
     const intervalId = setInterval(() => {
-      void this.call('setmocktime', [fakeTime++])
+      fakeTime += 3
+      void this.call('setmocktime', [fakeTime])
     }, 200)
 
     await this.waitForBlockHeight(100, timeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

`@defichain/testcontainers` `waitForWalletCoinbaseMaturity` is kinda slow and it makes us wait 30-40 seconds between each test cycle. Pretty bad developer experience.

This PR introduces `mockTime=true` to simulate post genesis time at 5x speed to speed up the initial block minting process to get past coinbase limit quickly. It will restore to default system time after coinbase.

---

Alternatively, we can submit 100 pre-defined deterministic blocks. However, this design is less static and more dynamic allowing for greater testing evolution.
