### PR TITLE
feat(jellyfish-api-core): listanchors supprot btcheight pagination

### DIFF
--- a/docs/node/CATEGORIES/14-spv.md
+++ b/docs/node/CATEGORIES/14-spv.md
@@ -283,7 +283,7 @@ List anchors.
 ```ts title=client.spv.listAnchors()"
 interface spv {
   listAnchors (
-    options: ListAnchorsOptions = { minBtcHeight: -1, maxBtcHeight: -1, minConfs: -1, maxConfs: -1 }
+    options: ListAnchorsOptions = { minBtcHeight: -1, maxBtcHeight: -1, minConfs: -1, maxConfs: -1, startBTCHeight: -1, limit: -1 }
   ): Promise<ListAnchorsResult[]>
 }
 
@@ -292,6 +292,8 @@ interface ListAnchorsOptions {
   maxBtcHeight?: number
   minConfs?: number
   maxConfs?: number
+  startBTCHeight?: number
+  limit?: number
 }
 
 interface ListAnchorsResult {

--- a/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
@@ -106,9 +106,9 @@ describe('Spv', () => {
     }], rewardAddress)
   }
 
-  // it('test', async () => {
-  //   console.log('test')
-  // })
+  it('test', async () => {
+    console.log('test')
+  })
 
   // it('should listAnchors', async () => {
   //   const anchors = await tGroup.get(0).rpc.spv.listAnchors()
@@ -152,7 +152,8 @@ describe('Spv', () => {
   //   expect(anchors.every(anchor => anchor.confirmations <= 3)).toStrictEqual(true)
   // })
 
-  // it('should listAnchors with startBTCHeight', async () => {
-
-  // })
+  it('should listAnchors with startBTCHeight', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ startBTCHeight: 2, limit: 1 })
+    console.log(anchors)
+  })
 })

--- a/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
@@ -106,54 +106,60 @@ describe('Spv', () => {
     }], rewardAddress)
   }
 
-  it('test', async () => {
-    console.log('test')
+  it('should listAnchors', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors()
+    expect(anchors.length).toStrictEqual(4)
+    for (const anchor of anchors) {
+      expect(typeof anchor.btcBlockHeight).toStrictEqual('number')
+      expect(typeof anchor.btcBlockHash).toStrictEqual('string')
+      expect(typeof anchor.btcTxHash).toStrictEqual('string')
+      expect(typeof anchor.previousAnchor).toStrictEqual('string')
+      expect(typeof anchor.defiBlockHeight).toStrictEqual('number')
+      expect(typeof anchor.defiBlockHash).toStrictEqual('string')
+      expect(typeof anchor.rewardAddress).toStrictEqual('string')
+      expect(typeof anchor.confirmations).toStrictEqual('number')
+      expect(typeof anchor.signatures).toStrictEqual('number')
+      expect(typeof anchor.anchorCreationHeight).toStrictEqual('number')
+      expect(typeof anchor.active).toStrictEqual('boolean')
+    }
   })
 
-  // it('should listAnchors', async () => {
-  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors()
-  //   expect(anchors.length).toStrictEqual(4)
-  //   for (const anchor of anchors) {
-  //     expect(typeof anchor.btcBlockHeight).toStrictEqual('number')
-  //     expect(typeof anchor.btcBlockHash).toStrictEqual('string')
-  //     expect(typeof anchor.btcTxHash).toStrictEqual('string')
-  //     expect(typeof anchor.previousAnchor).toStrictEqual('string')
-  //     expect(typeof anchor.defiBlockHeight).toStrictEqual('number')
-  //     expect(typeof anchor.defiBlockHash).toStrictEqual('string')
-  //     expect(typeof anchor.rewardAddress).toStrictEqual('string')
-  //     expect(typeof anchor.confirmations).toStrictEqual('number')
-  //     expect(typeof anchor.signatures).toStrictEqual('number')
-  //     expect(typeof anchor.anchorCreationHeight).toStrictEqual('number')
-  //     expect(typeof anchor.active).toStrictEqual('boolean')
-  //   }
-  // })
+  it('should listAnchors with minBtcHeight', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minBtcHeight: 4 })
+    expect(anchors.length).toStrictEqual(1)
+    expect(anchors.every(anchor => anchor.btcBlockHeight <= 4)).toStrictEqual(true)
+  })
 
-  // it('should listAnchors with minBtcHeight', async () => {
-  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minBtcHeight: 4 })
-  //   expect(anchors.length).toStrictEqual(1)
-  //   expect(anchors.every(anchor => anchor.btcBlockHeight <= 4)).toStrictEqual(true)
-  // })
+  it('should listAnchors with maxBtcHeight', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxBtcHeight: 3 })
+    expect(anchors.length).toStrictEqual(3)
+    expect(anchors.every(anchor => anchor.btcBlockHeight <= 3)).toStrictEqual(true)
+  })
 
-  // it('should listAnchors with maxBtcHeight', async () => {
-  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxBtcHeight: 3 })
-  //   expect(anchors.length).toStrictEqual(3)
-  //   expect(anchors.every(anchor => anchor.btcBlockHeight <= 3)).toStrictEqual(true)
-  // })
+  it('should listAnchors with minConfs', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minConfs: 5 })
+    expect(anchors.length).toStrictEqual(2)
+    expect(anchors.every(anchor => anchor.confirmations >= 5)).toStrictEqual(true)
+  })
 
-  // it('should listAnchors with minConfs', async () => {
-  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minConfs: 5 })
-  //   expect(anchors.length).toStrictEqual(2)
-  //   expect(anchors.every(anchor => anchor.confirmations >= 5)).toStrictEqual(true)
-  // })
+  it('should listAnchors with maxConfs', async () => {
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxConfs: 3 })
+    expect(anchors.length).toStrictEqual(1)
+    expect(anchors.every(anchor => anchor.confirmations <= 3)).toStrictEqual(true)
+  })
 
-  // it('should listAnchors with maxConfs', async () => {
-  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxConfs: 3 })
-  //   expect(anchors.length).toStrictEqual(1)
-  //   expect(anchors.every(anchor => anchor.confirmations <= 3)).toStrictEqual(true)
-  // })
+  it('should listAnchors with limit and list from the latest anchor', async () => {
+    const limit = 1
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ limit })
+    expect(anchors.length).toStrictEqual(1)
+
+    const latestAnchorBlock = 4
+    expect(anchors[0].btcBlockHeight).toStrictEqual(latestAnchorBlock)
+  })
 
   it('should listAnchors with startBTCHeight', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ startBTCHeight: 2, limit: 1 })
-    console.log(anchors)
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ startBTCHeight: 2 })
+    expect(anchors.length).toStrictEqual(3)
+    expect(anchors.every(anchor => anchor.btcBlockHeight >= 2)).toStrictEqual(true)
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
@@ -162,4 +162,12 @@ describe('Spv', () => {
     expect(anchors.length).toStrictEqual(3)
     expect(anchors.every(anchor => anchor.btcBlockHeight >= 2)).toStrictEqual(true)
   })
+
+  it('should listAnchors with limit and startBTCHeight', async () => {
+    const startBTCHeight = 2
+    const limit = 1
+    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ startBTCHeight, limit })
+    expect(anchors.length).toStrictEqual(limit)
+    expect(anchors.every(anchor => anchor.btcBlockHeight >= 2)).toStrictEqual(true)
+  })
 })

--- a/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/listAnchors.test.ts
@@ -2,7 +2,7 @@ import { spv } from '@defichain/jellyfish-api-core'
 import { TestingGroup } from '@defichain/jellyfish-testing'
 import { GenesisKeys } from '@defichain/testcontainers'
 
-describe.skip('Spv', () => {
+describe('Spv', () => {
   const tGroup = TestingGroup.create(3)
 
   beforeAll(async () => {
@@ -106,45 +106,53 @@ describe.skip('Spv', () => {
     }], rewardAddress)
   }
 
-  it('should listAnchors', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors()
-    expect(anchors.length).toStrictEqual(4)
-    for (const anchor of anchors) {
-      expect(typeof anchor.btcBlockHeight).toStrictEqual('number')
-      expect(typeof anchor.btcBlockHash).toStrictEqual('string')
-      expect(typeof anchor.btcTxHash).toStrictEqual('string')
-      expect(typeof anchor.previousAnchor).toStrictEqual('string')
-      expect(typeof anchor.defiBlockHeight).toStrictEqual('number')
-      expect(typeof anchor.defiBlockHash).toStrictEqual('string')
-      expect(typeof anchor.rewardAddress).toStrictEqual('string')
-      expect(typeof anchor.confirmations).toStrictEqual('number')
-      expect(typeof anchor.signatures).toStrictEqual('number')
-      expect(typeof anchor.anchorCreationHeight).toStrictEqual('number')
-      expect(typeof anchor.active).toStrictEqual('boolean')
-    }
-  })
+  // it('test', async () => {
+  //   console.log('test')
+  // })
 
-  it('should listAnchors with minBtcHeight', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minBtcHeight: 4 })
-    expect(anchors.length).toStrictEqual(1)
-    expect(anchors.every(anchor => anchor.btcBlockHeight <= 4)).toStrictEqual(true)
-  })
+  // it('should listAnchors', async () => {
+  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors()
+  //   expect(anchors.length).toStrictEqual(4)
+  //   for (const anchor of anchors) {
+  //     expect(typeof anchor.btcBlockHeight).toStrictEqual('number')
+  //     expect(typeof anchor.btcBlockHash).toStrictEqual('string')
+  //     expect(typeof anchor.btcTxHash).toStrictEqual('string')
+  //     expect(typeof anchor.previousAnchor).toStrictEqual('string')
+  //     expect(typeof anchor.defiBlockHeight).toStrictEqual('number')
+  //     expect(typeof anchor.defiBlockHash).toStrictEqual('string')
+  //     expect(typeof anchor.rewardAddress).toStrictEqual('string')
+  //     expect(typeof anchor.confirmations).toStrictEqual('number')
+  //     expect(typeof anchor.signatures).toStrictEqual('number')
+  //     expect(typeof anchor.anchorCreationHeight).toStrictEqual('number')
+  //     expect(typeof anchor.active).toStrictEqual('boolean')
+  //   }
+  // })
 
-  it('should listAnchors with maxBtcHeight', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxBtcHeight: 3 })
-    expect(anchors.length).toStrictEqual(3)
-    expect(anchors.every(anchor => anchor.btcBlockHeight <= 3)).toStrictEqual(true)
-  })
+  // it('should listAnchors with minBtcHeight', async () => {
+  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minBtcHeight: 4 })
+  //   expect(anchors.length).toStrictEqual(1)
+  //   expect(anchors.every(anchor => anchor.btcBlockHeight <= 4)).toStrictEqual(true)
+  // })
 
-  it('should listAnchors with minConfs', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minConfs: 5 })
-    expect(anchors.length).toStrictEqual(2)
-    expect(anchors.every(anchor => anchor.confirmations >= 5)).toStrictEqual(true)
-  })
+  // it('should listAnchors with maxBtcHeight', async () => {
+  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxBtcHeight: 3 })
+  //   expect(anchors.length).toStrictEqual(3)
+  //   expect(anchors.every(anchor => anchor.btcBlockHeight <= 3)).toStrictEqual(true)
+  // })
 
-  it('should listAnchors with maxConfs', async () => {
-    const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxConfs: 3 })
-    expect(anchors.length).toStrictEqual(1)
-    expect(anchors.every(anchor => anchor.confirmations <= 3)).toStrictEqual(true)
-  })
+  // it('should listAnchors with minConfs', async () => {
+  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ minConfs: 5 })
+  //   expect(anchors.length).toStrictEqual(2)
+  //   expect(anchors.every(anchor => anchor.confirmations >= 5)).toStrictEqual(true)
+  // })
+
+  // it('should listAnchors with maxConfs', async () => {
+  //   const anchors = await tGroup.get(0).rpc.spv.listAnchors({ maxConfs: 3 })
+  //   expect(anchors.length).toStrictEqual(1)
+  //   expect(anchors.every(anchor => anchor.confirmations <= 3)).toStrictEqual(true)
+  // })
+
+  // it('should listAnchors with startBTCHeight', async () => {
+
+  // })
 })

--- a/packages/jellyfish-api-core/src/category/spv.ts
+++ b/packages/jellyfish-api-core/src/category/spv.ts
@@ -192,15 +192,17 @@ export class Spv {
    * @param {number} [options.maxBtcHeight=-1]
    * @param {number} [options.minConfs=-1]
    * @param {number} [options.maxConfs=-1]
+   * @param {number} [options.startBTCHeight=-1]
+   * @param {number} [options.limit]
    * @return {Promise<ListAnchorsResult[]>}
    */
   async listAnchors (
     options: ListAnchorsOptions = {}
   ): Promise<ListAnchorsResult[]> {
-    const opts = { minBtcHeight: -1, maxBtcHeight: -1, minConfs: -1, maxConfs: -1, ...options }
+    const opts = { minBtcHeight: -1, maxBtcHeight: -1, minConfs: -1, maxConfs: -1, startBTCHeight: -1, limit: -1, ...options }
     return await this.client.call(
       'spv_listanchors',
-      [opts.minBtcHeight, opts.maxBtcHeight, opts.minConfs, opts.maxConfs],
+      [opts.minBtcHeight, opts.maxBtcHeight, opts.minConfs, opts.maxConfs, opts.startBTCHeight, opts.limit],
       'number'
     )
   }
@@ -387,6 +389,10 @@ export interface ListAnchorsOptions {
   minConfs?: number
   /** max confirmations */
   maxConfs?: number
+  /** start BTC height */
+  startBTCHeight?: number
+  /** limit */
+  limit?: number
 }
 
 export interface ListAnchorsResult {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -29,8 +29,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    // return 'defi/defichain:2.2.1'
-    return 'defi/defichain:HEAD-9f91434'
+    return 'defi/defichain:2.2.1'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -29,7 +29,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:2.2.1'
+    return 'defi/defichain:2.3.2'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -29,7 +29,8 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:2.2.1'
+    // return 'defi/defichain:2.2.1'
+    return 'defi/defichain:HEAD-9f91434'
   }
 
   public static readonly DefaultStartOptions = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
update listAnchor rpc to include start BTC height and limit

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/DeFiCh/jellyfish/issues/911

#### Additional comments?:
relies on https://github.com/DeFiCh/ain/pull/921 to release before changing docker version