### PR TITLE
fix(packages/testcontainers): add node after restart

### DIFF
--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -58,6 +58,10 @@ export class Testing {
     const rpc = new TestingJsonRpcClient(container)
     return new Testing(container, rpc)
   }
+
+  async add (container: MasterNodeRegTestContainer, name: string): Promise<void> {
+    await this.container.addNode(await container.getIp(name))
+  }
 }
 
 export class TestingGroup {

--- a/packages/jellyfish-testing/src/testing.ts
+++ b/packages/jellyfish-testing/src/testing.ts
@@ -58,10 +58,6 @@ export class Testing {
     const rpc = new TestingJsonRpcClient(container)
     return new Testing(container, rpc)
   }
-
-  async add (container: MasterNodeRegTestContainer, name: string): Promise<void> {
-    await this.container.addNode(await container.getIp(name))
-  }
 }
 
 export class TestingGroup {
@@ -109,6 +105,10 @@ export class TestingGroup {
 
   async stop (): Promise<void> {
     return await this.group.stop()
+  }
+
+  async link (): Promise<void> {
+    return await this.group.link()
   }
 
   async exec (runner: (testing: Testing) => Promise<void>): Promise<void> {

--- a/packages/testcontainers/__tests__/containers/ContainerRestart.test.ts
+++ b/packages/testcontainers/__tests__/containers/ContainerRestart.test.ts
@@ -64,7 +64,7 @@ describe('container group restart', () => {
 
       await alice.container.setDeFiConf([`masternode_operator=${mnAddr}`])
       await alice.container.restart()
-      await alice.add(bob.container, tGroup.group.getName())
+      await tGroup.link()
       await tGroup.waitForSync()
 
       await alice.generate(20)
@@ -83,7 +83,7 @@ describe('container group restart', () => {
 
       await bob.container.setDeFiConf([`masternode_operator=${mnAddr}`])
       await bob.container.restart()
-      await bob.add(alice.container, tGroup.group.getName())
+      await tGroup.link()
 
       await bob.generate(20)
       await tGroup.waitForSync()

--- a/packages/testcontainers/__tests__/containers/ContainerRestart.test.ts
+++ b/packages/testcontainers/__tests__/containers/ContainerRestart.test.ts
@@ -1,4 +1,6 @@
 import { GenesisKeys, MasterNodeRegTestContainer } from '../../src'
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
+import { TestingGroup } from '@defichain/jellyfish-testing'
 
 describe('container restart with setDeFiConf', () => {
   const container = new MasterNodeRegTestContainer()
@@ -37,5 +39,58 @@ describe('container restart with setDeFiConf', () => {
         expect(value.mintedBlocks).toBeGreaterThan(0)
       }
     })
+  })
+})
+
+describe('container group restart', () => {
+  const tGroup = TestingGroup.create(2, i => new MasterNodeRegTestContainer(RegTestFoundationKeys[i]))
+  const alice = tGroup.get(0)
+  const bob = tGroup.get(1)
+
+  beforeAll(async () => {
+    await tGroup.start()
+    await alice.container.waitForWalletCoinbaseMaturity()
+  })
+
+  afterAll(async () => {
+    await tGroup.stop()
+  })
+
+  it('test container group restart', async () => {
+    {
+      const mnAddr = await alice.container.getNewAddress('', 'legacy')
+      const mnId1 = await alice.container.call('createmasternode', [mnAddr])
+      await alice.container.generate(1)
+
+      await alice.container.setDeFiConf([`masternode_operator=${mnAddr}`])
+      await alice.container.restart()
+      await alice.add(bob.container, tGroup.group.getName())
+      await tGroup.waitForSync()
+
+      await alice.generate(20)
+      await alice.container.generate(5, mnAddr)
+
+      await alice.container.call('getmasternodeblocks', [{ id: mnId1 }])
+      await alice.container.call('getmasternodeblocks', [{ id: mnId1 }, 1])
+      await tGroup.waitForSync()
+    }
+
+    {
+      const mnAddr = await bob.container.getNewAddress('', 'legacy')
+      const mnId1 = await bob.container.call('createmasternode', [mnAddr])
+      await bob.container.generate(1)
+      await tGroup.waitForSync()
+
+      await bob.container.setDeFiConf([`masternode_operator=${mnAddr}`])
+      await bob.container.restart()
+      await bob.add(alice.container, tGroup.group.getName())
+
+      await bob.generate(20)
+      await tGroup.waitForSync()
+      await bob.container.generate(5, mnAddr)
+
+      await bob.container.call('getmasternodeblocks', [{ id: mnId1 }])
+      await bob.container.call('getmasternodeblocks', [{ id: mnId1 }, 1])
+    }
   })
 })

--- a/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
@@ -23,10 +23,6 @@ export class ContainerGroup {
     return this.containers[index] as MasterNodeRegTestContainer
   }
 
-  getName (): string {
-    return this.name
-  }
-
   async start (): Promise<void> {
     this.network = await new Promise((resolve, reject) => {
       return this.docker.createNetwork({
@@ -47,6 +43,14 @@ export class ContainerGroup {
     for (const container of this.containers.splice(0)) {
       await container.start()
       await this.add(container)
+    }
+  }
+
+  async link (): Promise<void> {
+    for (const container of this.containers) {
+      for (const each of this.containers) {
+        await each.addNode(await container.getIp(this.name))
+      }
     }
   }
 

--- a/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
+++ b/packages/testcontainers/src/containers/RegTestContainer/ContainerGroup.ts
@@ -23,6 +23,10 @@ export class ContainerGroup {
     return this.containers[index] as MasterNodeRegTestContainer
   }
 
+  getName (): string {
+    return this.name
+  }
+
   async start (): Promise<void> {
     this.network = await new Promise((resolve, reject) => {
       return this.docker.createNetwork({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What kind of PR is this?:
<!-- Use one of the following kinds:
/kind feature
/kind fix
/kind chore
/kind docs
/kind refactor
/kind dependencies
-->

/kind fix

#### What this PR does / why we need it:

Peers were lost after node restart.
Re-add node after restart.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #915

#### Additional comments?:
Easy (current):
```ts
node1.restart()
tGroup.link()
```
Manual
```ts
node1.restart()
node1.add(node2)
node1.add(node3)
```