### PR TITLE
feat(ocean-api): integrate playground with ocean-api

### DIFF
--- a/apps/ocean-api/__tests__/modules/PlaygroundModule.test.ts
+++ b/apps/ocean-api/__tests__/modules/PlaygroundModule.test.ts
@@ -13,7 +13,7 @@ describe('regtest', () => {
     await apiTesting.stop()
   })
 
-  it('block count should not increment', async () => {
+  it('should not increment block count', async () => {
     const initial = await apiTesting.rpc.blockchain.getBlockCount()
 
     await new Promise((resolve) => {
@@ -37,7 +37,7 @@ describe('playground', () => {
     await apiTesting.stop()
   })
 
-  it('block count should increment', async () => {
+  it('should increment block count', async () => {
     const initial = await apiTesting.rpc.blockchain.getBlockCount()
 
     await waitForExpect(async () => {

--- a/apps/ocean-api/__tests__/modules/PlaygroundModule.test.ts
+++ b/apps/ocean-api/__tests__/modules/PlaygroundModule.test.ts
@@ -1,0 +1,48 @@
+import { OceanApiTesting } from '../../testing/OceanApiTesting'
+import waitForExpect from 'wait-for-expect'
+
+describe('regtest', () => {
+  const apiTesting = OceanApiTesting.create()
+
+  beforeEach(async () => {
+    apiTesting.playgroundEnable(false)
+    await apiTesting.start()
+  })
+
+  afterEach(async () => {
+    await apiTesting.stop()
+  })
+
+  it('block count should not increment', async () => {
+    const initial = await apiTesting.rpc.blockchain.getBlockCount()
+
+    await new Promise((resolve) => {
+      setTimeout(_ => resolve(0), 5000)
+    })
+
+    const next = await apiTesting.rpc.blockchain.getBlockCount()
+    expect(next).toStrictEqual(initial)
+  })
+})
+
+describe('playground', () => {
+  const apiTesting = OceanApiTesting.create()
+
+  beforeEach(async () => {
+    apiTesting.playgroundEnable(true)
+    await apiTesting.start()
+  })
+
+  afterEach(async () => {
+    await apiTesting.stop()
+  })
+
+  it('block count should increment', async () => {
+    const initial = await apiTesting.rpc.blockchain.getBlockCount()
+
+    await waitForExpect(async () => {
+      const next = await apiTesting.rpc.blockchain.getBlockCount()
+      expect(next).toBeGreaterThan(initial)
+    })
+  })
+})

--- a/apps/ocean-api/src/modules/PlaygroundModule.ts
+++ b/apps/ocean-api/src/modules/PlaygroundModule.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger, Module } from '@nestjs/common'
+import { ConfigService } from '@nestjs/config'
+import { Interval, ScheduleModule } from '@nestjs/schedule'
+import { BotLogger, Playground } from '@defichain/playground'
+import { ApiClient } from '@defichain/jellyfish-api-core'
+
+/**
+ * Provide a PlaygroundRunner when PLAYGROUND_ENABLE is enabled.
+ */
+@Module({
+  imports: [
+    ScheduleModule.forRoot()
+  ],
+  providers: [
+    {
+      provide: 'PLAYGROUND_RUNNER',
+      useFactory: (configService: ConfigService, apiClient: ApiClient): PlaygroundRunner | undefined => {
+        if (configService.get<boolean>('PLAYGROUND_ENABLE') === true) {
+          return new PlaygroundRunner(apiClient)
+        }
+        return undefined
+      },
+      inject: [ConfigService, ApiClient]
+    }
+  ]
+})
+export class PlaygroundModule {
+}
+
+/**
+ * Universal logger for playground using NestJS logger.
+ */
+class PlaygroundLogger implements BotLogger {
+  private readonly logger = new Logger(PlaygroundLogger.name)
+
+  info (action: string, message: string): void {
+    this.logger.log(`${action} ${message}`)
+  }
+}
+
+@Injectable()
+class PlaygroundRunner {
+  constructor (
+    private readonly apiClient: ApiClient,
+    private readonly logger: PlaygroundLogger = new PlaygroundLogger(),
+    private readonly playground: Playground = new Playground(apiClient, logger)
+  ) {
+  }
+
+  async onApplicationBootstrap (): Promise<void> {
+    this.logger.info('onApplicationBootstrap', 'Bootstrapping')
+    await this.playground.bootstrap()
+    this.logger.info('onApplicationBootstrap', 'Bootstrapped')
+  }
+
+  @Interval(3000)
+  async cycle (): Promise<void> {
+    await this.playground.cycle()
+  }
+}

--- a/apps/ocean-api/src/modules/PlaygroundModule.ts
+++ b/apps/ocean-api/src/modules/PlaygroundModule.ts
@@ -15,10 +15,15 @@ import { ApiClient } from '@defichain/jellyfish-api-core'
     {
       provide: 'PLAYGROUND_RUNNER',
       useFactory: (configService: ConfigService, apiClient: ApiClient): PlaygroundRunner | undefined => {
-        if (configService.get<boolean>('PLAYGROUND_ENABLE') === true) {
-          return new PlaygroundRunner(apiClient)
+        if (configService.get<boolean>('PLAYGROUND_ENABLE') === false) {
+          return undefined
         }
-        return undefined
+
+        if (configService.get<string>('API_NETWORK') !== 'regtest') {
+          throw new Error('PLAYGROUND_ENABLE:true is only allowed on API_NETWORK:regtest')
+        }
+
+        return new PlaygroundRunner(apiClient)
       },
       inject: [ConfigService, ApiClient]
     }

--- a/apps/ocean-api/src/modules/RootModule.ts
+++ b/apps/ocean-api/src/modules/RootModule.ts
@@ -4,6 +4,7 @@ import { ConfigModule } from '@nestjs/config'
 import { ControllerModule } from './ControllerModule'
 import { BlockchainCppModule } from './BlockchainCppModule'
 import { ActuatorModule } from './ActuatorModule'
+import { PlaygroundModule } from './PlaygroundModule'
 
 @Module({
   imports: [
@@ -14,7 +15,8 @@ import { ActuatorModule } from './ActuatorModule'
     }),
     ActuatorModule,
     BlockchainCppModule,
-    ControllerModule
+    ControllerModule,
+    PlaygroundModule
   ]
 })
 export class RootModule {

--- a/apps/ocean-api/src/modules/RootModule.ts
+++ b/apps/ocean-api/src/modules/RootModule.ts
@@ -27,7 +27,7 @@ function ENV_VALIDATION_SCHEMA (): any {
     NODE_ENV: Joi.string().valid('production', 'test').default('test'),
     PORT: Joi.number().default(3000),
     API_VERSION: Joi.string().regex(/^v[0-9]+(\.[0-9]+)?$/).default('v1'),
-    API_NETWORK: Joi.string().valid('regtest', 'testnet', 'mainnet', 'playground').default('regtest'),
+    API_NETWORK: Joi.string().valid('regtest', 'testnet', 'mainnet').default('regtest'),
     PLAYGROUND_ENABLE: Joi.boolean()
   })
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

Integrated playground to automatically run when `PLAYGROUND_ENABLE` is provided on `regtest`.

