### PR TITLE
feat(ocean-api): add fee estimate to rawtx endpoint

### DIFF
--- a/apps/ocean-api/__tests__/controllers/RawTxController.test.ts
+++ b/apps/ocean-api/__tests__/controllers/RawTxController.test.ts
@@ -1,0 +1,40 @@
+import { OceanApiTesting } from '../../testing/OceanApiTesting'
+
+const apiTesting = OceanApiTesting.create()
+
+beforeEach(async () => {
+  await apiTesting.start()
+})
+
+afterEach(async () => {
+  await apiTesting.stop()
+})
+
+it('should be fixed fee of 0.00005000 when there are no transactions', async () => {
+  const feeRate = await apiTesting.client.rawtx.feeEstimate()
+
+  expect(feeRate).toStrictEqual(0.00005000)
+})
+
+it('should have fee of not 0.00005 with transactions activity', async () => {
+  await apiTesting.container.waitForWalletBalanceGTE(100)
+
+  for (let i = 0; i < 10; i++) {
+    for (let x = 0; x < 20; x++) {
+      await apiTesting.rpc.wallet.sendToAddress('bcrt1qf5v8n3kfe6v5mharuvj0qnr7g74xnu9leut39r', 0.1, {
+        subtractFeeFromAmount: true,
+        avoidReuse: false
+      })
+    }
+    await apiTesting.container.generate(1)
+  }
+
+  const feeRate = await apiTesting.client.rawtx.feeEstimate()
+  expect(feeRate).not.toStrictEqual(0.00005000)
+})
+
+it('should be able to provide confirmation target', async () => {
+  const feeRate = await apiTesting.client.rawtx.feeEstimate(100)
+
+  expect(feeRate).toBeDefined()
+})

--- a/apps/ocean-api/src/controllers/RawTxController.ts
+++ b/apps/ocean-api/src/controllers/RawTxController.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, ParseIntPipe, Query } from '@nestjs/common'
+import { ApiClient, mining } from '@defichain/jellyfish-api-core'
+
+@Controller('/rawtx')
+export class RawTxController {
+  constructor (private readonly client: ApiClient) {
+  }
+
+  /**
+   * If fee rate cannot be estimated it will return a fixed rate of 0.00005000
+   * That fee rate will max out at around 0.00001 DFI per average transaction (200vb).
+   *
+   * @param {number} confirmationTarget in blocks till fee get confirmed
+   * @return {Promise<number>} fee rate per KB
+   */
+  @Get('/fee/estimate')
+  async estimate (@Query('confirmationTarget', ParseIntPipe) confirmationTarget: number = 10): Promise<number> {
+    const estimation = await this.client.mining.estimateSmartFee(confirmationTarget, mining.EstimateMode.CONSERVATIVE)
+    if (estimation.feerate !== undefined) {
+      return estimation.feerate
+    }
+
+    return 0.00005000
+  }
+}

--- a/apps/ocean-api/src/modules/ControllerModule.ts
+++ b/apps/ocean-api/src/modules/ControllerModule.ts
@@ -6,6 +6,7 @@ import { ResponseInterceptor } from '../controllers/filters/ResponseInterceptor'
 import { ErrorFilter } from '../controllers/filters/ErrorFilter'
 import { ConfigService } from '@nestjs/config'
 import { NetworkName } from '@defichain/jellyfish-network'
+import { RawTxController } from '../controllers/RawTxController'
 
 /**
  * Exposed ApiModule for public interfacing
@@ -15,7 +16,8 @@ import { NetworkName } from '@defichain/jellyfish-network'
     CacheModule.register()
   ],
   controllers: [
-    ActuatorController
+    ActuatorController,
+    RawTxController
   ],
   providers: [
     {

--- a/packages/ocean-api-client/src/OceanApiClient.ts
+++ b/packages/ocean-api-client/src/OceanApiClient.ts
@@ -2,6 +2,7 @@ import 'url-search-params-polyfill'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
 import { ApiException, ApiMethod, ApiPagedResponse, ApiResponse, ClientException, TimeoutException } from './'
+import { RawTx } from './apis/RawTx'
 
 /**
  * OceanApiClient configurable options
@@ -31,8 +32,7 @@ export interface OceanApiClientOptions {
  * OceanApiClient
  */
 export class OceanApiClient {
-  // TODO(fuxingloh):
-  //  public readonly fee = new Fee(this)
+  public readonly rawtx = new RawTx(this)
 
   constructor (
     protected readonly options: OceanApiClientOptions
@@ -94,7 +94,7 @@ export class OceanApiClient {
    * @param {'POST|'GET'} method to request
    * @param {string} path to request
    * @param {any} [object] JSON to send in request
-   * @return {T} data object in the JSON response body
+   * @return data object in the JSON response body
    */
   async requestData<T> (method: ApiMethod, path: string, object?: any): Promise<T> {
     const response = await this.requestAsApiResponse<T>(method, path, object)

--- a/packages/ocean-api-client/src/apis/RawTx.ts
+++ b/packages/ocean-api-client/src/apis/RawTx.ts
@@ -1,0 +1,19 @@
+import { OceanApiClient } from '@defichain/ocean-api-client'
+
+export class RawTx {
+  constructor (private readonly api: OceanApiClient) {
+  }
+
+  /**
+   * The current fee rate to submit a rawtx into the network.
+   *
+   * If fee rate cannot be estimated it will return a fixed rate of 0.00005000
+   * This will max out at around 0.00001 DFI per average transaction (200vb).
+   *
+   * @param {number} confirmationTarget in blocks till fee get confirmed
+   * @return {Promise<number>} fee rate per KB
+   */
+  async feeEstimate (confirmationTarget: number = 10): Promise<number> {
+    return await this.api.requestData('GET', `rawtx/fee/estimate?confirmationTarget=${confirmationTarget}`)
+  }
+}

--- a/packages/ocean-api-client/src/apis/RawTx.ts
+++ b/packages/ocean-api-client/src/apis/RawTx.ts
@@ -1,4 +1,4 @@
-import { OceanApiClient } from '@defichain/ocean-api-client'
+import { OceanApiClient } from '../'
 
 export class RawTx {
   constructor (private readonly api: OceanApiClient) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Initial commit to add fee estimate to the `/rawtx` endpoint of OceanApi.

---

Different from the whale development testing style, everything in `apps/ocean-api` will be e2e tests only to keep things simple. Any spec if required should be tackled modularly and separated into their individual packages and tested in isolation.

This is 1 of 4 public Controller/Aspect that will be exposed for OceanApi.
- **RawTxController** 
- PlaygroundController
- RpcController
- GraphQLController