### PR TITLE
feat(jellyfish-api-core): add network getPeerInfo RPC

### DIFF
--- a/docs/node/CATEGORIES/03-net.md
+++ b/docs/node/CATEGORIES/03-net.md
@@ -23,6 +23,48 @@ interface net {
 }
 ```
 
+## getPeerInfo
+
+Returns data about each connected network node as a json array of objects.
+
+```ts title="client.net.getPeerInfo()"
+interface net {
+  getPeerInfo (): Promise<PeerInfo[]>
+}
+
+export interface PeerInfo {
+  id: number
+  addr: string
+  addrbind: string
+  addrlocal: string
+  services: string
+  relaytxes: boolean
+  lastsend: number
+  lastrecv: number
+  bytessent: number
+  bytesrecv: number
+  conntime: number
+  timeoffset: number
+  pingtime: number
+  minping: number
+  pingwait: number
+  version: number
+  subver: string
+  inbound: boolean
+  addnode: boolean
+  startingheight: number
+  banscore: number
+  synced_headers: number
+  synced_blocks: number
+  inflight: number[]
+  whitelisted: boolean
+  permissions: string[]
+  minfeefilter: number
+  bytessent_per_msg: Record<string, number>
+  bytesrecv_per_msg: Record<string, number>
+}
+```
+
 ## getNetworkInfo
 
 Returns an object containing various state info regarding P2P networking.

--- a/docs/node/CATEGORIES/03-net.md
+++ b/docs/node/CATEGORIES/03-net.md
@@ -35,8 +35,8 @@ interface net {
 export interface PeerInfo {
   id: number
   addr: string
-  addrbind: string
-  addrlocal: string
+  addrbind?: string
+  addrlocal?: string
   services: string
   relaytxes: boolean
   lastsend: number
@@ -45,23 +45,27 @@ export interface PeerInfo {
   bytesrecv: number
   conntime: number
   timeoffset: number
-  pingtime: number
-  minping: number
-  pingwait: number
+  pingtime?: number
+  minping?: number
+  pingwait?: number
   version: number
   subver: string
   inbound: boolean
   addnode: boolean
   startingheight: number
-  banscore: number
-  synced_headers: number
-  synced_blocks: number
+  banscore?: number
+  synced_headers?: number
+  synced_blocks?: number
   inflight: number[]
   whitelisted: boolean
   permissions: string[]
   minfeefilter: number
-  bytessent_per_msg: Record<string, number>
-  bytesrecv_per_msg: Record<string, number>
+  bytessent_per_msg: {
+    [msg: string]: number
+  }
+  bytesrecv_per_msg: {
+    [msg: string]: number
+  }
 }
 ```
 

--- a/packages/jellyfish-api-core/__tests__/category/loan/takeLoan.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/loan/takeLoan.test.ts
@@ -339,6 +339,7 @@ describe('takeLoan success', () => {
       loanSchemeId: 'scheme5'
     })
     await bob.generate(1)
+    await tGroup.waitForSync()
 
     await alice.rpc.loan.depositToVault({
       vaultId: vaultId, from: aliceAddr, amount: '10000@DFI'

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -23,7 +23,7 @@ function createNetworkTests (name: string, container: RegTestContainer | MasterN
 
       expect(peers.length).toBeGreaterThan(0)
 
-      for (const peer of await client.net.getPeerInfo()) {
+      for (const peer of peers) {
         expect(typeof peer.id).toStrictEqual('number')
 
         expectValidAddress(peer.addr)

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -21,40 +21,44 @@ function createNetworkTests (name: string, container: RegTestContainer | MasterN
       await expect(client.net.getPeerInfo()).resolves.toHaveLength(2)
     })
 
-    it('should return expected schema', async () => {
+    it('should return valid schema', async () => {
       for (const peer of await client.net.getPeerInfo()) {
         expect(typeof peer.id).toStrictEqual('number')
-        expect(typeof peer.addr).toStrictEqual('string')
-        expect(typeof peer.addrbind).toStrictEqual('string')
+
+        expectValidAddress(peer.addr)
+
+        expectUndefinedOrValidAddress(peer.addrbind)
+        expectUndefinedOrValidAddress(peer.addrlocal)
+
         expect(typeof peer.services).toStrictEqual('string')
+        expect(peer.services).toHaveLength(16)
+
         expect(typeof peer.relaytxes).toStrictEqual('boolean')
         expect(typeof peer.lastsend).toStrictEqual('number')
         expect(typeof peer.lastrecv).toStrictEqual('number')
+        expect(typeof peer.bytessent).toStrictEqual('number')
+        expect(typeof peer.bytesrecv).toStrictEqual('number')
         expect(typeof peer.conntime).toStrictEqual('number')
         expect(typeof peer.timeoffset).toStrictEqual('number')
+
+        expectUndefinedOrEquals('number', peer.pingtime)
+        expectUndefinedOrEquals('number', peer.minping)
+        expectUndefinedOrEquals('number', peer.pingwait)
+
         expect(typeof peer.version).toStrictEqual('number')
         expect(typeof peer.subver).toStrictEqual('string')
         expect(typeof peer.inbound).toStrictEqual('boolean')
         expect(typeof peer.addnode).toStrictEqual('boolean')
         expect(typeof peer.startingheight).toStrictEqual('number')
-        expect(typeof peer.banscore).toStrictEqual('number')
-        expect(typeof peer.synced_headers).toStrictEqual('number')
-        expect(typeof peer.synced_blocks).toStrictEqual('number')
+
+        expectUndefinedOrEquals('number', peer.banscore)
+        expectUndefinedOrEquals('number', peer.synced_headers)
+        expectUndefinedOrEquals('number', peer.synced_blocks)
+
         expect(typeof peer.inflight).toStrictEqual('object')
         expect(typeof peer.whitelisted).toStrictEqual('boolean')
         expect(typeof peer.permissions).toStrictEqual('object')
         expect(typeof peer.minfeefilter).toStrictEqual('number')
-        expect(typeof peer.bytessent_per_msg).toStrictEqual('object')
-        expect(typeof peer.bytesrecv_per_msg).toStrictEqual('object')
-      }
-    })
-
-    it('should return valid values', async () => {
-      for (const peer of await client.net.getPeerInfo()) {
-        expectValidAddress(peer.addr)
-        expectValidAddress(peer.addrbind)
-
-        expect(peer.services).toHaveLength(16)
 
         expectValidBytesPerMessage(peer.bytessent_per_msg)
         expectValidBytesPerMessage(peer.bytesrecv_per_msg)
@@ -63,12 +67,25 @@ function createNetworkTests (name: string, container: RegTestContainer | MasterN
   })
 }
 
+function expectUndefinedOrEquals (expected: any, actual?: any): void {
+  if (actual !== undefined) {
+    expect(typeof actual).toStrictEqual(expected)
+  }
+}
+
+function expectUndefinedOrValidAddress (address?: string): void {
+  if (address !== undefined) {
+    expectValidAddress(address)
+  }
+}
+
 function expectValidAddress (address: string): void {
-  return expect(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$/.test(address)).toBeTruthy()
+  expect(typeof address).toStrictEqual('string')
+  expect(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$/.test(address)).toBeTruthy()
 }
 
 function expectValidBytesPerMessage (obj: Record<string, number>): void {
   for (const key in obj) {
-    expect(obj[key]).toBeGreaterThanOrEqual(0)
+    expect(typeof obj[key]).toStrictEqual('number')
   }
 }

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -1,106 +1,204 @@
-import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { RegTestContainer } from '@defichain/testcontainers'
 import { PeerInfo } from 'packages/jellyfish-api-core/src/category/net'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 import Dockerode from 'dockerode'
+import { TestingGroup } from '@defichain/jellyfish-testing'
 
-createNetworkTests('Network without masternode', [new RegTestContainer(), new RegTestContainer()])
-createNetworkTests('Network on masternode', [new MasterNodeRegTestContainer(), new MasterNodeRegTestContainer()])
+const addrRegExp = /^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$/
 
-function createNetworkTests (name: string, container: RegTestContainer[] | MasterNodeRegTestContainer[]): void {
-  describe(name, () => {
-    const client = new ContainerAdapterClient(container[0])
-    let createdNetwork: Dockerode.NetworkInspectInfo
+describe('Network without masternode', () => {
+  const container = [
+    new RegTestContainer(),
+    new RegTestContainer()
+  ]
+  const client = new ContainerAdapterClient(container[0])
+  let createdNetwork: Dockerode.NetworkInspectInfo
 
-    beforeAll(async () => {
-      await container[0].start()
-      await container[0].createNetwork('test')
-      const networks = await container[0].listNetworks()
-      createdNetwork = networks.find(n => n.Name === 'test') as Dockerode.NetworkInspectInfo
-      await container[0].connectNetwork(createdNetwork.Id)
+  beforeAll(async () => {
+    await container[0].start()
+    await container[0].createNetwork('test')
+    const networks = await container[0].listNetworks()
+    createdNetwork = networks.find(n => n.Name === 'test') as Dockerode.NetworkInspectInfo
+    await container[0].connectNetwork(createdNetwork.Id)
 
-      await container[1].start()
-      await container[1].connectNetwork(createdNetwork.Id)
+    await container[1].start()
+    await container[1].connectNetwork(createdNetwork.Id)
 
-      // addnode
-      await container[0].addNode(await container[1].getIp('test'))
-    })
-
-    afterAll(async () => {
-      await container[0].stop()
-      await container[1].stop()
-
-      await container[0].removeNetwork(createdNetwork.Id)
-    })
-
-    it('should getPeerInfo', async () => {
-      const peers: PeerInfo[] = await client.net.getPeerInfo()
-
-      expect(peers.length).toBeGreaterThan(0)
-
-      for (const peer of peers) {
-        expect(typeof peer.id).toStrictEqual('number')
-
-        expectValidAddress(peer.addr)
-
-        expectUndefinedOrValidAddress(peer.addrbind)
-        expectUndefinedOrValidAddress(peer.addrlocal)
-
-        expect(typeof peer.services).toStrictEqual('string')
-        expect(peer.services).toHaveLength(16)
-
-        expect(typeof peer.relaytxes).toStrictEqual('boolean')
-        expect(typeof peer.lastsend).toStrictEqual('number')
-        expect(typeof peer.lastrecv).toStrictEqual('number')
-        expect(typeof peer.bytessent).toStrictEqual('number')
-        expect(typeof peer.bytesrecv).toStrictEqual('number')
-        expect(typeof peer.conntime).toStrictEqual('number')
-        expect(typeof peer.timeoffset).toStrictEqual('number')
-
-        expectUndefinedOrEquals('number', peer.pingtime)
-        expectUndefinedOrEquals('number', peer.minping)
-        expectUndefinedOrEquals('number', peer.pingwait)
-
-        expect(typeof peer.version).toStrictEqual('number')
-        expect(typeof peer.subver).toStrictEqual('string')
-        expect(typeof peer.inbound).toStrictEqual('boolean')
-        expect(typeof peer.addnode).toStrictEqual('boolean')
-        expect(typeof peer.startingheight).toStrictEqual('number')
-
-        expectUndefinedOrEquals('number', peer.banscore)
-        expectUndefinedOrEquals('number', peer.synced_headers)
-        expectUndefinedOrEquals('number', peer.synced_blocks)
-
-        expect(typeof peer.inflight).toStrictEqual('object')
-        expect(typeof peer.whitelisted).toStrictEqual('boolean')
-        expect(typeof peer.permissions).toStrictEqual('object')
-        expect(typeof peer.minfeefilter).toStrictEqual('number')
-
-        expectValidBytesPerMessage(peer.bytessent_per_msg)
-        expectValidBytesPerMessage(peer.bytesrecv_per_msg)
-      }
-    })
+    // addnode
+    await container[0].addNode(await container[1].getIp('test'))
   })
-}
 
-function expectUndefinedOrEquals (expected: any, actual?: any): void {
-  if (actual !== undefined) {
-    expect(typeof actual).toStrictEqual(expected)
-  }
-}
+  afterAll(async () => {
+    await container[0].stop()
+    await container[1].stop()
 
-function expectUndefinedOrValidAddress (address?: string): void {
-  if (address !== undefined) {
-    expectValidAddress(address)
-  }
-}
+    await container[0].removeNetwork(createdNetwork.Id)
+  })
 
-function expectValidAddress (address: string): void {
-  expect(typeof address).toStrictEqual('string')
-  expect(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$/.test(address)).toBeTruthy()
-}
+  it('should getPeerInfo', async () => {
+    const peers: PeerInfo[] = await client.net.getPeerInfo()
 
-function expectValidBytesPerMessage (obj: Record<string, number>): void {
-  for (const key in obj) {
-    expect(typeof obj[key]).toStrictEqual('number')
-  }
-}
+    expect(peers.length).toBeGreaterThan(0)
+
+    for (const peer of peers) {
+      expect(typeof peer.id).toStrictEqual('number')
+
+      expect(typeof peer.addr).toStrictEqual('string')
+      expect(addrRegExp.test(peer.addr)).toBeTruthy()
+
+      if (peer.addrbind !== undefined) {
+        expect(typeof peer.addrbind).toStrictEqual('string')
+        expect(addrRegExp.test(peer.addrbind)).toBeTruthy()
+      }
+
+      if (peer.addrlocal !== undefined) {
+        expect(typeof peer.addrlocal).toStrictEqual('string')
+        expect(addrRegExp.test(peer.addrlocal)).toBeTruthy()
+      }
+
+      expect(typeof peer.services).toStrictEqual('string')
+      expect(peer.services).toHaveLength(16)
+
+      expect(typeof peer.relaytxes).toStrictEqual('boolean')
+      expect(typeof peer.lastsend).toStrictEqual('number')
+      expect(typeof peer.lastrecv).toStrictEqual('number')
+      expect(typeof peer.bytessent).toStrictEqual('number')
+      expect(typeof peer.bytesrecv).toStrictEqual('number')
+      expect(typeof peer.conntime).toStrictEqual('number')
+      expect(typeof peer.timeoffset).toStrictEqual('number')
+
+      if (peer.pingtime !== undefined) {
+        expect(typeof peer.pingtime).toStrictEqual('number')
+      }
+
+      if (peer.minping !== undefined) {
+        expect(typeof peer.minping).toStrictEqual('number')
+      }
+
+      if (peer.pingwait !== undefined) {
+        expect(typeof peer.pingwait).toStrictEqual('number')
+      }
+
+      expect(typeof peer.version).toStrictEqual('number')
+      expect(typeof peer.subver).toStrictEqual('string')
+      expect(typeof peer.inbound).toStrictEqual('boolean')
+      expect(typeof peer.addnode).toStrictEqual('boolean')
+      expect(typeof peer.startingheight).toStrictEqual('number')
+
+      if (peer.banscore !== undefined) {
+        expect(typeof peer.banscore).toStrictEqual('number')
+      }
+
+      if (peer.synced_headers !== undefined) {
+        expect(typeof peer.synced_headers).toStrictEqual('number')
+      }
+
+      if (peer.synced_blocks !== undefined) {
+        expect(typeof peer.synced_blocks).toStrictEqual('number')
+      }
+
+      expect(typeof peer.inflight).toStrictEqual('object')
+      expect(typeof peer.whitelisted).toStrictEqual('boolean')
+      expect(typeof peer.permissions).toStrictEqual('object')
+      expect(typeof peer.minfeefilter).toStrictEqual('number')
+
+      for (const key in peer.bytessent_per_msg) {
+        expect(typeof peer.bytessent_per_msg[key]).toStrictEqual('number')
+      }
+
+      for (const key in peer.bytesrecv_per_msg) {
+        expect(typeof peer.bytesrecv_per_msg[key]).toStrictEqual('number')
+      }
+    }
+  })
+})
+
+describe('Network with masternode', () => {
+  const tgroup = TestingGroup.create(2)
+  const { rpc: { net } } = tgroup.get(0)
+
+  beforeAll(async () => {
+    await tgroup.start()
+  })
+
+  afterAll(async () => {
+    await tgroup.stop()
+  })
+
+  it('should getPeerInfo', async () => {
+    const peers: PeerInfo[] = await net.getPeerInfo()
+
+    expect(peers.length).toBeGreaterThan(0)
+
+    for (const peer of peers) {
+      expect(typeof peer.id).toStrictEqual('number')
+
+      expect(typeof peer.addr).toStrictEqual('string')
+      expect(addrRegExp.test(peer.addr)).toBeTruthy()
+
+      if (peer.addrbind !== undefined) {
+        expect(typeof peer.addrbind).toStrictEqual('string')
+        expect(addrRegExp.test(peer.addrbind)).toBeTruthy()
+      }
+
+      if (peer.addrlocal !== undefined) {
+        expect(typeof peer.addrlocal).toStrictEqual('string')
+        expect(addrRegExp.test(peer.addrlocal)).toBeTruthy()
+      }
+
+      expect(typeof peer.services).toStrictEqual('string')
+      expect(peer.services).toHaveLength(16)
+
+      expect(typeof peer.relaytxes).toStrictEqual('boolean')
+      expect(typeof peer.lastsend).toStrictEqual('number')
+      expect(typeof peer.lastrecv).toStrictEqual('number')
+      expect(typeof peer.bytessent).toStrictEqual('number')
+      expect(typeof peer.bytesrecv).toStrictEqual('number')
+      expect(typeof peer.conntime).toStrictEqual('number')
+      expect(typeof peer.timeoffset).toStrictEqual('number')
+
+      if (peer.pingtime !== undefined) {
+        expect(typeof peer.pingtime).toStrictEqual('number')
+      }
+
+      if (peer.minping !== undefined) {
+        expect(typeof peer.minping).toStrictEqual('number')
+      }
+
+      if (peer.pingwait !== undefined) {
+        expect(typeof peer.pingwait).toStrictEqual('number')
+      }
+
+      expect(typeof peer.version).toStrictEqual('number')
+      expect(typeof peer.subver).toStrictEqual('string')
+      expect(typeof peer.inbound).toStrictEqual('boolean')
+      expect(typeof peer.addnode).toStrictEqual('boolean')
+      expect(typeof peer.startingheight).toStrictEqual('number')
+
+      if (peer.banscore !== undefined) {
+        expect(typeof peer.banscore).toStrictEqual('number')
+      }
+
+      if (peer.synced_headers !== undefined) {
+        expect(typeof peer.synced_headers).toStrictEqual('number')
+      }
+
+      if (peer.synced_blocks !== undefined) {
+        expect(typeof peer.synced_blocks).toStrictEqual('number')
+      }
+
+      expect(typeof peer.inflight).toStrictEqual('object')
+      expect(typeof peer.whitelisted).toStrictEqual('boolean')
+      expect(typeof peer.permissions).toStrictEqual('object')
+      expect(typeof peer.minfeefilter).toStrictEqual('number')
+
+      for (const key in peer.bytessent_per_msg) {
+        expect(typeof peer.bytessent_per_msg[key]).toStrictEqual('number')
+      }
+
+      for (const key in peer.bytesrecv_per_msg) {
+        expect(typeof peer.bytesrecv_per_msg[key]).toStrictEqual('number')
+      }
+    }
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -1,8 +1,9 @@
 import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { PeerInfo } from 'packages/jellyfish-api-core/src/category/net'
 import { ContainerAdapterClient } from '../../container_adapter_client'
 
 createNetworkTests('Network without masternode', new RegTestContainer())
-createNetworkTests('Network with masternode', new MasterNodeRegTestContainer())
+createNetworkTests('Network on masternode', new MasterNodeRegTestContainer())
 
 function createNetworkTests (name: string, container: RegTestContainer | MasterNodeRegTestContainer): void {
   describe(name, () => {
@@ -17,11 +18,11 @@ function createNetworkTests (name: string, container: RegTestContainer | MasterN
       await container.stop()
     })
 
-    it('should return a list of peers', async () => {
-      await expect(client.net.getPeerInfo()).resolves.toHaveLength(2)
-    })
+    it('should getPeerInfo', async () => {
+      const peers: PeerInfo[] = await client.net.getPeerInfo()
 
-    it('should return valid schema', async () => {
+      expect(peers.length).toBeGreaterThan(0)
+
       for (const peer of await client.net.getPeerInfo()) {
         expect(typeof peer.id).toStrictEqual('number')
 

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -11,7 +11,7 @@ function createNetworkTests (name: string, container: RegTestContainer | MasterN
 
     beforeAll(async () => {
       await container.start()
-      await container.addNode('127.0.0.1')
+      await container.addNode(await container.getIp('bridge'))
     })
 
     afterAll(async () => {

--- a/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/getPeerInfo.test.ts
@@ -1,0 +1,74 @@
+import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+createNetworkTests('Network without masternode', new RegTestContainer())
+createNetworkTests('Network with masternode', new MasterNodeRegTestContainer())
+
+function createNetworkTests (name: string, container: RegTestContainer | MasterNodeRegTestContainer): void {
+  describe(name, () => {
+    const client = new ContainerAdapterClient(container)
+
+    beforeAll(async () => {
+      await container.start()
+      await container.addNode('127.0.0.1')
+    })
+
+    afterAll(async () => {
+      await container.stop()
+    })
+
+    it('should return a list of peers', async () => {
+      await expect(client.net.getPeerInfo()).resolves.toHaveLength(2)
+    })
+
+    it('should return expected schema', async () => {
+      for (const peer of await client.net.getPeerInfo()) {
+        expect(typeof peer.id).toStrictEqual('number')
+        expect(typeof peer.addr).toStrictEqual('string')
+        expect(typeof peer.addrbind).toStrictEqual('string')
+        expect(typeof peer.services).toStrictEqual('string')
+        expect(typeof peer.relaytxes).toStrictEqual('boolean')
+        expect(typeof peer.lastsend).toStrictEqual('number')
+        expect(typeof peer.lastrecv).toStrictEqual('number')
+        expect(typeof peer.conntime).toStrictEqual('number')
+        expect(typeof peer.timeoffset).toStrictEqual('number')
+        expect(typeof peer.version).toStrictEqual('number')
+        expect(typeof peer.subver).toStrictEqual('string')
+        expect(typeof peer.inbound).toStrictEqual('boolean')
+        expect(typeof peer.addnode).toStrictEqual('boolean')
+        expect(typeof peer.startingheight).toStrictEqual('number')
+        expect(typeof peer.banscore).toStrictEqual('number')
+        expect(typeof peer.synced_headers).toStrictEqual('number')
+        expect(typeof peer.synced_blocks).toStrictEqual('number')
+        expect(typeof peer.inflight).toStrictEqual('object')
+        expect(typeof peer.whitelisted).toStrictEqual('boolean')
+        expect(typeof peer.permissions).toStrictEqual('object')
+        expect(typeof peer.minfeefilter).toStrictEqual('number')
+        expect(typeof peer.bytessent_per_msg).toStrictEqual('object')
+        expect(typeof peer.bytesrecv_per_msg).toStrictEqual('object')
+      }
+    })
+
+    it('should return valid values', async () => {
+      for (const peer of await client.net.getPeerInfo()) {
+        expectValidAddress(peer.addr)
+        expectValidAddress(peer.addrbind)
+
+        expect(peer.services).toHaveLength(16)
+
+        expectValidBytesPerMessage(peer.bytessent_per_msg)
+        expectValidBytesPerMessage(peer.bytesrecv_per_msg)
+      }
+    })
+  })
+}
+
+function expectValidAddress (address: string): void {
+  return expect(/^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{1,5})?$/.test(address)).toBeTruthy()
+}
+
+function expectValidBytesPerMessage (obj: Record<string, number>): void {
+  for (const key in obj) {
+    expect(obj[key]).toBeGreaterThanOrEqual(0)
+  }
+}

--- a/packages/jellyfish-api-core/src/category/net.ts
+++ b/packages/jellyfish-api-core/src/category/net.ts
@@ -20,6 +20,15 @@ export class Net {
   }
 
   /**
+   * Returns data about each connected network node as a json array of objects.
+   *
+   * @return {Promise<PeerInfo[]>}
+   */
+  async getPeerInfo (): Promise<PeerInfo[]> {
+    return await this.client.call('getpeerinfo', [], 'number')
+  }
+
+  /**
    * Returns an object containing various state info regarding P2P networking.
    *
    * @return {Promise<NetworkInfo>}
@@ -27,6 +36,38 @@ export class Net {
   async getNetworkInfo (): Promise<NetworkInfo> {
     return await this.client.call('getnetworkinfo', [], 'number')
   }
+}
+
+export interface PeerInfo {
+  id: number
+  addr: string
+  addrbind: string
+  addrlocal: string
+  services: string
+  relaytxes: boolean
+  lastsend: number
+  lastrecv: number
+  bytessent: number
+  bytesrecv: number
+  conntime: number
+  timeoffset: number
+  pingtime: number
+  minping: number
+  pingwait: number
+  version: number
+  subver: string
+  inbound: boolean
+  addnode: boolean
+  startingheight: number
+  banscore: number
+  synced_headers: number
+  synced_blocks: number
+  inflight: number[]
+  whitelisted: boolean
+  permissions: string[]
+  minfeefilter: number
+  bytessent_per_msg: Record<string, number>
+  bytesrecv_per_msg: Record<string, number>
 }
 
 export interface NetworkInfo {

--- a/packages/jellyfish-api-core/src/category/net.ts
+++ b/packages/jellyfish-api-core/src/category/net.ts
@@ -41,8 +41,8 @@ export class Net {
 export interface PeerInfo {
   id: number
   addr: string
-  addrbind: string
-  addrlocal: string
+  addrbind?: string
+  addrlocal?: string
   services: string
   relaytxes: boolean
   lastsend: number
@@ -51,23 +51,27 @@ export interface PeerInfo {
   bytesrecv: number
   conntime: number
   timeoffset: number
-  pingtime: number
-  minping: number
-  pingwait: number
+  pingtime?: number
+  minping?: number
+  pingwait?: number
   version: number
   subver: string
   inbound: boolean
   addnode: boolean
   startingheight: number
-  banscore: number
-  synced_headers: number
-  synced_blocks: number
+  banscore?: number
+  synced_headers?: number
+  synced_blocks?: number
   inflight: number[]
   whitelisted: boolean
   permissions: string[]
   minfeefilter: number
-  bytessent_per_msg: Record<string, number>
-  bytesrecv_per_msg: Record<string, number>
+  bytessent_per_msg: {
+    [msg: string]: number
+  }
+  bytesrecv_per_msg: {
+    [msg: string]: number
+  }
 }
 
 export interface NetworkInfo {

--- a/packages/testcontainers/src/containers/DockerContainer.ts
+++ b/packages/testcontainers/src/containers/DockerContainer.ts
@@ -1,9 +1,8 @@
-import Dockerode, { Container, DockerOptions, Network } from 'dockerode'
+import Dockerode, { Container, DockerOptions } from 'dockerode'
 
 export abstract class DockerContainer {
   protected readonly docker: Dockerode
   protected container?: Container
-  protected dNetwork?: Network
 
   protected constructor (
     protected readonly image: string,


### PR DESCRIPTION
#### What this PR does / why we need it:

/kind feature

#### Which issue(s) does this PR fixes?:

Added getPeerInfo rpc as part of ongoing #48 
