### PR TITLE
feat(jellyfish-api-core): add network setNetworkActive RPC

### DIFF
--- a/docs/node/CATEGORIES/03-net.md
+++ b/docs/node/CATEGORIES/03-net.md
@@ -62,3 +62,13 @@ interface LocalAddress {
   score: number
 }
 ```
+
+## setNetworkActive
+
+Disable/enable all p2p network activity.
+
+```ts title="client.net.setNetworkActive()"
+interface net {
+  setNetworkActive (state: boolean): Promise<boolean>
+}
+```

--- a/packages/jellyfish-api-core/__tests__/category/net/setNetworkActive.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/setNetworkActive.test.ts
@@ -1,0 +1,64 @@
+import { Testing } from '@defichain/jellyfish-testing'
+import { MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+
+describe('Network on masternode', () => {
+  const testing = Testing.create(new MasterNodeRegTestContainer())
+  const container = testing.container
+  const client = testing.rpc
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should pass toggle network', async () => {
+    let info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(true)
+
+    let state: boolean = await client.net.setNetworkActive(false)
+    expect(state).toStrictEqual(false)
+
+    info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(false)
+
+    state = await client.net.setNetworkActive(true)
+    expect(state).toStrictEqual(true)
+
+    info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(true)
+  })
+})
+
+describe('Network without masternode', () => {
+  const container = new RegTestContainer()
+  const client = new ContainerAdapterClient(container)
+
+  beforeAll(async () => {
+    await container.start()
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should pass toggle network', async () => {
+    let info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(true)
+
+    let state: boolean = await client.net.setNetworkActive(false)
+    expect(state).toStrictEqual(false)
+
+    info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(false)
+
+    state = await client.net.setNetworkActive(true)
+    expect(state).toStrictEqual(true)
+
+    info = await client.net.getNetworkInfo()
+    expect(info.networkactive).toStrictEqual(true)
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/net/setNetworkActive.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/net/setNetworkActive.test.ts
@@ -4,31 +4,29 @@ import { ContainerAdapterClient } from '../../container_adapter_client'
 
 describe('Network on masternode', () => {
   const testing = Testing.create(new MasterNodeRegTestContainer())
-  const container = testing.container
-  const client = testing.rpc
 
   beforeAll(async () => {
-    await container.start()
+    await testing.container.start()
   })
 
   afterAll(async () => {
-    await container.stop()
+    await testing.container.stop()
   })
 
   it('should pass toggle network', async () => {
-    let info = await client.net.getNetworkInfo()
+    let info = await testing.rpc.net.getNetworkInfo()
     expect(info.networkactive).toStrictEqual(true)
 
-    let state: boolean = await client.net.setNetworkActive(false)
+    let state: boolean = await testing.rpc.net.setNetworkActive(false)
     expect(state).toStrictEqual(false)
 
-    info = await client.net.getNetworkInfo()
+    info = await testing.rpc.net.getNetworkInfo()
     expect(info.networkactive).toStrictEqual(false)
 
-    state = await client.net.setNetworkActive(true)
+    state = await testing.rpc.net.setNetworkActive(true)
     expect(state).toStrictEqual(true)
 
-    info = await client.net.getNetworkInfo()
+    info = await testing.rpc.net.getNetworkInfo()
     expect(info.networkactive).toStrictEqual(true)
   })
 })

--- a/packages/jellyfish-api-core/src/category/net.ts
+++ b/packages/jellyfish-api-core/src/category/net.ts
@@ -27,6 +27,16 @@ export class Net {
   async getNetworkInfo (): Promise<NetworkInfo> {
     return await this.client.call('getnetworkinfo', [], 'number')
   }
+
+  /**
+   * Disable/enable all p2p network activity.
+   *
+   * @param state true to enable networking, false to disable
+   * @return {Promise<boolean>} current network state
+   */
+  async setNetworkActive (state: boolean): Promise<boolean> {
+    return await this.client.call('setnetworkactive', [state], 'number')
+  }
 }
 
 export interface NetworkInfo {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Disable/enable all p2p network activity

#### Which issue(s) does this PR fixes?:
Added setNetworkActive rpc as part of ongoing #48
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
