### PR TITLE
docs(examples/ocean-dex-bot): DEX trading bot powered with Ocean API using whale-api-client and whale-api-wallet

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -249,6 +249,7 @@
       <w>unpkg</w>
       <w>updateloanscheme</w>
       <w>updateloantoken</w>
+      <w>usdt</w>
       <w>utxo</w>
       <w>utxos</w>
       <w>utxostoaccount</w>

--- a/examples/ocean-dex-bot/.gitignore
+++ b/examples/ocean-dex-bot/.gitignore
@@ -1,0 +1,20 @@
+# Yarn
+.yarn/*
+!.yarn/patches
+!.yarn/releases
+!.yarn/plugins
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+
+# Node Modules
+node_modules
+package-lock.json
+
+# dist & pack
+dist
+*.tgz
+.next
+tsconfig.build.tsbuildinfo
+
+

--- a/examples/ocean-dex-bot/README.md
+++ b/examples/ocean-dex-bot/README.md
@@ -1,0 +1,21 @@
+# Ocean DEX Trading Bot
+
+Ocean DEX trading bot, this is a very simple bot that takes all `dUSDT` and convert them into `dDOGE`.
+
+## Technical Design
+
+This Program assumes you always have enough UTXO. Only Account balances is used for trading. This bot just trades all
+dUSDT it has into dDOGE, no conditional logic is performed. You need to implement them yourself.
+
+## Deployment
+
+Deployable on AWS lambda, this bot is compiled with [vercel/ncc](https://github.com/vercel/ncc) which produce a single
+file that support TypeScript and binary addons (tiny-secp256k1). You are not required to deploy this on AWS lambda, it
+can simply be deployed as a NodeJS program.
+
+```shell
+npm i
+npm run build
+
+# Upload ./dist/main.zip into AWS Lambda
+```

--- a/examples/ocean-dex-bot/README.md
+++ b/examples/ocean-dex-bot/README.md
@@ -1,16 +1,16 @@
 # Ocean DEX Trading Bot
 
-Ocean DEX trading bot, this is a very simple bot that takes all `dUSDT` and convert them into `dDOGE`.
+Ocean DEX trading bot is a very simple bot that takes all `dUSDT` and converts them into `dDOGE`.
 
 ## Technical Design
 
-This Program assumes you always have enough UTXO. Only Account balances is used for trading. This bot just trades all
-dUSDT it has into dDOGE, no conditional logic is performed. You need to implement them yourself.
+This Program assumes you always have enough `UTXO`. Only Account balances are used for trading. This bot just trades all
+`dUSDT` it has into `dDOGE`, no conditional logic is performed. You need to implement them yourself.
 
 ## Deployment
 
-Deployable on AWS lambda, this bot is compiled with [vercel/ncc](https://github.com/vercel/ncc) which produce a single
-file that support TypeScript and binary addons (tiny-secp256k1). You are not required to deploy this on AWS lambda, it
+Deployable on AWS lambda, this bot is compiled with [vercel/ncc](https://github.com/vercel/ncc) which produces a single
+file that supports TypeScript and binary addons (tiny-secp256k1). You are not required to deploy this on AWS lambda, it
 can simply be deployed as a NodeJS program.
 
 ```shell

--- a/examples/ocean-dex-bot/package.json
+++ b/examples/ocean-dex-bot/package.json
@@ -1,0 +1,16 @@
+{
+  "private": true,
+  "scripts": {
+    "build": "npm run build:ncc && npm run build:zip",
+    "build:ncc": "ncc build ./src/main.ts --source-map -o ./dist/main",
+    "build:zip": "zip -r -j ./dist/main.zip ./dist/main/*"
+  },
+  "dependencies": {
+    "@defichain/jellyfish-wallet-classic": "latest",
+    "@defichain/whale-api-client": "latest",
+    "@defichain/whale-api-wallet": "latest"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "latest"
+  }
+}

--- a/examples/ocean-dex-bot/src/main.ts
+++ b/examples/ocean-dex-bot/src/main.ts
@@ -1,0 +1,101 @@
+import { WIF } from '@defichain/jellyfish-crypto'
+import { WalletClassic } from '@defichain/jellyfish-wallet-classic'
+import { WhaleApiClient } from '@defichain/whale-api-client'
+import { MainNet } from '@defichain/jellyfish-network'
+import { WhaleWalletAccount } from '@defichain/whale-api-wallet'
+import { CTransactionSegWit, TransactionSegWit } from '@defichain/jellyfish-transaction'
+import { BigNumber } from 'bignumber.js'
+import { AddressToken } from '@defichain/whale-api-client/dist/api/address'
+
+/**
+ * Initialize WhaleApiClient connected to ocean.defichain.com/v0
+ */
+const client = new WhaleApiClient({
+  url: 'https://ocean.defichain.com',
+  version: 'v0'
+})
+
+/**
+ * @param {string} privateKey you can `dumpprivkey [address]` with defi-cli, supports only Bech32 address (df1...)
+ */
+export async function main (privateKey: string | undefined = process.env.PRIVATE_KEY): Promise<void> {
+  if (privateKey === undefined) {
+    throw new Error('PrivateKey in WIF not provided')
+  }
+
+  const wallet = new WalletClassic(WIF.asEllipticPair(privateKey))
+  const program = new TradingProgram(wallet)
+  await program.run()
+}
+
+/**
+ * Single Address Wallet DEX Trading Program
+ *
+ * This Program assumes you always have enough UTXO.
+ * Only Account balances is used for trading.
+ *
+ * This bot just trades all dUSDT it has into dDOGE,
+ * no conditional logic is performed. You need to implement them yourself.
+ */
+export class TradingProgram {
+  constructor (
+    private readonly wallet: WalletClassic,
+    private readonly account = new WhaleWalletAccount(client, wallet, MainNet)
+  ) {
+  }
+
+  async run (): Promise<void> {
+    const usdt = await this.getAddressToken(0)
+    if (usdt === undefined) {
+      console.log('dUSDT balance is 0')
+      return
+    }
+
+    console.log(`Swap ${usdt.amount} dUSDT to dDOGE`)
+
+    const script = await this.account.getScript()
+    const txn = await this.account.withTransactionBuilder().dex.compositeSwap({
+      poolSwap: {
+        fromScript: script,
+        toScript: script,
+        // You can get tokenId here: https://ocean.defichain.com/v0/mainnet/tokens
+        fromTokenId: 0,
+        toTokenId: 2,
+        // Amount to swap from
+        fromAmount: new BigNumber(usdt.amount),
+        // Max price of the SWAP
+        maxPrice: new BigNumber('9223372036854775807')
+      },
+      pools: [
+        // Composite swap from dUSDT via (dUSDT-DFI) to (DFI-dDOGE) for dDOGE
+        { id: 6 }, // https://ocean.defichain.com/v0/mainnet/poolpairs/6
+        { id: 8 } // https://ocean.defichain.com/v0/mainnet/poolpairs/8
+      ]
+    }, script)
+
+    await TradingProgram.broadcast(txn)
+  }
+
+  /**
+   * Get token balance from wallet with minBalance
+   * @param {number} id of token to AddressToken
+   */
+  private async getAddressToken (id: number): Promise<AddressToken | undefined> {
+    const address = await this.account.getAddress()
+    const tokens = await client.address.listToken(address, 200)
+
+    return tokens.find(token => {
+      return token.id === `${id}`
+    })
+  }
+
+  /**
+   * @param {TransactionSegWit} txn to broadcast
+   */
+  private static async broadcast (txn: TransactionSegWit): Promise<void> {
+    const hex: string = new CTransactionSegWit(txn).toHex()
+    const txId: string = await client.rawtx.send({ hex: hex })
+
+    console.log(`Send TxId: ${txId}`)
+  }
+}

--- a/examples/ocean-dex-bot/tsconfig.json
+++ b/examples/ocean-dex-bot/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "es2020"
+    ],
+    "target": "esnext",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
#### What this PR does / why we need it:

Ocean DEX trading bot is a very simple bot that takes all `dUSDT` and converts them into `dDOGE`.

**Technical Design**

This Program assumes you always have enough `UTXO`. Only Account balances are used for trading. This bot just trades all `dUSDT` it has into `dDOGE`, no conditional logic is performed. You need to implement them yourself.

**Deployment**

Deployable on AWS lambda, this bot is compiled with [vercel/ncc](https://github.com/vercel/ncc) which produces a single file that supports TypeScript and binary addons (tiny-secp256k1). You are not required to deploy this on AWS lambda, it can simply be deployed as a NodeJS program.

```shell
npm i
npm run build

# Upload ./dist/main.zip into AWS Lambda
```
