### PR TITLE
chore(apps/ocean-api): should be private as it should not be published into npm

### DIFF
--- a/apps/ocean-api/package.json
+++ b/apps/ocean-api/package.json
@@ -1,5 +1,5 @@
 {
-  "private": false,
+  "private": true,
   "name": "@defichain-apps/ocean-api",
   "version": "0.0.0",
   "description": "DeFiChain Jellyfish Ecosystem",


### PR DESCRIPTION
#### What this PR does / why we need it:

Set `apps/ocean-api/package.json` `private: true`.