### PR TITLE
chore(jellyfish-api-jsonrpc): properly parse 422 error for JsonRpcClient

### DIFF
--- a/packages/jellyfish-api-jsonrpc/src/index.ts
+++ b/packages/jellyfish-api-jsonrpc/src/index.ts
@@ -61,6 +61,7 @@ export class JsonRpcClient extends ApiClient {
       case 401:
       case 403:
       case 404:
+      case 422:
         throw new ClientApiError(`${response.status} - ${response.statusText}`)
 
       case 200:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Add 422 status code to be parsed under ApiClientError.