### PR TITLE
chore(ocean-api): Updated ocean-related testing framework

### DIFF
--- a/apps/ocean-api/package.json
+++ b/apps/ocean-api/package.json
@@ -7,10 +7,6 @@
   "bugs": "https://github.com/DeFiCh/jellyfish/issues",
   "license": "MIT",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "build": "tsc -b tsconfig.build.json"
   },
@@ -28,7 +24,7 @@
     "cache-manager": "^3.6.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
-    "joi": "^17.5.0"
+    "joi": "^17.6.0"
   },
   "devDependencies": {
     "@defichain/ocean-api-client": "0.0.0",

--- a/apps/ocean-api/testing/OceanApiTesting.ts
+++ b/apps/ocean-api/testing/OceanApiTesting.ts
@@ -1,7 +1,7 @@
 import { Testing, TestingGroup } from '@defichain/jellyfish-testing'
 import { OceanApiClient } from '@defichain/ocean-api-client'
-import { StubServer } from './StubServer'
-import { StubClient } from './StubClient'
+import { OceanStubServer } from './OceanStubServer'
+import { OceanStubClient } from './OceanStubClient'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { ApiClient } from '@defichain/jellyfish-api-core'
 import { NestFastifyApplication } from '@nestjs/platform-fastify'
@@ -12,8 +12,8 @@ import { NestFastifyApplication } from '@nestjs/platform-fastify'
 export class OceanApiTesting {
   constructor (
     private readonly testingGroup: TestingGroup,
-    private readonly stubServer: StubServer = new StubServer(testingGroup.get(0).container),
-    private readonly stubApiClient: StubClient = new StubClient((stubServer))
+    private readonly stubServer: OceanStubServer = new OceanStubServer(testingGroup.get(0).container),
+    private readonly stubApiClient: OceanStubClient = new OceanStubClient((stubServer))
   ) {
   }
 
@@ -61,7 +61,7 @@ export class OceanApiTesting {
    *
    * @see TestingGroup
    * @see Testing
-   * @see StubServer
+   * @see OceanStubServer
    */
   async start (): Promise<void> {
     await this.group.start()
@@ -73,7 +73,7 @@ export class OceanApiTesting {
    *
    * @see TestingGroup
    * @see Testing
-   * @see StubServer
+   * @see OceanStubServer
    */
   async stop (): Promise<void> {
     try {

--- a/apps/ocean-api/testing/OceanStubClient.ts
+++ b/apps/ocean-api/testing/OceanStubClient.ts
@@ -1,13 +1,13 @@
 import { ApiMethod, OceanApiClient, ResponseAsString } from '@defichain/ocean-api-client'
-import { StubServer } from './StubServer'
+import { OceanStubServer } from './OceanStubServer'
 import { ConfigService } from '@nestjs/config'
 
 /**
  * Client stubs are simulations of a real client, which are used for functional testing.
  * StubClient simulate a real OceanApiClient connected to an Ocean API.
  */
-export class StubClient extends OceanApiClient {
-  constructor (readonly service: StubServer) {
+export class OceanStubClient extends OceanApiClient {
+  constructor (readonly service: OceanStubServer) {
     super({ url: 'not required for stub service' })
   }
 

--- a/apps/ocean-api/testing/OceanStubServer.ts
+++ b/apps/ocean-api/testing/OceanStubServer.ts
@@ -9,7 +9,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config'
  * Service stubs are simulations of a real service, which are used for functional testing.
  * Configures a TestingModule that is configured to connect to a provided @defichain/testcontainers.
  */
-export class StubServer extends RootServer {
+export class OceanStubServer extends RootServer {
   /**
    * @see PlaygroundModule
    */

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   testRegex: '((\\.|/)(e2e|test|spec))\\.[jt]sx?$',
   testSequencer: require.resolve('./jest.sequencer'),
   moduleNameMapper: {
-    '@defichain/(.*)': '<rootDir>/packages/$1/src'
+    '@defichain/(?!whale-api-client)(.*)': '<rootDir>/packages/$1/src'
   },
   verbose: true,
   clearMocks: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- fix jest.config.js not to resolve for @defichain/whale-api-client
- rename ocean-related in ocean-api/testing/* to Ocean... to differentiate project resources

#### Additional comments?:
Ref: https://github.com/DeFiCh/jellyfish/pull/1020
