### PR TITLE
feat(jellyfish-testing): created testingwrapper as an abstraction layer

### DIFF
--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -1,0 +1,110 @@
+import { Testing } from '@defichain/jellyfish-testing'
+import { MainNetContainer, RegTestContainer, TestNetContainer } from '@defichain/testcontainers'
+import { TestingWrapper } from '../src/testingwrapper'
+
+const testingWrapper = new TestingWrapper()
+describe('create a single test container using testwrapper', () => {
+  let testing: Testing
+
+  afterEach(async () => {
+    await testing.container.stop()
+  })
+
+  it('should be able to create and call single regtest masternoderegtest container', async () => {
+    testing = testingWrapper.create()
+    await testing.container.start()
+
+    // call rpc
+    let blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+    await testing.generate(1)
+    blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(1)
+  })
+
+  it('should be able to create regtest non masternode container', async () => {
+    testing = testingWrapper.create(1, index => new RegTestContainer()) as Testing
+    await testing.container.start()
+
+    // call rpc
+    const blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    const addr = await testing.generateAddress()
+    const promise = testing.container.call('generatetoaddress', [1, addr, 1])
+
+    await expect(promise).rejects.toThrow('Error: I am not masternode operator')
+  })
+
+  it('should be able to create mainnet container', async () => {
+    testing = testingWrapper.create(1, index => new MainNetContainer()) as Testing
+    await testing.container.start()
+    // call rpc
+    const { chain } = await testing.container.getMiningInfo()
+    expect(chain).toStrictEqual('main')
+  })
+
+  it('should be able to create testnet container', async () => {
+    testing = testingWrapper.create(1, index => new TestNetContainer()) as Testing
+    await testing.container.start()
+    // call rpc
+    const { chain } = await testing.container.getMiningInfo()
+    expect(chain).toStrictEqual('test')
+  })
+
+  // test override using startoption
+})
+
+describe('create multiple test container using testwrapper', () => {
+  it('should create a masternode group and test sync block and able to add and sync non masternode container', async () => {
+    const tGroup = testingWrapper.create(2)
+    await tGroup.start()
+
+    const alice = tGroup.get(0)
+    let blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    const bob = tGroup.get(1)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    await alice.generate(10)
+    await tGroup.waitForSync()
+
+    blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(10)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(10)
+
+    let blockHashAlice = await alice.rpc.blockchain.getBestBlockHash()
+    let blockHashBob = await alice.rpc.blockchain.getBestBlockHash()
+    expect(blockHashAlice).toStrictEqual(blockHashBob)
+
+    await bob.generate(10)
+    await tGroup.waitForSync()
+
+    blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+
+    blockHashAlice = await alice.rpc.blockchain.getBestBlockHash()
+    blockHashBob = await alice.rpc.blockchain.getBestBlockHash()
+    expect(blockHashAlice).toStrictEqual(blockHashBob)
+
+    // create a non masternode RegTestTesting
+    const nonMasternodeTesting = testingWrapper.create(1, index => new RegTestContainer()) as Testing
+    await nonMasternodeTesting.container.start()
+
+    // add to group
+    await tGroup.addTesting(nonMasternodeTesting)
+    await tGroup.waitForSync()
+    blockHeight = await nonMasternodeTesting.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+    const blockHashNonMasternode = await nonMasternodeTesting.rpc.blockchain.getBestBlockHash()
+    expect(blockHashNonMasternode).toStrictEqual(blockHashAlice)
+
+    await tGroup.stop()
+  })
+  // create individual container of masternode and regtest and create a group from it
+})

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -1,5 +1,5 @@
 import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
-import { DeFiDContainer, MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerGroup, DeFiDContainer, MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing, TestingGroup } from '.'
 
 export class TestingWrapper {
@@ -17,5 +17,12 @@ export class TestingWrapper {
     }
 
     return TestingGroup.create(n, init)
+  }
+
+  group (): TestingGroup {
+    const containers: MasterNodeRegTestContainer[] = []
+    const group = new ContainerGroup(containers)
+    const testings: Testing[] = []
+    return new TestingGroup(group, testings)
   }
 }

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -1,0 +1,21 @@
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
+import { DeFiDContainer, MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { Testing, TestingGroup } from '.'
+
+export class TestingWrapper {
+  create (): Testing
+  create (n: number): TestingGroup
+  create (n: number, init: (index: number) => DeFiDContainer): Testing | TestingGroup
+
+  create (n?: number, init?: (index: number) => DeFiDContainer): Testing | TestingGroup {
+    if (init === undefined) {
+      init = (index: number) => new MasterNodeRegTestContainer(RegTestFoundationKeys[index])
+    }
+
+    if (n === undefined || n <= 1) {
+      return Testing.createBase(init(0))
+    }
+
+    return TestingGroup.create(n, init)
+  }
+}

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -27,7 +27,7 @@ export interface StartFlags {
 /**
  * DeFiChain defid node managed in docker
  */
-export abstract class DeFiDContainer extends DockerContainer {
+export class DeFiDContainer extends DockerContainer {
   /* eslint-disable @typescript-eslint/no-non-null-assertion, no-void */
   public static readonly PREFIX = 'defichain-testcontainers-'
 
@@ -51,7 +51,7 @@ export abstract class DeFiDContainer extends DockerContainer {
    * @param {string} image docker image name
    * @param {DockerOptions} options
    */
-  protected constructor (
+  constructor (
     protected readonly network: Network,
     protected readonly image: string = DeFiDContainer.image,
     options?: DockerOptions
@@ -118,7 +118,9 @@ export abstract class DeFiDContainer extends DockerContainer {
   /**
    * Get host machine port used for defid rpc
    */
-  public abstract getRpcPort (): Promise<string>
+  async getRpcPort (): Promise<string> {
+    return await this.getPort('8554/tcp')
+  }
 
   /**
    * Get host machine url used for defid rpc calls with auth


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
create a new layer of abstraction with the goal of being able to create a test /testGroup instance in a standardised manner.
creating a new layer seems to introduce the least amount of changes to existing use cases

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #637

#### Additional comments?:
Using the wrapper class
- should be able to create a single testing instance regardless of container
- should be able to create a new group and add new testing instance