### PR TITLE
bump(testcontainers): DeFiDContainer defi/defichain to v2.6.1

### DIFF
--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:2.6.0'
+    return 'defi/defichain:2.6.1'
   }
 
   public static readonly DefaultStartOptions = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Bump `defi/defichain` to the latest release.
