### PR TITLE
feat(jellyfish-network): BlockSubsidy calculations

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -20,6 +20,7 @@
       <w>bestblock</w>
       <w>bestblockhash</w>
       <w>blockhash</w>
+      <w>blockreward</w>
       <w>blocktime</w>
       <w>booland</w>
       <w>boolor</w>
@@ -53,12 +54,14 @@
       <w>defich</w>
       <w>defichain</w>
       <w>defid</w>
+      <w>defiscan</w>
       <w>deposittovault</w>
       <w>descendantcount</w>
       <w>descendantfees</w>
       <w>descendantsize</w>
       <w>destroyloanscheme</w>
       <w>devnet</w>
+      <w>dfip</w>
       <w>dftx</w>
       <w>dockerode</w>
       <w>dogfooding</w>
@@ -66,6 +69,7 @@
       <w>dumpprivkey</w>
       <w>emissionburn</w>
       <w>equalverify</w>
+      <w>eunos</w>
       <w>eunospayaheight</w>
       <w>feeburn</w>
       <w>fiveyeartimelock</w>

--- a/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
+++ b/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
@@ -1,0 +1,391 @@
+import {
+  BlockSubsidy,
+  CoinbaseSubsidyOptions,
+  MainNetCoinbaseSubsidyOptions,
+  TestNetCoinbaseSubsidyOptions
+} from '../src/BlockSubsidy'
+import BigNumber from 'bignumber.js'
+import { getBlockRewardDistribution } from '../src/BlockRewardDistribution'
+
+function getReductionHeight (count: number, options: CoinbaseSubsidyOptions): number {
+  return options.eunosHeight + count * options.emissionReductionInterval
+}
+
+describe('blockreward_dfip8_reductions', () => {
+  // Test vector taken from https://github.com/DeFiCh/ain/blob/fabc60699afd4e92c73db23a4c366de76c575fab/src/test/dip1fork_tests.cpp#L147-L233
+
+  const blockSubsidy = new BlockSubsidy()
+
+  it('should get coinbase rewards for reduction 0', () => {
+    const height = getReductionHeight(0, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(40504000000))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 13499983200,
+      community: 1988746400,
+      anchor: 8100800,
+      liquidity: 10308268000,
+      loan: 9996387200,
+      options: 4001795200,
+      unallocated: 700719200
+    })
+  })
+
+  it('should get coinbase rewards for reduction 1', () => {
+    const height = getReductionHeight(1, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(39832443680))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 13276153478,
+      community: 1955772984,
+      anchor: 7966488,
+      liquidity: 10137356916,
+      loan: 9830647100,
+      options: 3935445435,
+      unallocated: 689101275
+    })
+  })
+
+  it('should get coinbase rewards for reduction 100', () => {
+    const height = getReductionHeight(100, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(7610296073))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 2536511681,
+      community: 373665537,
+      anchor: 1522059,
+      liquidity: 1936820350,
+      loan: 1878221070,
+      options: 751897252,
+      unallocated: 131658122
+    })
+  })
+
+  it('should get coinbase rewards for reduction 1000', () => {
+    const height = getReductionHeight(1000, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(2250))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 749,
+      community: 110,
+      anchor: 0,
+      liquidity: 572,
+      loan: 555,
+      options: 222,
+      unallocated: 38
+    })
+  })
+
+  it('should get coinbase rewards for reduction 1251', () => {
+    const height = getReductionHeight(1251, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(60))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 19,
+      community: 2,
+      anchor: 0,
+      liquidity: 15,
+      loan: 14,
+      options: 5,
+      unallocated: 1
+    })
+  })
+
+  it('should get coinbase rewards for reduction 1252', () => {
+    const height = getReductionHeight(1252, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(0))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 0,
+      community: 0,
+      anchor: 0,
+      liquidity: 0,
+      loan: 0,
+      options: 0,
+      unallocated: 0
+    })
+  })
+
+  it('should get coinbase rewards for reduction 1253 (not included in cpp)', () => {
+    const height = getReductionHeight(1253, MainNetCoinbaseSubsidyOptions)
+    const subsidy = blockSubsidy.getBlockSubsidy(height)
+
+    expect(subsidy).toStrictEqual(new BigNumber(0))
+
+    expect(getBlockRewardDistribution(subsidy)).toStrictEqual({
+      masternode: 0,
+      community: 0,
+      anchor: 0,
+      liquidity: 0,
+      loan: 0,
+      options: 0,
+      unallocated: 0
+    })
+  })
+})
+
+describe('validation', () => {
+  const blockSubsidy = new BlockSubsidy()
+
+  it('should not fail if height=1.0 is valid', () => {
+    blockSubsidy.getBlockSubsidy(1.0)
+  })
+
+  it('should not fail if height=1234567 is valid', () => {
+    blockSubsidy.getBlockSubsidy(1234567)
+  })
+
+  it('should fail if height is a negative number', () => {
+    expect(() => {
+      blockSubsidy.getBlockSubsidy(-1)
+    }).toThrowError('height must be a positive whole number')
+  })
+
+  it('should fail if height is a floating point number', () => {
+    expect(() => {
+      blockSubsidy.getBlockSubsidy(1.1)
+    }).toThrowError('height must be a positive whole number')
+  })
+
+  it('should fail if height is a negative floating point number', () => {
+    expect(() => {
+      blockSubsidy.getBlockSubsidy(-123.4)
+    }).toThrowError('height must be a positive whole number')
+  })
+})
+
+describe('MainNet.getBlockSubsidy', () => {
+  const blockSubsidy = new BlockSubsidy()
+
+  it('should get block subsidy for genesis', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(0)
+    expect(subsidy).toStrictEqual(new BigNumber(59100003000000000))
+  })
+
+  it('should get block subsidy for height=1', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(1)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=100000', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(100000)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=356000', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(356000)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=356500', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(356500)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=893999', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(893999)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=894000 (0th reduction)', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(894000)
+    expect(subsidy).toStrictEqual(new BigNumber(40504000000))
+  })
+
+  it('should get block subsidy for height=926689 (0th reduction)', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(926689)
+    expect(subsidy).toStrictEqual(new BigNumber(40504000000))
+  })
+
+  it('should get block subsidy for height=926690 (1st reduction)', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(926690)
+    expect(subsidy).toStrictEqual(new BigNumber(39832443680))
+  })
+
+  it('should get block subsidy for height=959379 (1nd reduction)', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(959379)
+    expect(subsidy).toStrictEqual(new BigNumber(39832443680))
+  })
+
+  it('should get block subsidy for height=959380 (2nd reduction)', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(959380)
+    expect(subsidy).toStrictEqual(new BigNumber(39172021764))
+  })
+
+  it('should get block subsidy for height=33584000', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(33584000)
+    expect(subsidy).toStrictEqual(new BigNumber(2250))
+  })
+
+  it('should get block subsidy for height=33584001', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(33584001)
+    expect(subsidy).toStrictEqual(new BigNumber(2250))
+  })
+
+  it('should get block subsidy for height=41789190', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(41789190)
+    expect(subsidy).toStrictEqual(new BigNumber(60))
+  })
+
+  it('should get block subsidy for height=41789191', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(41789191)
+    expect(subsidy).toStrictEqual(new BigNumber(60))
+  })
+
+  it('should get block subsidy for height=41821879', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(41821879)
+    expect(subsidy).toStrictEqual(new BigNumber(60))
+  })
+
+  it('should get block subsidy for height=41821880', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(41821880)
+    expect(subsidy).toStrictEqual(new BigNumber(0))
+  })
+
+  it('should get block subsidy for height=1,000,000,000', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(1000000000)
+    expect(subsidy).toStrictEqual(new BigNumber(0))
+  })
+})
+
+describe('TestNet.getBlockSubsidy', () => {
+  const blockSubsidy = new BlockSubsidy(TestNetCoinbaseSubsidyOptions)
+
+  it('should get block subsidy for genesis', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(0)
+    expect(subsidy).toStrictEqual(new BigNumber(30400004000000000))
+  })
+
+  it('should get block subsidy for height=1', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(1)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=354949', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(354949)
+    expect(subsidy).toStrictEqual(new BigNumber(20000000000))
+  })
+
+  it('should get block subsidy for height=354950', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(354950)
+    expect(subsidy).toStrictEqual(new BigNumber(40504000000))
+  })
+
+  it('should get block subsidy for height=387639', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(387639)
+    expect(subsidy).toStrictEqual(new BigNumber(40504000000))
+  })
+
+  it('should get block subsidy for height=387640', () => {
+    const subsidy = blockSubsidy.getBlockSubsidy(387640)
+    expect(subsidy).toStrictEqual(new BigNumber(39832443680))
+  })
+})
+
+describe('MainNet.getSupply', () => {
+  const blockSubsidy = new BlockSubsidy()
+
+  it('should get supply for genesis', () => {
+    const supply = blockSubsidy.getSupply(0)
+    expect(supply).toStrictEqual(new BigNumber('59100003000000000'))
+  })
+
+  it('should get supply for height=1', () => {
+    const supply = blockSubsidy.getSupply(1)
+    expect(supply).toStrictEqual(new BigNumber('59100023000000000'))
+  })
+
+  it('should get supply for height=2', () => {
+    const supply = blockSubsidy.getSupply(2)
+    expect(supply).toStrictEqual(new BigNumber('59100043000000000'))
+  })
+
+  it('should get supply for height=100000', () => {
+    const supply = blockSubsidy.getSupply(100000)
+    // 100000 * 200 = 2000000000000000
+    expect(supply).toStrictEqual(new BigNumber('61100003000000000'))
+  })
+
+  it('should get supply for height=356500', () => {
+    const supply = blockSubsidy.getSupply(356500)
+    // 356500 * 200 = 7130000000000000
+    expect(supply).toStrictEqual(new BigNumber('66230003000000000'))
+  })
+
+  it('should get supply for height=893999', () => {
+    const supply = blockSubsidy.getSupply(893999)
+    // 893999 * 200 = 17879980000000000
+    // 59100003000000000 + 17879980000000000 = 7.6979983E16
+    expect(supply).toStrictEqual(new BigNumber('76979983000000000'))
+  })
+
+  it('should get supply for height=894000', () => {
+    const supply = blockSubsidy.getSupply(894000)
+    // 893999 * 20000000000 = 17879980000000000
+    //      1 * 40504000000 = 40504000000
+    expect(supply).toStrictEqual(new BigNumber('76980023504000000'))
+  })
+
+  it('should get supply for height=926689', () => {
+    const supply = blockSubsidy.getSupply(926689)
+    // 893999 * 20000000000 = 59100003000000000
+    // 893999 * 20000000000 = 17879980000000000
+    //  32690 * 40504000000 =  1324075760000000
+    expect(supply).toStrictEqual(new BigNumber('78304058760000000'))
+  })
+
+  it('should get supply for height=926690', () => {
+    const supply = blockSubsidy.getSupply(926690)
+    // 893999 * 20000000000 = 59100003000000000
+    // 893999 * 20000000000 = 17879980000000000
+    //  32690 * 40504000000 =  1324075760000000
+    //      1 * 39832443680 =       39832443680
+    expect(supply).toStrictEqual(new BigNumber('78304098592443680'))
+  })
+
+  it('should get supply for height=959379', () => {
+    const supply = blockSubsidy.getSupply(959379)
+    // 893999 * 20000000000 = 59100003000000000
+    // 893999 * 20000000000 = 17879980000000000
+    //  32690 * 40504000000 =  1324075760000000
+    //  32690 * 39832443680 =  1302122583899200
+    expect(supply).toStrictEqual(new BigNumber('79606181343899200'))
+  })
+
+  it('should get supply for height=959380', () => {
+    const supply = blockSubsidy.getSupply(959380)
+    // 893999 * 20000000000 = 59100003000000000
+    // 893999 * 20000000000 = 17879980000000000
+    //  32690 * 40504000000 =  1324075760000000
+    //  32690 * 39832443680 =  1302122583899200
+    //      1 * 39172021764 =       39172021764
+    expect(supply).toStrictEqual(new BigNumber('79606220515920964'))
+  })
+
+  it('should get supply for height=41821879', () => {
+    const supply = blockSubsidy.getSupply(41821879)
+    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+  })
+
+  it('should get supply for height=41821880', () => {
+    const supply = blockSubsidy.getSupply(41821880)
+    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+  })
+
+  it('should get supply for height=1000000000', () => {
+    const supply = blockSubsidy.getSupply(1000000000)
+    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+  })
+})

--- a/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
+++ b/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
@@ -344,7 +344,7 @@ describe('MainNet.getSupply', () => {
     //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //      1 * 40504000000 = 40504000000
-    expect(supply).toStrictEqual(new BigNumber('49680023504000000'))
+    expect(supply).toStrictEqual(new BigNumber('50120734196170954'))
   })
 
   it('should get supply for height=926689', () => {
@@ -352,7 +352,7 @@ describe('MainNet.getSupply', () => {
     //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
-    expect(supply).toStrictEqual(new BigNumber('51004058760000000'))
+    expect(supply).toStrictEqual(new BigNumber('51444769452170954'))
   })
 
   it('should get supply for height=926690', () => {
@@ -361,7 +361,7 @@ describe('MainNet.getSupply', () => {
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //      1 * 39832443680 =       39832443680
-    expect(supply).toStrictEqual(new BigNumber('51004098592443680'))
+    expect(supply).toStrictEqual(new BigNumber('51444809284614634'))
   })
 
   it('should get supply for height=959379', () => {
@@ -370,7 +370,7 @@ describe('MainNet.getSupply', () => {
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200
-    expect(supply).toStrictEqual(new BigNumber('52306181343899200'))
+    expect(supply).toStrictEqual(new BigNumber('52746892036070154'))
   })
 
   it('should get supply for height=959380', () => {
@@ -380,21 +380,21 @@ describe('MainNet.getSupply', () => {
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200
     //      1 * 39172021764 =       39172021764
-    expect(supply).toStrictEqual(new BigNumber('52306220515920964'))
+    expect(supply).toStrictEqual(new BigNumber('52746931208091918'))
   })
 
   it('should get supply for height=41821879', () => {
     const supply = blockSubsidy.getSupply(41821879)
-    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129980511465002554'))
   })
 
   it('should get supply for height=41821880', () => {
     const supply = blockSubsidy.getSupply(41821880)
-    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129980511465002554'))
   })
 
   it('should get supply for height=1000000000', () => {
     const supply = blockSubsidy.getSupply(1000000000)
-    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129980511465002554'))
   })
 })

--- a/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
+++ b/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
@@ -341,60 +341,60 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for height=894000', () => {
     const supply = blockSubsidy.getSupply(894000)
-    //              Genesis = 59100003000000000 - Foundation Burn
+    //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //      1 * 40504000000 = 40504000000
-    expect(supply).toStrictEqual(new BigNumber('76980023504000000'))
+    expect(supply).toStrictEqual(new BigNumber('49680023504000000'))
   })
 
   it('should get supply for height=926689', () => {
     const supply = blockSubsidy.getSupply(926689)
-    //              Genesis = 59100003000000000 - Foundation Burn
+    //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
-    expect(supply).toStrictEqual(new BigNumber('78304058760000000'))
+    expect(supply).toStrictEqual(new BigNumber('51004058760000000'))
   })
 
   it('should get supply for height=926690', () => {
     const supply = blockSubsidy.getSupply(926690)
-    //              Genesis = 59100003000000000 - Foundation Burn
+    //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //      1 * 39832443680 =       39832443680
-    expect(supply).toStrictEqual(new BigNumber('78304098592443680'))
+    expect(supply).toStrictEqual(new BigNumber('51004098592443680'))
   })
 
   it('should get supply for height=959379', () => {
     const supply = blockSubsidy.getSupply(959379)
-    //              Genesis = 59100003000000000 - Foundation Burn
+    //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200
-    expect(supply).toStrictEqual(new BigNumber('79606181343899200'))
+    expect(supply).toStrictEqual(new BigNumber('52306181343899200'))
   })
 
   it('should get supply for height=959380', () => {
     const supply = blockSubsidy.getSupply(959380)
-    //              Genesis = 59100003000000000 - Foundation Burn
+    //              Genesis = 59100003000000000 - Foundation Burn (273m)
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200
     //      1 * 39172021764 =       39172021764
-    expect(supply).toStrictEqual(new BigNumber('79606220515920964'))
+    expect(supply).toStrictEqual(new BigNumber('52306220515920964'))
   })
 
   it('should get supply for height=41821879', () => {
     const supply = blockSubsidy.getSupply(41821879)
-    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
   })
 
   it('should get supply for height=41821880', () => {
     const supply = blockSubsidy.getSupply(41821880)
-    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
   })
 
   it('should get supply for height=1000000000', () => {
     const supply = blockSubsidy.getSupply(1000000000)
-    expect(supply).toStrictEqual(new BigNumber('156839800772831600'))
+    expect(supply).toStrictEqual(new BigNumber('129539800772831600'))
   })
 })

--- a/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
+++ b/packages/jellyfish-network/__tests__/BockSubsidy.test.ts
@@ -299,40 +299,49 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for genesis', () => {
     const supply = blockSubsidy.getSupply(0)
+    //              Genesis = 59100003000000000
     expect(supply).toStrictEqual(new BigNumber('59100003000000000'))
   })
 
   it('should get supply for height=1', () => {
     const supply = blockSubsidy.getSupply(1)
+    //              Genesis = 59100003000000000
+    //      1 * 20000000000 = 00000020000000000
     expect(supply).toStrictEqual(new BigNumber('59100023000000000'))
   })
 
   it('should get supply for height=2', () => {
     const supply = blockSubsidy.getSupply(2)
+    //              Genesis = 59100003000000000
+    //      2 * 20000000000 = 00000040000000000
     expect(supply).toStrictEqual(new BigNumber('59100043000000000'))
   })
 
   it('should get supply for height=100000', () => {
     const supply = blockSubsidy.getSupply(100000)
-    // 100000 * 200 = 2000000000000000
+    //              Genesis = 59100003000000000
+    // 100000 * 20000000000 = 02000000000000000
     expect(supply).toStrictEqual(new BigNumber('61100003000000000'))
   })
 
   it('should get supply for height=356500', () => {
     const supply = blockSubsidy.getSupply(356500)
-    // 356500 * 200 = 7130000000000000
+    //              Genesis = 59100003000000000
+    // 356500 * 20000000000 = 07130000000000000
     expect(supply).toStrictEqual(new BigNumber('66230003000000000'))
   })
 
   it('should get supply for height=893999', () => {
     const supply = blockSubsidy.getSupply(893999)
-    // 893999 * 200 = 17879980000000000
+    //              Genesis = 59100003000000000
+    // 893999 * 20000000000 = 17879980000000000
     // 59100003000000000 + 17879980000000000 = 7.6979983E16
     expect(supply).toStrictEqual(new BigNumber('76979983000000000'))
   })
 
   it('should get supply for height=894000', () => {
     const supply = blockSubsidy.getSupply(894000)
+    //              Genesis = 59100003000000000 - Foundation Burn
     // 893999 * 20000000000 = 17879980000000000
     //      1 * 40504000000 = 40504000000
     expect(supply).toStrictEqual(new BigNumber('76980023504000000'))
@@ -340,7 +349,7 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for height=926689', () => {
     const supply = blockSubsidy.getSupply(926689)
-    // 893999 * 20000000000 = 59100003000000000
+    //              Genesis = 59100003000000000 - Foundation Burn
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     expect(supply).toStrictEqual(new BigNumber('78304058760000000'))
@@ -348,7 +357,7 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for height=926690', () => {
     const supply = blockSubsidy.getSupply(926690)
-    // 893999 * 20000000000 = 59100003000000000
+    //              Genesis = 59100003000000000 - Foundation Burn
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //      1 * 39832443680 =       39832443680
@@ -357,7 +366,7 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for height=959379', () => {
     const supply = blockSubsidy.getSupply(959379)
-    // 893999 * 20000000000 = 59100003000000000
+    //              Genesis = 59100003000000000 - Foundation Burn
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200
@@ -366,7 +375,7 @@ describe('MainNet.getSupply', () => {
 
   it('should get supply for height=959380', () => {
     const supply = blockSubsidy.getSupply(959380)
-    // 893999 * 20000000000 = 59100003000000000
+    //              Genesis = 59100003000000000 - Foundation Burn
     // 893999 * 20000000000 = 17879980000000000
     //  32690 * 40504000000 =  1324075760000000
     //  32690 * 39832443680 =  1302122583899200

--- a/packages/jellyfish-network/src/BlockRewardDistribution.ts
+++ b/packages/jellyfish-network/src/BlockRewardDistribution.ts
@@ -1,0 +1,50 @@
+import BigNumber from 'bignumber.js'
+
+export interface BlockRewardDistribution {
+  masternode: number
+  community: number
+  anchor: number
+  liquidity: number
+  loan: number
+  options: number
+  unallocated: number
+}
+
+export const BlockRewardDistributionPercentage: BlockRewardDistribution = {
+  masternode: 3333,
+  community: 491,
+  anchor: 2,
+  liquidity: 2545,
+  loan: 2468,
+  options: 988,
+  unallocated: 173
+}
+
+/**
+ * Get block reward distribution with block base subsidy
+ *
+ * @param {BigNumber} subsidy
+ * @return BlockRewardDistribution
+ */
+export function getBlockRewardDistribution (subsidy: BigNumber): BlockRewardDistribution {
+  return {
+    masternode: calculateReward(subsidy, BlockRewardDistributionPercentage.masternode),
+    community: calculateReward(subsidy, BlockRewardDistributionPercentage.community),
+    anchor: calculateReward(subsidy, BlockRewardDistributionPercentage.anchor),
+    liquidity: calculateReward(subsidy, BlockRewardDistributionPercentage.liquidity),
+    loan: calculateReward(subsidy, BlockRewardDistributionPercentage.loan),
+    options: calculateReward(subsidy, BlockRewardDistributionPercentage.options),
+    unallocated: calculateReward(subsidy, BlockRewardDistributionPercentage.unallocated)
+  }
+}
+
+/**
+ * Amount * Percent / 10000 using Integer Arithmetic (matching cpp CAmount)
+ *
+ * @param {BigNumber} amount
+ * @param {number} percent presented in integer as a numerator with denominator of 10000
+ * @return number
+ */
+function calculateReward (amount: BigNumber, percent: number): number {
+  return amount.times(percent).div(10000).integerValue(BigNumber.ROUND_DOWN).toNumber()
+}

--- a/packages/jellyfish-network/src/BlockSubsidy.ts
+++ b/packages/jellyfish-network/src/BlockSubsidy.ts
@@ -4,10 +4,10 @@ import BigNumber from 'bignumber.js'
 
 export interface CoinbaseSubsidyOptions {
   eunosHeight: number
-  genesisBlockSubsidy: number
-  preEunosBlockSubsidy: 20000000000
-  eunosBaseBlockSubsidy: 40504000000
-  eunosFoundationBurn: number
+  genesisBlockSubsidy: string
+  preEunosBlockSubsidy: '20000000000'
+  eunosBaseBlockSubsidy: '40504000000'
+  eunosFoundationBurn: string
   emissionReduction: 1658
   emissionReductionInterval: 32690
 }
@@ -17,10 +17,10 @@ export const MainNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
   /**
    * https://defiscan.live/blocks/279b1a87aedc7b9471d4ad4e5f12967ab6259926cd097ade188dfcf22ebfe72a
    */
-  genesisBlockSubsidy: 59100003000000000,
-  preEunosBlockSubsidy: 20000000000,
-  eunosBaseBlockSubsidy: 40504000000,
-  eunosFoundationBurn: 27370000000,
+  genesisBlockSubsidy: '59100003000000000',
+  preEunosBlockSubsidy: '20000000000',
+  eunosBaseBlockSubsidy: '40504000000',
+  eunosFoundationBurn: '27370000000000000',
   emissionReduction: 1658,
   emissionReductionInterval: 32690
 }
@@ -30,10 +30,10 @@ export const TestNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
   /**
    * https://defiscan.live/blocks/034ac8c88a1a9b846750768c1ad6f295bc4d0dc4b9b418aee5c0ebd609be8f90?network=TestNet
    */
-  genesisBlockSubsidy: 30400004000000000,
-  preEunosBlockSubsidy: 20000000000,
-  eunosBaseBlockSubsidy: 40504000000,
-  eunosFoundationBurn: 0,
+  genesisBlockSubsidy: '30400004000000000',
+  preEunosBlockSubsidy: '20000000000',
+  eunosBaseBlockSubsidy: '40504000000',
+  eunosFoundationBurn: '0',
   emissionReduction: 1658,
   emissionReductionInterval: 32690
 }
@@ -117,10 +117,10 @@ export class BlockSubsidy {
   }
 
   private computeReductionSupplyMilestones (reductionBlockSubsidies: BigNumber[]): BigNumber[] {
-    const baseSupply = new BigNumber(this.options.genesisBlockSubsidy).plus(
-      new BigNumber(this.options.preEunosBlockSubsidy).times(this.options.eunosHeight - 1)
-    )
-    // minus eunosFoundationBurn
+    const preEunosTotalSupply = new BigNumber(this.options.preEunosBlockSubsidy).times(this.options.eunosHeight - 1)
+    const baseSupply = new BigNumber(this.options.genesisBlockSubsidy)
+      .plus(preEunosTotalSupply)
+      .minus(this.options.eunosFoundationBurn)
 
     const supplyMilestones: BigNumber[] = [
       baseSupply

--- a/packages/jellyfish-network/src/BlockSubsidy.ts
+++ b/packages/jellyfish-network/src/BlockSubsidy.ts
@@ -1,0 +1,148 @@
+import BigNumber from 'bignumber.js'
+
+// 273,130,999.89
+
+export interface CoinbaseSubsidyOptions {
+  eunosHeight: number
+  genesisBlockSubsidy: number
+  preEunosBlockSubsidy: 20000000000
+  eunosBaseBlockSubsidy: 40504000000
+  eunosFoundationBurn: number
+  emissionReduction: 1658
+  emissionReductionInterval: 32690
+}
+
+export const MainNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
+  eunosHeight: 894000,
+  /**
+   * https://defiscan.live/blocks/279b1a87aedc7b9471d4ad4e5f12967ab6259926cd097ade188dfcf22ebfe72a
+   */
+  genesisBlockSubsidy: 59100003000000000,
+  preEunosBlockSubsidy: 20000000000,
+  eunosBaseBlockSubsidy: 40504000000,
+  eunosFoundationBurn: 27370000000,
+  emissionReduction: 1658,
+  emissionReductionInterval: 32690
+}
+
+export const TestNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
+  eunosHeight: 354950,
+  /**
+   * https://defiscan.live/blocks/034ac8c88a1a9b846750768c1ad6f295bc4d0dc4b9b418aee5c0ebd609be8f90?network=TestNet
+   */
+  genesisBlockSubsidy: 30400004000000000,
+  preEunosBlockSubsidy: 20000000000,
+  eunosBaseBlockSubsidy: 40504000000,
+  eunosFoundationBurn: 0,
+  emissionReduction: 1658,
+  emissionReductionInterval: 32690
+}
+
+/**
+ * All calculation are in satoshi
+ */
+export class BlockSubsidy {
+  private readonly reductionBlockSubsidies: BigNumber[] = this.computeBlockReductionSubsidies()
+  private readonly reductionSupplyMilestones: BigNumber[] = this.computeReductionSupplyMilestones(this.reductionBlockSubsidies)
+
+  constructor (private readonly options: CoinbaseSubsidyOptions = MainNetCoinbaseSubsidyOptions) {
+  }
+
+  getSupply (height: number): BigNumber {
+    validateHeight(height)
+
+    if (height < this.options.eunosHeight) {
+      return this.getPreEunosSupply(height)
+    }
+
+    return this.getPostEunosSupply(height)
+  }
+
+  getBlockSubsidy (height: number): BigNumber {
+    validateHeight(height)
+
+    if (height === 0) {
+      return new BigNumber(this.options.genesisBlockSubsidy)
+    }
+
+    if (height < this.options.eunosHeight) {
+      return new BigNumber(this.options.preEunosBlockSubsidy)
+    }
+
+    const reductionCount = Math.floor((height - this.options.eunosHeight) / this.options.emissionReductionInterval)
+    if (this.reductionBlockSubsidies[reductionCount] !== undefined) {
+      return this.reductionBlockSubsidies[reductionCount]
+    }
+
+    return new BigNumber(0)
+  }
+
+  private getPreEunosSupply (height: number): BigNumber {
+    let supply = new BigNumber(this.options.genesisBlockSubsidy)
+    supply = supply.plus(
+      new BigNumber(this.options.preEunosBlockSubsidy).times(height)
+    )
+    return supply
+  }
+
+  private getPostEunosSupply (height: number): BigNumber {
+    const postEunosDiff = height - (this.options.eunosHeight - 1)
+    const reductionCount = Math.floor(postEunosDiff / this.options.emissionReductionInterval)
+    const reductionRemainder = postEunosDiff % this.options.emissionReductionInterval
+
+    if (reductionCount >= this.reductionBlockSubsidies.length) {
+      return this.reductionSupplyMilestones[this.reductionSupplyMilestones.length - 1]
+    }
+
+    return this.reductionSupplyMilestones[reductionCount].plus(
+      this.reductionBlockSubsidies[reductionCount].times(reductionRemainder)
+    )
+  }
+
+  private computeReductionSupplyMilestones (reductionBlockSubsidies: BigNumber[]): BigNumber[] {
+    const baseSupply = new BigNumber(this.options.genesisBlockSubsidy).plus(
+      new BigNumber(this.options.preEunosBlockSubsidy).times(this.options.eunosHeight - 1)
+    )
+    // minus eunosFoundationBurn
+
+    const supplyMilestones: BigNumber[] = [
+      baseSupply
+    ]
+
+    for (let i = 1; i < reductionBlockSubsidies.length; i++) {
+      const previousBlockSubsidy = reductionBlockSubsidies[i - 1]
+      const previousMilestone = supplyMilestones[i - 1]
+      supplyMilestones[i] = previousMilestone.plus(
+        previousBlockSubsidy.times(this.options.emissionReductionInterval)
+      )
+    }
+
+    return supplyMilestones
+  }
+
+  private computeBlockReductionSubsidies (): BigNumber[] {
+    const subsidyReductions: BigNumber[] = [
+      new BigNumber(this.options.eunosBaseBlockSubsidy)
+    ]
+
+    while (true) {
+      const previousSubsidy = subsidyReductions[subsidyReductions.length - 1]
+      const amount = previousSubsidy.times(this.options.emissionReduction).div(100000).integerValue(BigNumber.ROUND_DOWN)
+
+      if (amount.isZero()) {
+        subsidyReductions.push(new BigNumber(0))
+        break
+      }
+
+      subsidyReductions.push(previousSubsidy.minus(amount))
+    }
+
+    return subsidyReductions
+  }
+}
+
+function validateHeight (height: number): void {
+  if (height < 0 || height % 1 !== 0) {
+    throw new Error('height must be a positive whole number')
+  }
+}

--- a/packages/jellyfish-network/src/BlockSubsidy.ts
+++ b/packages/jellyfish-network/src/BlockSubsidy.ts
@@ -1,7 +1,5 @@
 import BigNumber from 'bignumber.js'
 
-// 273,130,999.89
-
 export interface CoinbaseSubsidyOptions {
   eunosHeight: number
   genesisBlockSubsidy: string
@@ -20,7 +18,7 @@ export const MainNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
   genesisBlockSubsidy: '59100003000000000',
   preEunosBlockSubsidy: '20000000000',
   eunosBaseBlockSubsidy: '40504000000',
-  eunosFoundationBurn: '27370000000000000',
+  eunosFoundationBurn: '27300000000000000',
   emissionReduction: 1658,
   emissionReductionInterval: 32690
 }
@@ -52,6 +50,10 @@ export class BlockSubsidy {
   }
 
   /**
+   * DFI supply calculation up to a given height are done with the best effort.
+   * This does not take DFI burning into account.
+   * Fee burning, burn address, round-down burning, loan burning, etc. are all excluded.
+   *
    * @param {number} height
    * @return BigNumber supply in satoshi up to given height
    */

--- a/packages/jellyfish-network/src/BlockSubsidy.ts
+++ b/packages/jellyfish-network/src/BlockSubsidy.ts
@@ -18,7 +18,14 @@ export const MainNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
   genesisBlockSubsidy: '59100003000000000',
   preEunosBlockSubsidy: '20000000000',
   eunosBaseBlockSubsidy: '40504000000',
-  eunosFoundationBurn: '27300000000000000',
+  /**
+   * Eunos Foundation Burn at Block Height: 894000
+   *
+   * Balances at 893999 right before it got wiped.
+   * dJEbxbfufyPF14SC93yxiquECEfq4YSd9L: 265,713,999.89000000@DFI
+   * 8UAhRuUFCyFUHEPD7qvtj8Zy2HxF5HH5nb:   2,878,893.18829048@DFI
+   */
+  eunosFoundationBurn: '26859289307829046', // 265713999.89000000 + 2,878,893.18829048
   emissionReduction: 1658,
   emissionReductionInterval: 32690
 }

--- a/packages/jellyfish-network/src/BlockSubsidy.ts
+++ b/packages/jellyfish-network/src/BlockSubsidy.ts
@@ -39,7 +39,10 @@ export const TestNetCoinbaseSubsidyOptions: CoinbaseSubsidyOptions = {
 }
 
 /**
- * All calculation are in satoshi
+ * All calculation are in satoshi.
+ *
+ * This class cache all 1252 reductions block subsidies and milestones allowing instantaneous computation.
+ * With very little memory footprint, 1252 x 2 BigNumber classes for both getSupply and getBlockSubsidy.
  */
 export class BlockSubsidy {
   private readonly reductionBlockSubsidies: BigNumber[] = this.computeBlockReductionSubsidies()
@@ -48,6 +51,10 @@ export class BlockSubsidy {
   constructor (private readonly options: CoinbaseSubsidyOptions = MainNetCoinbaseSubsidyOptions) {
   }
 
+  /**
+   * @param {number} height
+   * @return BigNumber supply in satoshi up to given height
+   */
   getSupply (height: number): BigNumber {
     validateHeight(height)
 
@@ -58,6 +65,10 @@ export class BlockSubsidy {
     return this.getPostEunosSupply(height)
   }
 
+  /**
+   * @param {number} height
+   * @return BigNumber total block subsidy in satoshi at the given height
+   */
   getBlockSubsidy (height: number): BigNumber {
     validateHeight(height)
 
@@ -77,6 +88,9 @@ export class BlockSubsidy {
     return new BigNumber(0)
   }
 
+  /**
+   * Calculate pre-eunos supply
+   */
   private getPreEunosSupply (height: number): BigNumber {
     let supply = new BigNumber(this.options.genesisBlockSubsidy)
     supply = supply.plus(
@@ -85,6 +99,9 @@ export class BlockSubsidy {
     return supply
   }
 
+  /**
+   * Calculate post-eunos supply
+   */
   private getPostEunosSupply (height: number): BigNumber {
     const postEunosDiff = height - (this.options.eunosHeight - 1)
     const reductionCount = Math.floor(postEunosDiff / this.options.emissionReductionInterval)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

> Related to https://github.com/DeFiCh/whale/issues/310 and https://github.com/DeFiCh/whale/pull/661. This PR simplifies the development with a no-index, zero-lookup, instantaneous computation of supply, and block subsidy at a given height.

Inspired by https://github.com/DeFiCh/whale/pull/661, however, this PR introduces a deterministic DFI block subsidy and DFI supply calculation. All calculations within this utility class are in satoshi, test vectors are taken directly from c++ tests.

This class cache all 1252 reductions block subsidies and milestones allowing instantaneous computation. With very little memory footprint, 1252 x 2 BigNumber classes for both `getSupply` and `getBlockSubsidy`.

It introduces 2 public methods:

```ts
/**
 * DFI supply calculation up to a given height are done with the best effort.
 * This does not take DFI burning into account.
 * Fee burning, burn address, round-down burning, loan burning, etc. are all excluded.
 *
 * @param {number} height
 * @return BigNumber supply in satoshi up to given height
 */
getSupply (height: number): BigNumber
```

```ts
/**
 * @param {number} height
 * @return BigNumber total block subsidy in satoshi at the given height
 */
getBlockSubsidy (height: number): BigNumber
```