### PR TITLE
fix(jellyfish-api-core): fix getBurnInfo type

### DIFF
--- a/docs/node/CATEGORIES/08-account.md
+++ b/docs/node/CATEGORIES/08-account.md
@@ -391,16 +391,16 @@ interface account {
   getBurnInfo (): Promise<BurnInfo>
 }
 
-export interface BurnInfo {
+interface BurnInfo {
   address: string
   /**
    * Amount send to burn address
    */
   amount: BigNumber
   /**
-   * Token amount send to burn address
+   * Token amount send to burn address; formatted as AMOUNT@SYMBOL
    */
-  tokens: Array<{ name: string, amount: BigNumber }>
+  tokens: string[]
   /**
    * Amount collected via fee burn
    */
@@ -414,11 +414,15 @@ export interface BurnInfo {
    */
   paybackburn: BigNumber
   /**
+   * Formatted as AMOUNT@SYMBOL
+   */
+  dexfeetokens: string[]
+  /**
    * Amount of DFI collected from penalty resulting from paying DUSD using DFI
    */
   dfipaybackfee: BigNumber
   /**
-   * Amount of tokens that are paid back
+   * Amount of tokens that are paid back; formatted as AMOUNT@SYMBOL
    */
   dfipaybacktokens: string[]
 }

--- a/packages/jellyfish-api-core/__tests__/category/account/getBurnInfo.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/getBurnInfo.test.ts
@@ -1,9 +1,10 @@
 import BigNumber from 'bignumber.js'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
-import { createToken } from '@defichain/testing'
 import { ContainerAdapterClient } from '../../container_adapter_client'
+import { Testing } from '@defichain/jellyfish-testing'
 
 const container = new MasterNodeRegTestContainer()
+const testing = Testing.create(container)
 const client = new ContainerAdapterClient(container)
 const burnAddress = 'mfburnZSAM7Gs1hpDeNaMotJXSGA7edosG'
 
@@ -16,11 +17,20 @@ beforeAll(async () => {
   await container.generate(1)
 
   // burn gold token
-  const fundedAddress = await container.getNewAddress()
-  await createToken(container, 'GOLD', { collateralAddress: fundedAddress })
-  await client.token.mintTokens('100@GOLD')
+  await testing.token.create({ symbol: 'GOLD' })
   await container.generate(1)
-  await client.account.sendTokensToAddress({}, { [burnAddress]: ['50@GOLD'] })
+
+  await testing.token.mint({
+    amount: 100,
+    symbol: 'GOLD'
+  })
+  await container.generate(1)
+
+  await testing.token.send({
+    address: burnAddress,
+    amount: 50,
+    symbol: 'GOLD'
+  })
 
   // send utxo to burn address
   await client.wallet.sendToAddress(burnAddress, 10)

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -493,9 +493,9 @@ export interface BurnInfo {
    */
   amount: BigNumber
   /**
-   * Token amount send to burn address
+   * Token amount send to burn address; formatted as AMOUNT@SYMBOL
    */
-  tokens: Array<{ name: string, amount: BigNumber }>
+  tokens: string[]
   /**
    * Amount collected via fee burn
    */
@@ -509,11 +509,15 @@ export interface BurnInfo {
    */
   paybackburn: BigNumber
   /**
+   * Formatted as AMOUNT@SYMBOL
+   */
+  dexfeetokens: string[]
+  /**
    * Amount of DFI collected from penalty resulting from paying DUSD using DFI
    */
   dfipaybackfee: BigNumber
   /**
-   * Amount of tokens that are paid back
+   * Amount of tokens that are paid back; formatted as AMOUNT@SYMBOL
    */
   dfipaybacktokens: string[]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- `tokens: string[]` was typed wrongly
-  `dexfeetokens: string[]` was missing

Also updated test to move away from deprecated methods.