### PR TITLE
feat(jellyfish-api-core): add account getAccountHistory RPC

### DIFF
--- a/docs/node/CATEGORIES/08-account.md
+++ b/docs/node/CATEGORIES/08-account.md
@@ -235,6 +235,31 @@ interface AccountHistoryOptions {
 }
 ```
 
+## getAccountHistory
+
+Returns information about single account history
+
+```ts title="client.account.getAccountHistory()"
+interface account {
+  getAccountHistory (
+    owner: string,
+    blockHeight: number,
+    txn:number
+  ): Promise<AccountHistory>
+}
+
+interface AccountHistory {
+  owner: string
+  blockHeight: number
+  blockHash: string
+  blockTime: number
+  type: string
+  txn: number
+  txid: string
+  amounts: string[]
+}
+```
+
 ## historyCount 
 
 Returns count of account history

--- a/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
@@ -1,5 +1,5 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
-import { ContainerAdapterClient } from '../../container_adapter_client'
+import { Testing } from '@defichain/jellyfish-testing'
 import waitForExpect from 'wait-for-expect'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
 
@@ -22,31 +22,30 @@ function createTokenForContainer (container: MasterNodeRegTestContainer) {
 }
 
 describe('Account', () => {
-  const container = new MasterNodeRegTestContainer()
-  const client = new ContainerAdapterClient(container)
-  const createToken = createTokenForContainer(container)
+  const testing = Testing.create(new MasterNodeRegTestContainer())
+  const createToken = createTokenForContainer(testing.container)
 
   beforeAll(async () => {
-    await container.start()
-    await container.waitForWalletCoinbaseMaturity()
-    await container.waitForWalletBalanceGTE(100)
-    await createToken(await container.getNewAddress(), 'DBTC', 200)
+    await testing.container.start()
+    await testing.container.waitForWalletCoinbaseMaturity()
+    await testing.container.waitForWalletBalanceGTE(100)
+    await createToken(await testing.container.getNewAddress(), 'DBTC', 200)
   })
 
   afterAll(async () => {
-    await container.stop()
+    await testing.container.stop()
   })
 
   it('should getAccountHistory', async () => {
     await waitForExpect(async () => {
-      const accountHistories = await client.account.listAccountHistory()
+      const accountHistories = await testing.rpc.account.listAccountHistory()
       expect(accountHistories.length).toBeGreaterThan(0)
     })
 
-    const accountHistories = await client.account.listAccountHistory()
+    const accountHistories = await testing.rpc.account.listAccountHistory()
     const referenceHistory = accountHistories[0]
 
-    const history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn)
+    const history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn)
     expect(history.owner).toStrictEqual(referenceHistory.owner)
     expect(history.blockHeight).toStrictEqual(referenceHistory.blockHeight)
     expect(history.txn).toStrictEqual(referenceHistory.txn)
@@ -56,30 +55,30 @@ describe('Account', () => {
 
   it('should not getAccountHistory', async () => {
     await waitForExpect(async () => {
-      const accountHistories = await client.account.listAccountHistory()
+      const accountHistories = await testing.rpc.account.listAccountHistory()
       expect(accountHistories.length).toBeGreaterThan(0)
     })
 
-    const accountHistories = await client.account.listAccountHistory()
+    const accountHistories = await testing.rpc.account.listAccountHistory()
     const referenceHistory = accountHistories[0]
 
-    let history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn)
+    let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn)
     expect(history.owner).toBeUndefined()
 
-    history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn - 1)
+    history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn - 1)
     expect(history.owner).toBeUndefined()
 
-    history = await client.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn - 1)
+    history = await testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn - 1)
     expect(history.owner).toBeUndefined()
 
-    const historyPromise = client.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERw', referenceHistory.blockHeight, referenceHistory.txn - 1)
+    const historyPromise = testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERw', referenceHistory.blockHeight, referenceHistory.txn - 1)
     await expect(historyPromise).rejects.toThrow(RpcApiError)
     await expect(historyPromise).rejects.toThrow('does not refer to any valid address')
 
-    history = await client.account.getAccountHistory(referenceHistory.owner, -103, referenceHistory.txn)
+    history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, -103, referenceHistory.txn)
     expect(history.owner).toBeUndefined()
 
-    history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, -1)
+    history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, -1)
     expect(history.owner).toBeUndefined()
   })
 })

--- a/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
@@ -1,0 +1,85 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { ContainerAdapterClient } from '../../container_adapter_client'
+import waitForExpect from 'wait-for-expect'
+import { RpcApiError } from '@defichain/jellyfish-api-core'
+
+function createTokenForContainer (container: MasterNodeRegTestContainer) {
+  return async (address: string, symbol: string, amount: number) => {
+    const metadata = {
+      symbol,
+      name: symbol,
+      isDAT: true,
+      mintable: true,
+      tradeable: true,
+      collateralAddress: address
+    }
+    await container.call('createtoken', [metadata])
+    await container.generate(1)
+
+    await container.call('minttokens', [`${amount.toString()}@${symbol}`])
+    await container.generate(1)
+  }
+}
+
+describe('Account', () => {
+  const container = new MasterNodeRegTestContainer()
+  const client = new ContainerAdapterClient(container)
+  const createToken = createTokenForContainer(container)
+
+  beforeAll(async () => {
+    await container.start()
+    await container.waitForWalletCoinbaseMaturity()
+    await container.waitForWalletBalanceGTE(100)
+    await createToken(await container.getNewAddress(), 'DBTC', 200)
+  })
+
+  afterAll(async () => {
+    await container.stop()
+  })
+
+  it('should getAccountHistory', async () => {
+    await waitForExpect(async () => {
+      const accountHistories = await client.account.listAccountHistory()
+      expect(accountHistories.length).toBeGreaterThan(0)
+    })
+
+    const accountHistories = await client.account.listAccountHistory()
+    const referenceHistory = accountHistories[0]
+
+    const history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn)
+    expect(history.owner).toStrictEqual(referenceHistory.owner)
+    expect(history.blockHeight).toStrictEqual(referenceHistory.blockHeight)
+    expect(history.txn).toStrictEqual(referenceHistory.txn)
+    expect(history.txid).toStrictEqual(referenceHistory.txid)
+    expect(history.type).toStrictEqual(referenceHistory.type)
+  })
+
+  it('should not getAccountHistory', async () => {
+    await waitForExpect(async () => {
+      const accountHistories = await client.account.listAccountHistory()
+      expect(accountHistories.length).toBeGreaterThan(0)
+    })
+
+    const accountHistories = await client.account.listAccountHistory()
+    const referenceHistory = accountHistories[0]
+
+    let history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn)
+    expect(history.owner).toBeUndefined()
+
+    history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn - 1)
+    expect(history.owner).toBeUndefined()
+
+    history = await client.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn - 1)
+    expect(history.owner).toBeUndefined()
+
+    const historyPromise = client.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERw', referenceHistory.blockHeight, referenceHistory.txn - 1)
+    await expect(historyPromise).rejects.toThrow(RpcApiError)
+    await expect(historyPromise).rejects.toThrow('does not refer to any valid address')
+
+    history = await client.account.getAccountHistory(referenceHistory.owner, -103, referenceHistory.txn)
+    expect(history.owner).toBeUndefined()
+
+    history = await client.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, -1)
+    expect(history.owner).toBeUndefined()
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/account/getAccountHistory.test.ts
@@ -1,6 +1,5 @@
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
 import { Testing } from '@defichain/jellyfish-testing'
-import waitForExpect from 'wait-for-expect'
 import { RpcApiError } from '@defichain/jellyfish-api-core'
 
 describe('Account', () => {
@@ -28,13 +27,32 @@ describe('Account', () => {
     await testing.container.stop()
   })
 
-  it('should getAccountHistory', async () => {
-    await waitForExpect(async () => {
-      const accountHistories = await testing.rpc.account.listAccountHistory()
-      expect(accountHistories.length).toBeGreaterThan(0)
-    })
+  it('should getAccountHistory with owner CScript', async () => {
+    const accounts: any[] = await testing.rpc.account.listAccounts()
 
+    const { owner } = accounts[0]
+    const { hex, addresses } = owner
+
+    const accountHistories = await testing.rpc.account.listAccountHistory(hex)
+
+    const referenceHistory = accountHistories[0]
+
+    const history = await testing.rpc.account.getAccountHistory(hex, referenceHistory.blockHeight, referenceHistory.txn)
+    expect(history.owner).toStrictEqual(referenceHistory.owner)
+    expect(history.blockHeight).toStrictEqual(referenceHistory.blockHeight)
+    expect(history.txn).toStrictEqual(referenceHistory.txn)
+    expect(history.txid).toStrictEqual(referenceHistory.txid)
+    expect(history.type).toStrictEqual(referenceHistory.type)
+    expect(history.blockHash).toStrictEqual(referenceHistory.blockHash)
+    expect(history.blockTime).toStrictEqual(referenceHistory.blockTime)
+    expect(history.amounts).toStrictEqual(referenceHistory.amounts)
+    expect(addresses.includes(history.owner)).toStrictEqual(true)
+  })
+
+  it('should getAccountHistory with owner address', async () => {
     const accountHistories = await testing.rpc.account.listAccountHistory()
+    expect(accountHistories.length).toBeGreaterThan(0)
+
     const referenceHistory = accountHistories[0]
 
     const history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn)
@@ -49,12 +67,9 @@ describe('Account', () => {
   })
 
   it('should not getAccountHistory when address is not valid', async () => {
-    await waitForExpect(async () => {
-      const accountHistories = await testing.rpc.account.listAccountHistory()
-      expect(accountHistories.length).toBeGreaterThan(0)
-    })
-
     const accountHistories = await testing.rpc.account.listAccountHistory()
+    expect(accountHistories.length).toBeGreaterThan(0)
+
     const referenceHistory = accountHistories[0]
 
     const history = await testing.rpc.account.getAccountHistory('mrLrCt3kMFhhfYeT8euQw5ERwyvFg9K21j', referenceHistory.blockHeight, referenceHistory.txn)
@@ -66,12 +81,9 @@ describe('Account', () => {
   })
 
   it('should not getAccountHistory when blockHeight is not valid', async () => {
-    await waitForExpect(async () => {
-      const accountHistories = await testing.rpc.account.listAccountHistory()
-      expect(accountHistories.length).toBeGreaterThan(0)
-    })
-
     const accountHistories = await testing.rpc.account.listAccountHistory()
+    expect(accountHistories.length).toBeGreaterThan(0)
+
     const referenceHistory = accountHistories[0]
 
     let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight - 1, referenceHistory.txn)
@@ -82,12 +94,9 @@ describe('Account', () => {
   })
 
   it('should not getAccountHistory when txn is not valid', async () => {
-    await waitForExpect(async () => {
-      const accountHistories = await testing.rpc.account.listAccountHistory()
-      expect(accountHistories.length).toBeGreaterThan(0)
-    })
-
     const accountHistories = await testing.rpc.account.listAccountHistory()
+    expect(accountHistories.length).toBeGreaterThan(0)
+
     const referenceHistory = accountHistories[0]
 
     let history = await testing.rpc.account.getAccountHistory(referenceHistory.owner, referenceHistory.blockHeight, referenceHistory.txn - 1)

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -303,9 +303,9 @@ export class Account {
   /**
    * Returns information about single account history
    *
-   * @param {string} [owner] Single account ID (CScript or address)
-   * @param {number} [blockHeight] Height to iterate from genesis block
-   * @param {number} [txn] Order in block
+   * @param {string} owner Single account ID (CScript or address)
+   * @param {number} blockHeight Height to iterate from genesis block
+   * @param {number} txn Order in block
    * @return {Promise<AccountHistory>}
    */
   async getAccountHistory (

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -304,7 +304,7 @@ export class Account {
    * Returns information about single account history
    *
    * @param {string} owner Single account ID (CScript or address)
-   * @param {number} blockHeight Height to iterate from genesis block
+   * @param {number} blockHeight Block height to search in
    * @param {number} txn Order in block
    * @return {Promise<AccountHistory>}
    */

--- a/packages/jellyfish-api-core/src/category/account.ts
+++ b/packages/jellyfish-api-core/src/category/account.ts
@@ -301,6 +301,22 @@ export class Account {
   }
 
   /**
+   * Returns information about single account history
+   *
+   * @param {string} [owner] Single account ID (CScript or address)
+   * @param {number} [blockHeight] Height to iterate from genesis block
+   * @param {number} [txn] Order in block
+   * @return {Promise<AccountHistory>}
+   */
+  async getAccountHistory (
+    owner: string,
+    blockHeight: number,
+    txn: number
+  ): Promise<AccountHistory> {
+    return await this.client.call('getaccounthistory', [owner, blockHeight, txn], 'number')
+  }
+
+  /**
    * Returns count of account history
    *
    * @param {OwnerType | string} [owner=OwnerType.MINE] single account ID (CScript or address) or reserved words 'mine' to list history count for all owned accounts or 'all' to list whole DB

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:HEAD-5c8d587'
+    return 'defi/defichain:HEAD-f5373b2'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:HEAD-f5373b2'
+    return 'defi/defichain:master-c0a25f7'
   }
 
   public static readonly DefaultStartOptions = {

--- a/packages/testcontainers/src/containers/DeFiDContainer.ts
+++ b/packages/testcontainers/src/containers/DeFiDContainer.ts
@@ -35,7 +35,7 @@ export abstract class DeFiDContainer extends DockerContainer {
     if (process?.env?.DEFICHAIN_DOCKER_IMAGE !== undefined) {
       return process.env.DEFICHAIN_DOCKER_IMAGE
     }
-    return 'defi/defichain:2.6.1'
+    return 'defi/defichain:HEAD-5c8d587'
   }
 
   public static readonly DefaultStartOptions = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
/kind feature

#### What this PR does / why we need it:
Currently, we have listaccounthistory on DeFiCh/ain. However, there isn't a way to filter to get one AccountHistory and we need an RPC to get single account history to resolve balance transfer.

#### Which issue(s) does this PR fixes?:

Fixes https://github.com/DeFiCh/jellyfish/issues/1025
