### PR TITLE
chore(jellyfish-api-core): WhaleApiClient caching

### DIFF
--- a/apps/legacy-api/__tests__/providers/WhaleApiClientProvider.test.ts
+++ b/apps/legacy-api/__tests__/providers/WhaleApiClientProvider.test.ts
@@ -1,0 +1,45 @@
+import { WhaleApiClientProvider } from '../../src/providers/WhaleApiClientProvider'
+import { Test } from '@nestjs/testing'
+
+describe('WhaleApiClientProvider', () => {
+  let whaleApiClientProvider: WhaleApiClientProvider
+
+  beforeEach(async () => {
+    const moduleRef = await Test.createTestingModule({
+      providers: [WhaleApiClientProvider]
+    }).compile()
+
+    whaleApiClientProvider = moduleRef.get(WhaleApiClientProvider)
+  })
+
+  it('should cache and return same client instance for the same network', () => {
+    {
+      const first = whaleApiClientProvider.getClient('mainnet')
+      const second = whaleApiClientProvider.getClient('mainnet')
+      expect(first === second) // points to the same object
+        .toStrictEqual(true)
+    }
+    {
+      const first = whaleApiClientProvider.getClient('testnet')
+      const second = whaleApiClientProvider.getClient('testnet')
+      expect(first === second) // points to the same object
+        .toStrictEqual(true)
+    }
+    {
+      const first = whaleApiClientProvider.getClient('regtest')
+      const second = whaleApiClientProvider.getClient('regtest')
+      expect(first === second) // points to the same object
+        .toStrictEqual(true)
+    }
+  })
+
+  it('should return different clients for different networks', () => {
+    const mainnet = whaleApiClientProvider.getClient('mainnet')
+    const testnet = whaleApiClientProvider.getClient('testnet')
+    const regtest = whaleApiClientProvider.getClient('regtest')
+
+    expect(mainnet).not.toStrictEqual(testnet)
+    expect(mainnet).not.toStrictEqual(regtest)
+    expect(testnet).not.toStrictEqual(regtest)
+  })
+})

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,18 +1,16 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { WhaleApiClient } from '@defichain/whale-api-client'
 import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
+import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 
 @Controller('v1')
 export class MiscController {
+  constructor (private readonly whaleApiClientProvider: WhaleApiClientProvider) {}
+
   @Get('getblockcount')
   async getToken (
     @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet'
   ): Promise<{ [key: string]: Number }> {
-    const api = new WhaleApiClient({
-      version: 'v0',
-      network: network,
-      url: 'https://ocean.defichain.com'
-    })
+    const api = this.whaleApiClientProvider.getClient(network)
 
     const data: StatsData = await api.stats.get()
     return {

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -1,19 +1,17 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { WhaleApiClient } from '@defichain/whale-api-client'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
+import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 
 @Controller('v1')
 export class PoolPairController {
+  constructor (private readonly whaleApiClientProvider: WhaleApiClientProvider) {}
+
   @Get('getpoolpair')
   async getToken (
     @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
     @Query('id') poolPairId: string
   ): Promise<LegacyPoolPairData> {
-    const api = new WhaleApiClient({
-      version: 'v0',
-      network: network,
-      url: 'https://ocean.defichain.com'
-    })
+    const api = this.whaleApiClientProvider.getClient(network)
 
     return reformatPoolPairData(await api.poolpairs.get(poolPairId))
   }
@@ -22,11 +20,7 @@ export class PoolPairController {
   async listPoolPairs (
     @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet'
   ): Promise<{ [key: string]: LegacyPoolPairData }> {
-    const api = new WhaleApiClient({
-      version: 'v0',
-      network: network,
-      url: 'https://ocean.defichain.com'
-    })
+    const api = this.whaleApiClientProvider.getClient(network)
 
     const data: PoolPairData[] = await api.poolpairs.list(200)
 

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -1,19 +1,17 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { WhaleApiClient } from '@defichain/whale-api-client'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
+import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 
 @Controller('v1')
 export class TokenController {
+  constructor (private readonly whaleApiClientProvider: WhaleApiClientProvider) {}
+
   @Get('gettoken')
   async getToken (
     @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
-    const api = new WhaleApiClient({
-      version: 'v0',
-      network: network,
-      url: 'https://ocean.defichain.com'
-    })
+    const api = this.whaleApiClientProvider.getClient(network)
 
     const data = await api.tokens.get(tokenId)
     return {
@@ -26,11 +24,7 @@ export class TokenController {
     @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
-    const api = new WhaleApiClient({
-      version: 'v0',
-      network: network,
-      url: 'https://ocean.defichain.com'
-    })
+    const api = this.whaleApiClientProvider.getClient(network)
 
     const data: TokenData[] = await api.tokens.list(200)
 

--- a/apps/legacy-api/src/modules/ControllerModule.ts
+++ b/apps/legacy-api/src/modules/ControllerModule.ts
@@ -2,6 +2,7 @@ import { CacheModule, Module } from '@nestjs/common'
 import { TokenController } from '../controllers/TokenController'
 import { PoolPairController } from '../controllers/PoolPairController'
 import { MiscController } from '../controllers/MiscController'
+import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 
 /**
  * Exposed ApiModule for public interfacing
@@ -14,6 +15,9 @@ import { MiscController } from '../controllers/MiscController'
     TokenController,
     PoolPairController,
     MiscController
+  ],
+  providers: [
+    WhaleApiClientProvider
   ]
 })
 export class ControllerModule {

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -1,0 +1,31 @@
+import { WhaleApiClient } from '@defichain/whale-api-client'
+import { Injectable } from '@nestjs/common'
+
+type Network = 'mainnet' | 'testnet' | 'regtest'
+
+@Injectable()
+export class WhaleApiClientProvider {
+  private readonly clientCacheByNetwork: Map<Network, WhaleApiClient> = new Map()
+
+  /**
+   * Lazily initialises WhaleApiClients and caches them by network for performance.
+   * @param network - the network to connect to
+   */
+  getClient (network: Network): WhaleApiClient {
+    const client = this.clientCacheByNetwork.get(network)
+    if (client !== undefined) {
+      return client
+    }
+    return this.createAndCacheClient(network)
+  }
+
+  private createAndCacheClient (network: Network): WhaleApiClient {
+    const client = new WhaleApiClient({
+      version: 'v0',
+      network: network,
+      url: 'https://ocean.defichain.com'
+    })
+    this.clientCacheByNetwork.set(network, client)
+    return client
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Creates a `WhaleApiClientProvider` that lazily initialises `WhaleApiClient`s and caches them by network (i.e. mainnet, regtest, testnet) so they can be reused - improving performance

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1052
