### PR TITLE
chore(apps/legacy-api): legacy-api health check

### DIFF
--- a/apps/legacy-api/__tests__/controllers/ActuatorController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/ActuatorController.test.ts
@@ -1,0 +1,131 @@
+import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
+import { WhaleApiClientProvider } from '../../src/providers/WhaleApiClientProvider'
+import { WhaleApiClient } from '@defichain/whale-api-client'
+
+describe('connected to ocean', () => {
+  const apiTesting = LegacyApiTesting.create()
+
+  beforeAll(async () => {
+    await apiTesting.start()
+  })
+
+  afterAll(async () => {
+    await apiTesting.stop()
+  })
+
+  it('/_actuator/probes/liveness healthy', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/_actuator/probes/liveness'
+    })
+
+    expect(res.json()).toStrictEqual({
+      details: {
+        whale: {
+          status: 'up'
+        }
+      },
+      error: {},
+      info: {
+        whale: {
+          status: 'up'
+        }
+      },
+      status: 'ok'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/_actuator/probes/readiness healthy', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/_actuator/probes/readiness'
+    })
+
+    expect(res.json()).toStrictEqual({
+      details: {
+        whale: {
+          blocks: expect.any(Number),
+          headers: expect.any(Number),
+          initialBlockDownload: false,
+          status: 'up'
+        }
+      },
+      error: {},
+      info: {
+        whale: {
+          blocks: expect.any(Number),
+          headers: expect.any(Number),
+          initialBlockDownload: expect.any(Boolean),
+          status: 'up'
+        }
+      },
+      status: 'ok'
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+})
+
+// TODO(eli-lim): simulate disconnection
+describe.skip('disconnected from ocean', () => {
+  const apiTesting = LegacyApiTesting.create()
+
+  beforeAll(async () => {
+    await apiTesting.start()
+    jest.spyOn(apiTesting.app.get(WhaleApiClientProvider), 'getClient')
+      .mockImplementation(() => new WhaleApiClient({
+        version: 'v0',
+        network: 'mainnet',
+        url: 'https://wrongendpoint.defichain.com'
+      }))
+  })
+
+  afterAll(async () => {
+    await apiTesting.stop()
+  })
+
+  it('/_actuator/probes/liveness unhealthy', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/_actuator/probes/liveness'
+    })
+    expect(res.json()).toStrictEqual({
+      details: {
+        whale: {
+          status: 'down'
+        }
+      },
+      error: {
+        whale: {
+          status: 'down'
+        }
+      },
+      info: {},
+      status: 'error'
+    })
+    expect(res.statusCode).toStrictEqual(503)
+  })
+
+  it('/_actuator/probes/readiness unhealthy', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/_actuator/probes/readiness'
+    })
+
+    expect(res.json()).toStrictEqual({
+      details: {
+        whale: {
+          status: 'down'
+        }
+      },
+      error: {
+        whale: {
+          status: 'down'
+        }
+      },
+      info: {},
+      status: 'error'
+    })
+    expect(res.statusCode).toStrictEqual(503)
+  })
+})

--- a/apps/legacy-api/__tests__/controllers/NetworkParamValidation.test.ts
+++ b/apps/legacy-api/__tests__/controllers/NetworkParamValidation.test.ts
@@ -21,7 +21,7 @@ describe('NetworkParamValidation', () => {
     const unprotectedRoutes = []
     const routes = apiTesting.getAllRoutes()
     for (const { url } of routes) {
-      if (url === '*') {
+      if (url === '*' || url.startsWith('/_')) {
         continue
       }
 

--- a/apps/legacy-api/src/modules/ControllerModule.ts
+++ b/apps/legacy-api/src/modules/ControllerModule.ts
@@ -5,6 +5,7 @@ import { MiscController } from '../controllers/MiscController'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { StatsController } from '../controllers/stats/StatsController'
 import { MainnetLegacyStatsProvider, TestnetLegacyStatsProvider } from '../controllers/stats/LegacyStatsProvider'
+import { ActuatorController } from '@defichain-apps/libs/actuator'
 
 /**
  * Exposed ApiModule for public interfacing
@@ -17,7 +18,8 @@ import { MainnetLegacyStatsProvider, TestnetLegacyStatsProvider } from '../contr
     TokenController,
     PoolPairController,
     MiscController,
-    StatsController
+    StatsController,
+    ActuatorController
   ],
   providers: [
     WhaleApiClientProvider,

--- a/apps/legacy-api/src/modules/RootModule.ts
+++ b/apps/legacy-api/src/modules/RootModule.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common'
 import { ConfigModule } from '@nestjs/config'
 import { ControllerModule } from './ControllerModule'
+import { WhaleApiModule } from './WhaleApiModule'
+import { ActuatorModule } from '@defichain-apps/libs/actuator'
 
 @Module({
   imports: [
@@ -8,9 +10,10 @@ import { ControllerModule } from './ControllerModule'
       isGlobal: true,
       cache: true
     }),
+    ActuatorModule,
+    WhaleApiModule,
     ControllerModule
   ]
 })
-
 export class RootModule {
 }

--- a/apps/legacy-api/src/modules/WhaleApiModule.ts
+++ b/apps/legacy-api/src/modules/WhaleApiModule.ts
@@ -1,0 +1,61 @@
+import { Global, Injectable, Module } from '@nestjs/common'
+import { HealthIndicatorResult } from '@nestjs/terminus'
+import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
+import { ActuatorProbes, ProbeIndicator } from '@defichain-apps/libs/actuator'
+import { BlockchainInfo } from '@defichain/jellyfish-api-core/src/category/blockchain'
+
+@Injectable()
+export class WhaleApiProbeIndicator extends ProbeIndicator {
+  constructor (private readonly clientProvider: WhaleApiClientProvider) {
+    super()
+  }
+
+  async liveness (): Promise<HealthIndicatorResult> {
+    try {
+      const client = this.clientProvider.getClient('mainnet')
+      await client.stats.get()
+      return this.withAlive('whale')
+    } catch (ignored) {
+      return this.withDead('whale', 'could not connect to mainnet')
+    }
+  }
+
+  async readiness (): Promise<HealthIndicatorResult> {
+    let info
+    try {
+      const client = this.clientProvider.getClient('mainnet')
+      info = await client.rpc.call<BlockchainInfo>('getblockchaininfo', [], 'number')
+    } catch (ignored) {
+      return this.withDead('whale', 'could not get blockchain info from mainnet')
+    }
+
+    const details = {
+      initialBlockDownload: info.initialblockdownload,
+      blocks: info.blocks,
+      headers: info.headers
+    }
+    return this.withAlive('whale', details)
+  }
+}
+
+@Global()
+@Module({
+  providers: [
+    WhaleApiProbeIndicator,
+    WhaleApiClientProvider
+  ],
+  exports: [
+    WhaleApiClientProvider
+  ]
+})
+export class WhaleApiModule {
+  constructor (
+    private readonly probes: ActuatorProbes,
+    private readonly whaleApiClientProbeIndicator: WhaleApiProbeIndicator
+  ) {
+  }
+
+  async onApplicationBootstrap (): Promise<void> {
+    this.probes.add(this.whaleApiClientProbeIndicator)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@defichain/jellyfish-testing": "^0.0.0",
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
-        "@defichain/whale-api-client": "0.23.2",
+        "@defichain/whale-api-client": "0.26.2",
         "@nestjs/common": "^8.2.6",
         "@nestjs/config": "^1.2.0",
         "@nestjs/core": "^8.2.6",
@@ -95,6 +95,54 @@
         "@nestjs/cli": "^8.2.1",
         "@nestjs/schematics": "^8.0.6",
         "@nestjs/testing": "^8.3.1"
+      }
+    },
+    "apps/node_modules/@defichain/jellyfish-json": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.22.0.tgz",
+      "integrity": "sha512-3CsoK2VrOOw1W/lvheIe0+0ZpE4qmhtMTx4OzQz9Et6l+iNkIyIoZAsxl4ErdEvjofwlYn3kBvefvaf5KfgxLg==",
+      "dependencies": {
+        "@types/lossless-json": "^1.0.1",
+        "bignumber.js": "^9.0.2",
+        "lossless-json": "^1.0.5"
+      },
+      "peerDependencies": {
+        "defichain": "^2.22.0"
+      }
+    },
+    "apps/node_modules/@defichain/whale-api-client": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
+      "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
+      "dependencies": {
+        "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.5",
+        "url-search-params-polyfill": "8.1.1"
+      }
+    },
+    "apps/node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-core": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.22.0.tgz",
+      "integrity": "sha512-8rSP6t2N9Dq0+218vWvEKDQpYhcOSvIRMk7YuajVWWtTHJn1BMlb+qTGeD18dVYwFxeH3B3ckLRwR4acP17VKw==",
+      "dependencies": {
+        "@defichain/jellyfish-json": "2.22.0"
+      },
+      "peerDependencies": {
+        "defichain": "^2.22.0"
+      }
+    },
+    "apps/node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-jsonrpc": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.22.0.tgz",
+      "integrity": "sha512-L/qcJVB0wIJU+02WOKosiqXlpTkuW2sHerWmJSnEbG13HmpuiXZ8uj50Ms3Pq/EC/1LWalMIL15JblIG2xxK2Q==",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": "2.22.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "defichain": "^2.22.0"
       }
     },
     "apps/node_modules/@nestjs/common": {
@@ -451,6 +499,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "apps/node_modules/defichain": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.22.0.tgz",
+      "integrity": "sha512-Jf9f3E9HBcp0nIGFiAyMp/lPztTpTRSH6k1gReMZRzZ58wDPj7Z3yIrXEB6DSx5tyD+Ma596BDUljg+inQcPJg==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.x"
       }
     },
     "apps/node_modules/eslint-visitor-keys": {
@@ -2918,63 +2975,6 @@
     "node_modules/@defichain/website": {
       "resolved": "website",
       "link": true
-    },
-    "node_modules/@defichain/whale-api-client": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.23.2.tgz",
-      "integrity": "sha512-rs6S+EYKqAEVzRyQUKqUp9hyYO8O9ybEqa3HWZkHefmFwDbSTEfeGb4o6lBB/iOPLsFzF5wMFFEVM1hZsG/fyg==",
-      "dependencies": {
-        "@defichain/jellyfish-api-jsonrpc": "^2.18.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.5",
-        "url-search-params-polyfill": "8.1.1"
-      }
-    },
-    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-core": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.18.3.tgz",
-      "integrity": "sha512-22tdkG+Q1IbmfgGVrqMGEfLXAbJiyXJNucc+WIfauhb7YJbHrQxKkf9TZyA5HCRQ04FVzp8VMrGh9Z3Mb0D8Pg==",
-      "dependencies": {
-        "@defichain/jellyfish-json": "2.18.3"
-      },
-      "peerDependencies": {
-        "defichain": "^2.18.3"
-      }
-    },
-    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-jsonrpc": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.18.3.tgz",
-      "integrity": "sha512-tvBqDcakTtSU725fk2tVfxX7boxx3U6I23DLxr4qrZ+7lhfMeXtagPc4JB2hT7EEqsOCAHFUC92rO/nir2Fq7g==",
-      "dependencies": {
-        "@defichain/jellyfish-api-core": "2.18.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.5"
-      },
-      "peerDependencies": {
-        "defichain": "^2.18.3"
-      }
-    },
-    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-json": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.18.3.tgz",
-      "integrity": "sha512-oXxcgxYRMEoB2HnZd07p6iSG757oBqIf0LXugmtSZTm+hQjG/Wjr6wtXSM4u/004vBBAxpld4SjT29NEJ6MHIQ==",
-      "dependencies": {
-        "@types/lossless-json": "^1.0.1",
-        "bignumber.js": "^9.0.2",
-        "lossless-json": "^1.0.5"
-      },
-      "peerDependencies": {
-        "defichain": "^2.18.3"
-      }
-    },
-    "node_modules/@defichain/whale-api-client/node_modules/defichain": {
-      "version": "2.18.3",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.18.3.tgz",
-      "integrity": "sha512-DI6UIAVgOXyYNrIGbSh6pjUo1VvxLXhD0iVC1nqw9aUuTIJ5ygWstHBmFX2TXXAIY8ZPMKKJdVC+HAAezfmRsw==",
-      "peer": true,
-      "engines": {
-        "node": ">=14.x"
-      }
     },
     "node_modules/@docsearch/css": {
       "version": "3.0.0",
@@ -27676,7 +27676,7 @@
         "@defichain/jellyfish-testing": "^0.0.0",
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
-        "@defichain/whale-api-client": "0.23.2",
+        "@defichain/whale-api-client": "0.26.2",
         "@nestjs/cli": "^8.0.0",
         "@nestjs/common": "^8.2.6",
         "@nestjs/config": "^1.2.0",
@@ -27710,6 +27710,47 @@
         "typeorm": "^0.2.43"
       },
       "dependencies": {
+        "@defichain/jellyfish-json": {
+          "version": "2.22.0",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.22.0.tgz",
+          "integrity": "sha512-3CsoK2VrOOw1W/lvheIe0+0ZpE4qmhtMTx4OzQz9Et6l+iNkIyIoZAsxl4ErdEvjofwlYn3kBvefvaf5KfgxLg==",
+          "requires": {
+            "@types/lossless-json": "^1.0.1",
+            "bignumber.js": "^9.0.2",
+            "lossless-json": "^1.0.5"
+          }
+        },
+        "@defichain/whale-api-client": {
+          "version": "0.26.2",
+          "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
+          "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
+          "requires": {
+            "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
+            "abort-controller": "^3.0.0",
+            "cross-fetch": "^3.1.5",
+            "url-search-params-polyfill": "8.1.1"
+          },
+          "dependencies": {
+            "@defichain/jellyfish-api-core": {
+              "version": "2.22.0",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.22.0.tgz",
+              "integrity": "sha512-8rSP6t2N9Dq0+218vWvEKDQpYhcOSvIRMk7YuajVWWtTHJn1BMlb+qTGeD18dVYwFxeH3B3ckLRwR4acP17VKw==",
+              "requires": {
+                "@defichain/jellyfish-json": "2.22.0"
+              }
+            },
+            "@defichain/jellyfish-api-jsonrpc": {
+              "version": "2.22.0",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.22.0.tgz",
+              "integrity": "sha512-L/qcJVB0wIJU+02WOKosiqXlpTkuW2sHerWmJSnEbG13HmpuiXZ8uj50Ms3Pq/EC/1LWalMIL15JblIG2xxK2Q==",
+              "requires": {
+                "@defichain/jellyfish-api-core": "2.22.0",
+                "abort-controller": "^3.0.0",
+                "cross-fetch": "^3.1.5"
+              }
+            }
+          }
+        },
         "@nestjs/common": {
           "version": "8.3.1",
           "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.3.1.tgz",
@@ -27895,6 +27936,12 @@
             "@typescript-eslint/types": "5.12.1",
             "eslint-visitor-keys": "^3.0.0"
           }
+        },
+        "defichain": {
+          "version": "2.22.0",
+          "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.22.0.tgz",
+          "integrity": "sha512-Jf9f3E9HBcp0nIGFiAyMp/lPztTpTRSH6k1gReMZRzZ58wDPj7Z3yIrXEB6DSx5tyD+Ma596BDUljg+inQcPJg==",
+          "peer": true
         },
         "eslint-visitor-keys": {
           "version": "3.3.0",
@@ -28911,53 +28958,6 @@
               }
             }
           }
-        }
-      }
-    },
-    "@defichain/whale-api-client": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.23.2.tgz",
-      "integrity": "sha512-rs6S+EYKqAEVzRyQUKqUp9hyYO8O9ybEqa3HWZkHefmFwDbSTEfeGb4o6lBB/iOPLsFzF5wMFFEVM1hZsG/fyg==",
-      "requires": {
-        "@defichain/jellyfish-api-jsonrpc": "^2.18.3",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.5",
-        "url-search-params-polyfill": "8.1.1"
-      },
-      "dependencies": {
-        "@defichain/jellyfish-api-core": {
-          "version": "2.18.3",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.18.3.tgz",
-          "integrity": "sha512-22tdkG+Q1IbmfgGVrqMGEfLXAbJiyXJNucc+WIfauhb7YJbHrQxKkf9TZyA5HCRQ04FVzp8VMrGh9Z3Mb0D8Pg==",
-          "requires": {
-            "@defichain/jellyfish-json": "2.18.3"
-          }
-        },
-        "@defichain/jellyfish-api-jsonrpc": {
-          "version": "2.18.3",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.18.3.tgz",
-          "integrity": "sha512-tvBqDcakTtSU725fk2tVfxX7boxx3U6I23DLxr4qrZ+7lhfMeXtagPc4JB2hT7EEqsOCAHFUC92rO/nir2Fq7g==",
-          "requires": {
-            "@defichain/jellyfish-api-core": "2.18.3",
-            "abort-controller": "^3.0.0",
-            "cross-fetch": "^3.1.5"
-          }
-        },
-        "@defichain/jellyfish-json": {
-          "version": "2.18.3",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.18.3.tgz",
-          "integrity": "sha512-oXxcgxYRMEoB2HnZd07p6iSG757oBqIf0LXugmtSZTm+hQjG/Wjr6wtXSM4u/004vBBAxpld4SjT29NEJ6MHIQ==",
-          "requires": {
-            "@types/lossless-json": "^1.0.1",
-            "bignumber.js": "^9.0.2",
-            "lossless-json": "^1.0.5"
-          }
-        },
-        "defichain": {
-          "version": "2.18.3",
-          "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.18.3.tgz",
-          "integrity": "sha512-DI6UIAVgOXyYNrIGbSh6pjUo1VvxLXhD0iVC1nqw9aUuTIJ5ygWstHBmFX2TXXAIY8ZPMKKJdVC+HAAezfmRsw==",
-          "peer": true
         }
       }
     },
@@ -36017,7 +36017,7 @@
             "@defichain/jellyfish-testing": "^0.0.0",
             "@defichain/ocean-api-client": "^0.0.0",
             "@defichain/playground": "^0.0.0",
-            "@defichain/whale-api-client": "0.23.2",
+            "@defichain/whale-api-client": "0.26.2",
             "@nestjs/cli": "^8.0.0",
             "@nestjs/common": "^8.2.6",
             "@nestjs/config": "^1.2.0",
@@ -36051,6 +36051,47 @@
             "typeorm": "^0.2.43"
           },
           "dependencies": {
+            "@defichain/jellyfish-json": {
+              "version": "2.22.0",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.22.0.tgz",
+              "integrity": "sha512-3CsoK2VrOOw1W/lvheIe0+0ZpE4qmhtMTx4OzQz9Et6l+iNkIyIoZAsxl4ErdEvjofwlYn3kBvefvaf5KfgxLg==",
+              "requires": {
+                "@types/lossless-json": "^1.0.1",
+                "bignumber.js": "^9.0.2",
+                "lossless-json": "^1.0.5"
+              }
+            },
+            "@defichain/whale-api-client": {
+              "version": "0.26.2",
+              "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
+              "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
+              "requires": {
+                "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
+                "abort-controller": "^3.0.0",
+                "cross-fetch": "^3.1.5",
+                "url-search-params-polyfill": "8.1.1"
+              },
+              "dependencies": {
+                "@defichain/jellyfish-api-core": {
+                  "version": "2.22.0",
+                  "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.22.0.tgz",
+                  "integrity": "sha512-8rSP6t2N9Dq0+218vWvEKDQpYhcOSvIRMk7YuajVWWtTHJn1BMlb+qTGeD18dVYwFxeH3B3ckLRwR4acP17VKw==",
+                  "requires": {
+                    "@defichain/jellyfish-json": "2.22.0"
+                  }
+                },
+                "@defichain/jellyfish-api-jsonrpc": {
+                  "version": "2.22.0",
+                  "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.22.0.tgz",
+                  "integrity": "sha512-L/qcJVB0wIJU+02WOKosiqXlpTkuW2sHerWmJSnEbG13HmpuiXZ8uj50Ms3Pq/EC/1LWalMIL15JblIG2xxK2Q==",
+                  "requires": {
+                    "@defichain/jellyfish-api-core": "2.22.0",
+                    "abort-controller": "^3.0.0",
+                    "cross-fetch": "^3.1.5"
+                  }
+                }
+              }
+            },
             "@nestjs/common": {
               "version": "8.3.1",
               "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.3.1.tgz",
@@ -36236,6 +36277,12 @@
                 "@typescript-eslint/types": "5.12.1",
                 "eslint-visitor-keys": "^3.0.0"
               }
+            },
+            "defichain": {
+              "version": "2.22.0",
+              "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.22.0.tgz",
+              "integrity": "sha512-Jf9f3E9HBcp0nIGFiAyMp/lPztTpTRSH6k1gReMZRzZ58wDPj7Z3yIrXEB6DSx5tyD+Ma596BDUljg+inQcPJg==",
+              "peer": true
             },
             "eslint-visitor-keys": {
               "version": "3.3.0",
@@ -37252,53 +37299,6 @@
                   }
                 }
               }
-            }
-          }
-        },
-        "@defichain/whale-api-client": {
-          "version": "0.23.2",
-          "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.23.2.tgz",
-          "integrity": "sha512-rs6S+EYKqAEVzRyQUKqUp9hyYO8O9ybEqa3HWZkHefmFwDbSTEfeGb4o6lBB/iOPLsFzF5wMFFEVM1hZsG/fyg==",
-          "requires": {
-            "@defichain/jellyfish-api-jsonrpc": "^2.18.3",
-            "abort-controller": "^3.0.0",
-            "cross-fetch": "^3.1.5",
-            "url-search-params-polyfill": "8.1.1"
-          },
-          "dependencies": {
-            "@defichain/jellyfish-api-core": {
-              "version": "2.18.3",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.18.3.tgz",
-              "integrity": "sha512-22tdkG+Q1IbmfgGVrqMGEfLXAbJiyXJNucc+WIfauhb7YJbHrQxKkf9TZyA5HCRQ04FVzp8VMrGh9Z3Mb0D8Pg==",
-              "requires": {
-                "@defichain/jellyfish-json": "2.18.3"
-              }
-            },
-            "@defichain/jellyfish-api-jsonrpc": {
-              "version": "2.18.3",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.18.3.tgz",
-              "integrity": "sha512-tvBqDcakTtSU725fk2tVfxX7boxx3U6I23DLxr4qrZ+7lhfMeXtagPc4JB2hT7EEqsOCAHFUC92rO/nir2Fq7g==",
-              "requires": {
-                "@defichain/jellyfish-api-core": "2.18.3",
-                "abort-controller": "^3.0.0",
-                "cross-fetch": "^3.1.5"
-              }
-            },
-            "@defichain/jellyfish-json": {
-              "version": "2.18.3",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.18.3.tgz",
-              "integrity": "sha512-oXxcgxYRMEoB2HnZd07p6iSG757oBqIf0LXugmtSZTm+hQjG/Wjr6wtXSM4u/004vBBAxpld4SjT29NEJ6MHIQ==",
-              "requires": {
-                "@types/lossless-json": "^1.0.1",
-                "bignumber.js": "^9.0.2",
-                "lossless-json": "^1.0.5"
-              }
-            },
-            "defichain": {
-              "version": "2.18.3",
-              "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.18.3.tgz",
-              "integrity": "sha512-DI6UIAVgOXyYNrIGbSh6pjUo1VvxLXhD0iVC1nqw9aUuTIJ5ygWstHBmFX2TXXAIY8ZPMKKJdVC+HAAezfmRsw==",
-              "peer": true
             }
           }
         },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Adds `_actuator/probes/...` health check similar to Ocean API's

#### Which issue(s) does this PR fixes?:
Fixes #1060

#### Additional comments?:
- Importing code directly from `apps/ocean-api` into `apps/legacy-api` causes some weirdness with Nest, hence duplicating the code is necessary at this stage --> refactoring work at #1078
