### PR TITLE
chore(ocean-api): temporary disable docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,24 +62,25 @@ jobs:
       - run: npm ci
       - run: npx --no-install eslint .
 
-  docker-buildx:
-    name: Docker Buildx
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [ linux/amd64, linux/arm64 ]
-        app: [ legacy-api, ocean-api ]
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
+  # TODO(kodemon): Re-enable in subsequent docker PRs
+  # docker-buildx:
+  #   name: Docker Buildx
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       platform: [ linux/amd64, linux/arm64 ]
+  #       app: [ legacy-api, ocean-api ]
+  #   steps:
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25
 
-      - name: Build platforms
-        uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
-        with:
-          push: false
-          build-args: APP=${{ matrix.app }}
-          platforms: ${{ matrix.platform }}
-          tags: ghcr.io/defich/${{ matrix.app }}:latest
+  #     - name: Build platforms
+  #       uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
+  #       with:
+  #         push: false
+  #         build-args: APP=${{ matrix.app }}
+  #         platforms: ${{ matrix.platform }}
+  #         tags: ghcr.io/defich/${{ matrix.app }}:latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Workflow addition in #1070 is bloating our build times up to 1 hour because of slow arm64 builds. This disables the workflow temporarily until we have a final solution for our docker release and sanity flow to keep our current build processes snappy.

#### Additional comments?:

Will re-enable a version of this with #943
