### PR TITLE
fix(apps/legacy-api): reject with 404 for queries with invalid network url param

### DIFF
--- a/apps/legacy-api/__tests__/controllers/NetworkParamValidation.test.ts
+++ b/apps/legacy-api/__tests__/controllers/NetworkParamValidation.test.ts
@@ -1,0 +1,38 @@
+import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
+
+const apiTesting = LegacyApiTesting.create()
+
+describe('NetworkParamValidation', () => {
+  beforeAll(async () => {
+    await apiTesting.start()
+  })
+
+  afterAll(async () => {
+    await apiTesting.stop()
+  })
+
+  it('all registered routes are guarded against invalid network param', async () => {
+    // dummy call to trigger fastify hooks so that all routes are registered
+    await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1'
+    }).catch()
+
+    const routes = apiTesting.getAllRoutes()
+    for (const { url } of routes) {
+      if (url === '*') {
+        continue
+      }
+
+      const result = await apiTesting.app.inject({
+        method: 'GET',
+        url: url + '?network=abc' // Query with some invalid network
+      })
+
+      expect(result.json()).toStrictEqual({
+        message: 'Not Found',
+        statusCode: 404
+      })
+    }
+  })
+})

--- a/apps/legacy-api/__tests__/providers/WhaleApiClientProvider.test.ts
+++ b/apps/legacy-api/__tests__/providers/WhaleApiClientProvider.test.ts
@@ -25,21 +25,12 @@ describe('WhaleApiClientProvider', () => {
       expect(first === second) // points to the same object
         .toStrictEqual(true)
     }
-    {
-      const first = whaleApiClientProvider.getClient('regtest')
-      const second = whaleApiClientProvider.getClient('regtest')
-      expect(first === second) // points to the same object
-        .toStrictEqual(true)
-    }
   })
 
   it('should return different clients for different networks', () => {
     const mainnet = whaleApiClientProvider.getClient('mainnet')
     const testnet = whaleApiClientProvider.getClient('testnet')
-    const regtest = whaleApiClientProvider.getClient('regtest')
 
     expect(mainnet).not.toStrictEqual(testnet)
-    expect(mainnet).not.toStrictEqual(regtest)
-    expect(testnet).not.toStrictEqual(regtest)
   })
 })

--- a/apps/legacy-api/src/common/networks.ts
+++ b/apps/legacy-api/src/common/networks.ts
@@ -1,0 +1,1 @@
+export type SupportedNetwork = 'mainnet' | 'testnet'

--- a/apps/legacy-api/src/common/networks.ts
+++ b/apps/legacy-api/src/common/networks.ts
@@ -1,1 +1,0 @@
-export type SupportedNetwork = 'mainnet' | 'testnet'

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,8 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
-import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
-import { SupportedNetwork } from '../common/networks'
+import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 
 @Controller('v1')
 export class MiscController {

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
+import { NetworkName } from '@defichain/jellyfish-network'
+import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
 
 @Controller('v1')
 export class MiscController {
@@ -8,7 +10,7 @@ export class MiscController {
 
   @Get('getblockcount')
   async getToken (
-    @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet'
+    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet'
   ): Promise<{ [key: string]: Number }> {
     const api = this.whaleApiClientProvider.getClient(network)
 

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,8 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
-import { NetworkName } from '@defichain/jellyfish-network'
 import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
+import { SupportedNetwork } from '../common/networks'
 
 @Controller('v1')
 export class MiscController {
@@ -10,7 +10,7 @@ export class MiscController {
 
   @Get('getblockcount')
   async getToken (
-    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet'
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet'
   ): Promise<{ [key: string]: Number }> {
     const api = this.whaleApiClientProvider.getClient(network)
 

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -1,8 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
-import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
-import { SupportedNetwork } from '../common/networks'
+import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 
 @Controller('v1')
 export class PoolPairController {

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
+import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
+import { NetworkName } from '@defichain/jellyfish-network'
 
 @Controller('v1')
 export class PoolPairController {
@@ -8,7 +10,7 @@ export class PoolPairController {
 
   @Get('getpoolpair')
   async getToken (
-    @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
     @Query('id') poolPairId: string
   ): Promise<LegacyPoolPairData> {
     const api = this.whaleApiClientProvider.getClient(network)
@@ -18,7 +20,7 @@ export class PoolPairController {
 
   @Get('listpoolpairs')
   async listPoolPairs (
-    @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet'
+    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet'
   ): Promise<{ [key: string]: LegacyPoolPairData }> {
     const api = this.whaleApiClientProvider.getClient(network)
 

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Query } from '@nestjs/common'
 import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
-import { NetworkName } from '@defichain/jellyfish-network'
+import { SupportedNetwork } from '../common/networks'
 
 @Controller('v1')
 export class PoolPairController {
@@ -10,7 +10,7 @@ export class PoolPairController {
 
   @Get('getpoolpair')
   async getToken (
-    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
     @Query('id') poolPairId: string
   ): Promise<LegacyPoolPairData> {
     const api = this.whaleApiClientProvider.getClient(network)
@@ -20,7 +20,7 @@ export class PoolPairController {
 
   @Get('listpoolpairs')
   async listPoolPairs (
-    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet'
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet'
   ): Promise<{ [key: string]: LegacyPoolPairData }> {
     const api = this.whaleApiClientProvider.getClient(network)
 

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
+import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
+import { NetworkName } from '@defichain/jellyfish-network'
 
 @Controller('v1')
 export class TokenController {
@@ -8,7 +10,7 @@ export class TokenController {
 
   @Get('gettoken')
   async getToken (
-    @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
     const api = this.whaleApiClientProvider.getClient(network)
@@ -21,7 +23,7 @@ export class TokenController {
 
   @Get('listtokens')
   async listTokens (
-    @Query('network') network: 'mainnet' | 'testnet' | 'regtest' = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
     const api = this.whaleApiClientProvider.getClient(network)

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -1,8 +1,7 @@
 import { Controller, Get, Query } from '@nestjs/common'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
-import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
-import { SupportedNetwork } from '../common/networks'
+import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 
 @Controller('v1')
 export class TokenController {

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Query } from '@nestjs/common'
 import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe } from '../pipes/NetworkValidationPipe'
-import { NetworkName } from '@defichain/jellyfish-network'
+import { SupportedNetwork } from '../common/networks'
 
 @Controller('v1')
 export class TokenController {
@@ -10,7 +10,7 @@ export class TokenController {
 
   @Get('gettoken')
   async getToken (
-    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
     const api = this.whaleApiClientProvider.getClient(network)
@@ -23,7 +23,7 @@ export class TokenController {
 
   @Get('listtokens')
   async listTokens (
-    @Query('network', NetworkValidationPipe) network: NetworkName = 'mainnet',
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
     @Query('id') tokenId: string
   ): Promise<{ [key: string]: LegacyTokenData }> {
     const api = this.whaleApiClientProvider.getClient(network)

--- a/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
+++ b/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
@@ -4,15 +4,14 @@ import {
   Injectable,
   PipeTransform
 } from '@nestjs/common'
-import { NetworkName } from '@defichain/jellyfish-network'
+import { SupportedNetwork } from '../common/networks'
 
 @Injectable()
 export class NetworkValidationPipe implements PipeTransform {
-  private static readonly VALID_NETWORKS: Set<undefined | NetworkName> = new Set([
+  private static readonly VALID_NETWORKS: Set<undefined | SupportedNetwork> = new Set([
     undefined, // defaults to 'mainnet'
     'mainnet',
-    'testnet',
-    'regtest'
+    'testnet'
   ])
 
   transform (value: any, metadata: ArgumentMetadata): any {

--- a/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
+++ b/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
@@ -1,0 +1,33 @@
+import {
+  ArgumentMetadata,
+  HttpException,
+  Injectable,
+  PipeTransform
+} from '@nestjs/common'
+import { NetworkName } from '@defichain/jellyfish-network'
+
+@Injectable()
+export class NetworkValidationPipe implements PipeTransform {
+  private static readonly VALID_NETWORKS: Set<undefined | NetworkName> = new Set([
+    undefined, // defaults to 'mainnet'
+    'mainnet',
+    'testnet',
+    'regtest'
+  ])
+
+  transform (value: any, metadata: ArgumentMetadata): any {
+    if (NetworkValidationPipe.VALID_NETWORKS.has(value)) {
+      return value
+    }
+    throw new InvalidNetworkException()
+  }
+}
+
+export class InvalidNetworkException extends HttpException {
+  constructor () {
+    super({
+      statusCode: 404,
+      message: 'Not Found'
+    }, 404)
+  }
+}

--- a/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
+++ b/apps/legacy-api/src/pipes/NetworkValidationPipe.ts
@@ -4,7 +4,8 @@ import {
   Injectable,
   PipeTransform
 } from '@nestjs/common'
-import { SupportedNetwork } from '../common/networks'
+
+export type SupportedNetwork = 'mainnet' | 'testnet'
 
 @Injectable()
 export class NetworkValidationPipe implements PipeTransform {

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -1,16 +1,16 @@
 import { WhaleApiClient } from '@defichain/whale-api-client'
 import { Injectable } from '@nestjs/common'
-import { NetworkName } from '@defichain/jellyfish-network'
+import { SupportedNetwork } from '../common/networks'
 
 @Injectable()
 export class WhaleApiClientProvider {
-  private readonly clientCacheByNetwork: Map<NetworkName, WhaleApiClient> = new Map()
+  private readonly clientCacheByNetwork: Map<SupportedNetwork, WhaleApiClient> = new Map()
 
   /**
    * Lazily initialises WhaleApiClients and caches them by network for performance.
    * @param network - the network to connect to
    */
-  getClient (network: NetworkName): WhaleApiClient {
+  getClient (network: SupportedNetwork): WhaleApiClient {
     const client = this.clientCacheByNetwork.get(network)
     if (client !== undefined) {
       return client
@@ -18,7 +18,7 @@ export class WhaleApiClientProvider {
     return this.createAndCacheClient(network)
   }
 
-  private createAndCacheClient (network: NetworkName): WhaleApiClient {
+  private createAndCacheClient (network: SupportedNetwork): WhaleApiClient {
     const client = new WhaleApiClient({
       version: 'v0',
       network: network,

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -1,17 +1,16 @@
 import { WhaleApiClient } from '@defichain/whale-api-client'
 import { Injectable } from '@nestjs/common'
-
-type Network = 'mainnet' | 'testnet' | 'regtest'
+import { NetworkName } from '@defichain/jellyfish-network'
 
 @Injectable()
 export class WhaleApiClientProvider {
-  private readonly clientCacheByNetwork: Map<Network, WhaleApiClient> = new Map()
+  private readonly clientCacheByNetwork: Map<NetworkName, WhaleApiClient> = new Map()
 
   /**
    * Lazily initialises WhaleApiClients and caches them by network for performance.
    * @param network - the network to connect to
    */
-  getClient (network: Network): WhaleApiClient {
+  getClient (network: NetworkName): WhaleApiClient {
     const client = this.clientCacheByNetwork.get(network)
     if (client !== undefined) {
       return client
@@ -19,7 +18,7 @@ export class WhaleApiClientProvider {
     return this.createAndCacheClient(network)
   }
 
-  private createAndCacheClient (network: Network): WhaleApiClient {
+  private createAndCacheClient (network: NetworkName): WhaleApiClient {
     const client = new WhaleApiClient({
       version: 'v0',
       network: network,

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -1,6 +1,6 @@
 import { WhaleApiClient } from '@defichain/whale-api-client'
 import { Injectable } from '@nestjs/common'
-import { SupportedNetwork } from '../common/networks'
+import { SupportedNetwork } from '../pipes/NetworkValidationPipe'
 
 @Injectable()
 export class WhaleApiClientProvider {

--- a/apps/legacy-api/testing/LegacyApiTesting.ts
+++ b/apps/legacy-api/testing/LegacyApiTesting.ts
@@ -1,4 +1,4 @@
-import { LegacyStubServer } from './LegacyStubServer'
+import { LegacyStubServer, RegisteredRoute } from './LegacyStubServer'
 import { NestFastifyApplication } from '@nestjs/platform-fastify'
 import { InjectOptions, Response as LightMyRequestResponse } from 'light-my-request'
 
@@ -50,5 +50,9 @@ export class LegacyApiTesting {
     } catch (err) {
       console.error(err)
     }
+  }
+
+  getAllRoutes (): RegisteredRoute[] {
+    return this.stubServer.getAllRoutes()
   }
 }

--- a/apps/legacy-api/testing/LegacyStubServer.ts
+++ b/apps/legacy-api/testing/LegacyStubServer.ts
@@ -8,6 +8,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config'
  * Service stubs are simulations of a real service, which are used for functional testing.
  */
 export class LegacyStubServer extends RootServer {
+  private readonly allRoutes: RegisteredRoute[] = []
+
   async create (): Promise<NestFastifyApplication> {
     const module = await Test.createTestingModule({
       imports: [
@@ -21,10 +23,36 @@ export class LegacyStubServer extends RootServer {
     const adapter = new FastifyAdapter({
       logger: false
     })
-    return module.createNestApplication<NestFastifyApplication>(adapter)
+    const app = module.createNestApplication<NestFastifyApplication>(adapter)
+    this.recordAllRegisteredRoutes(app)
+    return app
   }
 
   async init (app: NestFastifyApplication, config: ConfigService): Promise<void> {
     await app.init()
   }
+
+  /**
+   * Helper to get all the registered routes for testing purposes
+   */
+  getAllRoutes (): RegisteredRoute[] {
+    return this.allRoutes
+  }
+
+  private recordAllRegisteredRoutes (app: NestFastifyApplication): void {
+    app.getHttpAdapter()
+      .getInstance()
+      .addHook('onRoute', (opts: RegisteredRoute) => {
+        this.allRoutes.push(opts)
+      })
+  }
+}
+
+// See https://www.fastify.io/docs/latest/Reference/Hooks/#onroute
+export interface RegisteredRoute {
+  method: string
+  url: string // the complete URL of the route, it will include the prefix if any
+  path: string // `url` alias
+  routePath: string // the URL of the route without the prefix
+  prefix: string
 }

--- a/apps/legacy-api/testing/LegacyStubServer.ts
+++ b/apps/legacy-api/testing/LegacyStubServer.ts
@@ -48,7 +48,9 @@ export class LegacyStubServer extends RootServer {
   }
 }
 
-// See https://www.fastify.io/docs/latest/Reference/Hooks/#onroute
+/**
+ * @see https://www.fastify.io/docs/latest/Reference/Hooks/#onroute
+ */
 export interface RegisteredRoute {
   method: string
   url: string // the complete URL of the route, it will include the prefix if any


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- Since WhaleApiClientProvider caches clients by network, currently it naively creates new clients based on the 'network' param. 
- Potential memory issues if the endpoints are spammed with invalid networks - the cache will get filled with clients that will never be cleared
- Solution: reject all invalid `network` values, as the WhaleApiClient doesn't validate the network value when instantiated. The only way it _detects_ an invalid network is when it tries to make the request and fails.

#### Additional comments?:
- Added a test to guard all registered routes in `legacy-api`
- Also refactored `'mainnet' | 'testnet' | 'regtest'` to use `NetworkName`
