### PR TITLE
feat(apps/legacy-api): Legacy API - validateaddress and getgov

### DIFF
--- a/apps/legacy-api/__tests__/controllers/MiscController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/MiscController.test.ts
@@ -10,13 +10,82 @@ afterAll(async () => {
   await apiTesting.stop()
 })
 
-it('/v1/getblockcount', async () => {
-  const res = await apiTesting.app.inject({
-    method: 'GET',
-    url: '/v1/getblockcount'
+describe('MiscController', () => {
+  it('/v1/getblockcount', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getblockcount'
+    })
+
+    expect(res.json()).toStrictEqual({
+      data: expect.any(Number)
+    })
   })
 
-  expect(res.json()).toStrictEqual({
-    data: expect.any(Number)
+  it('/v1/validateaddress - valid address', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/validateaddress?address=8VPSYCX6K2svJFM1994jF46iAo982AP7mM'
+    })
+
+    expect(res.json()).toStrictEqual({
+      data: {
+        address: '8VPSYCX6K2svJFM1994jF46iAo982AP7mM',
+        isscript: false,
+        isvalid: true,
+        iswitness: false,
+        scriptPubKey: '76a9149ce50f2da09678b80b8a5bf3898ae4f2a010b15188ac'
+      }
+    })
+  })
+
+  it('/v1/validateaddress - invalid address', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/validateaddress?address=abcdefg'
+    })
+
+    expect(res.json()).toStrictEqual({
+      data: {
+        isvalid: false
+      }
+    })
+  })
+
+  it('/v1/getgov?name=LP_DAILY_DFI_REWARD - valid', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getgov?name=LP_DAILY_DFI_REWARD'
+    })
+
+    expect(res.json()).toStrictEqual({
+      LP_DAILY_DFI_REWARD: expect.any(String)
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/v1/getgov?name=LP_SPLITS - valid', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getgov?name=LP_SPLITS'
+    })
+
+    expect(res.json()).toStrictEqual({
+      LP_SPLITS: expect.any(Object)
+    })
+    expect(res.statusCode).toStrictEqual(200)
+  })
+
+  it('/v1/getgov - invalid name', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getgov?name=abc'
+    })
+
+    expect(res.json()).toStrictEqual({
+      statusCode: 404,
+      message: 'Not Found'
+    })
+    expect(res.statusCode).toStrictEqual(404)
   })
 })

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,11 +1,13 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { Controller, Get, NotFoundException, Query } from '@nestjs/common'
 import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
+import { ValidateAddressResult } from '@defichain/jellyfish-api-core/src/category/wallet'
 
 @Controller('v1')
 export class MiscController {
-  constructor (private readonly whaleApiClientProvider: WhaleApiClientProvider) {}
+  constructor (private readonly whaleApiClientProvider: WhaleApiClientProvider) {
+  }
 
   @Get('getblockcount')
   async getToken (
@@ -17,5 +19,42 @@ export class MiscController {
     return {
       data: data.count.blocks
     }
+  }
+
+  @Get('validateaddress')
+  async validateAddress (
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
+    @Query('address') address: string
+  ): Promise<{ data: Partial<ValidateAddressResult> }> {
+    const api = this.whaleApiClientProvider.getClient(network)
+    const rpcResult = await api.rpc.call<ValidateAddressResult>('validateaddress', [address], 'number')
+
+    const response: Partial<ValidateAddressResult> = { isvalid: rpcResult.isvalid }
+    if (rpcResult.isvalid) {
+      response.isvalid = rpcResult.isvalid
+      response.address = rpcResult.address
+      response.scriptPubKey = rpcResult.scriptPubKey
+      response.isscript = rpcResult.isscript
+      response.iswitness = rpcResult.iswitness
+    }
+
+    return { data: response }
+  }
+
+  @Get('getgov')
+  async getGov (
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
+    @Query('name') name: 'LP_DAILY_DFI_REWARD' | 'LP_SPLITS'
+  ): Promise<Record<string, any>> {
+    const api = this.whaleApiClientProvider.getClient(network)
+
+    if (name !== 'LP_DAILY_DFI_REWARD' && name !== 'LP_SPLITS') {
+      throw new NotFoundException()
+    }
+
+    const rpcResult = await api.rpc.call<Record<string, any>>('getgov', [name], 'bignumber')
+
+    // e.g. { "LP_DAILY_DFI_REWARD": "123" }
+    return { [name]: rpcResult[name] }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Implementation of legacy-api to remap the legacy API:
- https://api.defichain.com/v1/validateaddress
- https://api.defichain.com/v1/getgov

#### Which issue(s) does this PR fixes?:
Fixes part of #1024
