### PR TITLE
feat(jellyfish-testing):Add TestingWrapper as an abstraction layer

### DIFF
--- a/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
+++ b/packages/jellyfish-testing/__tests__/testingcontainer.test.ts
@@ -1,0 +1,128 @@
+import { NonMNTesting, Testing } from '@defichain/jellyfish-testing'
+import { RegTestContainer, StartFlags } from '@defichain/testcontainers'
+import { TestingWrapper } from '../src/testingwrapper'
+
+describe('create a single test container using testwrapper', () => {
+  let testing: Testing | NonMNTesting
+
+  afterEach(async () => {
+    await testing.container.stop()
+  })
+
+  it('should be able to create and call single regtest masternoderegtest container', async () => {
+    testing = TestingWrapper.create()
+    await testing.container.start()
+
+    // call rpc
+    let blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+    await testing.generate(1)
+    blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(1)
+  })
+
+  it('should be able to create regtest non masternode container', async () => {
+    testing = TestingWrapper.createNonMN()
+    await testing.container.start()
+
+    // call rpc
+    const blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    const addr = await testing.generateAddress()
+    const promise = testing.container.call('generatetoaddress', [1, addr, 1])
+
+    await expect(promise).rejects.toThrow('Error: I am not masternode operator')
+  })
+
+  it('should be able to override start option', async () => {
+    testing = TestingWrapper.create()
+    const startFlags: StartFlags[] = [{ name: 'fortcanninghillheight', value: 11 }]
+    await testing.container.start({ startFlags })
+
+    const { softforks } = await testing.rpc.blockchain.getBlockchainInfo()
+    // eslint-disable-next-line @typescript-eslint/dot-notation
+    expect(softforks['fortcanninghill'].height).toStrictEqual(11)
+  })
+
+  it('should create 1 testing instance even if 0 is passed in as a param', async () => {
+    testing = TestingWrapper.createNonMN(0, () => new RegTestContainer())
+    await testing.container.start()
+
+    // call rpc
+    const blockHeight = await testing.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+  })
+})
+
+describe('create multiple test container using testwrapper', () => {
+  it('should create a masternode group and test sync block and able to add and sync non masternode container', async () => {
+    const tGroup = TestingWrapper.create(2)
+    await tGroup.start()
+
+    const alice = tGroup.get(0)
+    let blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    const bob = tGroup.get(1)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(0)
+
+    await alice.generate(10)
+    await tGroup.waitForSync()
+
+    blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(10)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(10)
+
+    let blockHashAlice = await alice.rpc.blockchain.getBestBlockHash()
+    let blockHashBob = await alice.rpc.blockchain.getBestBlockHash()
+    expect(blockHashAlice).toStrictEqual(blockHashBob)
+
+    await bob.generate(10)
+    await tGroup.waitForSync()
+
+    blockHeight = await alice.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+    blockHeight = await bob.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+
+    blockHashAlice = await alice.rpc.blockchain.getBestBlockHash()
+    blockHashBob = await alice.rpc.blockchain.getBestBlockHash()
+    expect(blockHashAlice).toStrictEqual(blockHashBob)
+
+    // create a non masternode RegTestTesting
+    const nonMasternodeTesting = TestingWrapper.createNonMN()
+    await nonMasternodeTesting.container.start()
+
+    // add to group
+    await tGroup.addNonMNTesting(nonMasternodeTesting)
+    await tGroup.waitForSync()
+    blockHeight = await nonMasternodeTesting.rpc.blockchain.getBlockCount()
+    expect(blockHeight).toStrictEqual(20)
+    const blockHashNonMasternode = await nonMasternodeTesting.rpc.blockchain.getBestBlockHash()
+    expect(blockHashNonMasternode).toStrictEqual(blockHashAlice)
+
+    await tGroup.stop()
+  })
+
+  it('should be able to create individual container of masternode and regtest and create a group from it', async () => {
+    const masternodeTesting = TestingWrapper.create()
+    await masternodeTesting.container.start()
+    const nonmasternodeTesting = TestingWrapper.createNonMN(1)
+    await nonmasternodeTesting.container.start()
+
+    const tGroup = TestingWrapper.group([masternodeTesting], [nonmasternodeTesting])
+    await tGroup.start()
+
+    await masternodeTesting.container.generate(1)
+    await tGroup.waitForSync()
+
+    const masternodeBestHash = await masternodeTesting.rpc.blockchain.getBestBlockHash()
+    const nonMasternodeBestHash = await nonmasternodeTesting.rpc.blockchain.getBestBlockHash()
+    expect(masternodeBestHash).toStrictEqual(nonMasternodeBestHash)
+
+    await tGroup.stop()
+  })
+})

--- a/packages/jellyfish-testing/src/testingwrapper.ts
+++ b/packages/jellyfish-testing/src/testingwrapper.ts
@@ -1,0 +1,57 @@
+import { RegTestFoundationKeys } from '@defichain/jellyfish-network'
+import { ContainerGroup, MasterNodeRegTestContainer, RegTestContainer } from '@defichain/testcontainers'
+import { Testing, TestingGroup, NonMNTesting } from '.'
+
+type InitMNRegContainerFn = (index: number) => MasterNodeRegTestContainer
+function defaultInitMNRegContainer (index: number): MasterNodeRegTestContainer {
+  return new MasterNodeRegTestContainer(RegTestFoundationKeys[index])
+}
+
+type InitNonMNRegContainerFn = (index: number) => RegTestContainer
+function defaultInitNonMNRegContainer (index: number): RegTestContainer {
+  return new RegTestContainer()
+}
+export const TestingWrapper = new (class TestingWrapperFactory {
+  create (): Testing
+  create (n: 0 | 1): Testing
+  create (n: number): TestingGroup
+  create (n: 0 | 1, init: InitMNRegContainerFn): Testing
+  create (n: number, init: InitMNRegContainerFn): TestingGroup
+
+  create (n?: number, init: InitMNRegContainerFn = defaultInitMNRegContainer): Testing | TestingGroup {
+    if (n === undefined || n <= 1) {
+      return Testing.create(init(0))
+    }
+
+    return TestingGroup.create(n, init)
+  }
+
+  createNonMN (): NonMNTesting
+  createNonMN (n: 0 | 1): NonMNTesting
+  createNonMN (n: number): TestingGroup
+  createNonMN (n: 0 | 1, init: InitNonMNRegContainerFn): NonMNTesting
+  createNonMN (n: number, init: InitNonMNRegContainerFn): TestingGroup
+
+  createNonMN (n?: number, init: InitNonMNRegContainerFn = defaultInitNonMNRegContainer): NonMNTesting | TestingGroup {
+    if (n === undefined || n <= 1) {
+      return NonMNTesting.create(init(0))
+    }
+
+    return TestingGroup.create(n, init)
+  }
+
+  group (testings: Testing[], nonMNTestings: NonMNTesting[]): TestingGroup {
+    const containers: RegTestContainer[] = []
+
+    testings.forEach(testing => {
+      containers.push(testing.container)
+    })
+
+    nonMNTestings.forEach(nonMNTesting => {
+      containers.push(nonMNTesting.container)
+    })
+
+    const group = new ContainerGroup(containers)
+    return TestingGroup.createFrom(group, testings, nonMNTestings)
+  }
+})()


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Tries a different approach to address https://github.com/DeFiCh/jellyfish/issues/637 and https://github.com/DeFiCh/jellyfish/issues/965 instead of #1035

Here we introduce  `TestingWrapper` class to create a new layer of abstraction with the goal of being able to create a test /testGroup instance in a standardized manner.
creating a new layer seems to introduce the least amount of changes to existing use cases

Also adds the capability to add NonMasternode RegTestContainers to the tests. For this, `NonMNTesting` class has been introduced.

Again this is not the most perfect way to do this. But given the restrictions discussed here -> https://github.com/DeFiCh/jellyfish/pull/1035#discussion_r808761851, this way seems not ugly and at the same time serves the purpose.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/DeFiCh/jellyfish/issues/637
Fixes https://github.com/DeFiCh/jellyfish/issues/965

#### Additional comments?:
