### PR TITLE
chore(workflow): add default jest run config for IDEA IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 !.idea/*.iml
 !.idea/README.md
 
+!.idea/.run/
+.idea/.run/*
+!.idea/.run/run-all-jest-tests-from-proj-root.run.xml
+
 # Yarn
 .yarn/*
 !.yarn/patches

--- a/.idea/.run/run-all-jest-tests-from-proj-root.run.xml
+++ b/.idea/.run/run-all-jest-tests-from-proj-root.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+    <configuration default="true" name="run-all-jest-tests-from-proj-root" type="JavaScriptTestRunnerJest">
+        <config-file value="$PROJECT_DIR$/jest.config.js" />
+        <node-interpreter value="project" />
+        <node-options value="" />
+        <jest-package value="$PROJECT_DIR$/node_modules/jest" />
+        <working-dir value="$PROJECT_DIR$" />
+        <envs />
+        <scope-kind value="ALL" />
+        <method v="2" />
+    </configuration>
+</component>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Add default run config for IDEA IDEs to run jest tests from project root (when you click the play button on the test suite)
