### PR TITLE
feat(apps/legacy-api): getsubgraphswaps

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -114,3 +114,64 @@ it('/v1/listswaps', async () => {
     })
   }
 })
+
+describe('getsubgraphswaps', () => {
+  it('/v1/getsubgraphswaps', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps'
+    })
+
+    const response = res.json()
+
+    expect(response.data.swaps.length).toStrictEqual(100)
+
+    for (const swap of response.data.swaps) {
+      expect(swap).toStrictEqual({
+        id: expect.stringMatching(/[a-zA-Z0-9]{64}/),
+        pair: {
+          fromToken: {
+            decimals: 8,
+            symbol: expect.any(String),
+            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
+          },
+          toToken: {
+            decimals: 8,
+            symbol: expect.any(String),
+            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
+          }
+        },
+        timestamp: expect.stringMatching(/\d+/),
+        fromAmount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX),
+        toAmount: 'TODO' // TODO(eli-lim)
+      })
+    }
+  })
+
+  it('/v1/getsubgraphswaps?limit=3', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=3'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(3)
+  })
+
+  it('/v1/getsubgraphswaps?limit=-1', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=-1'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(0)
+  })
+
+  it('/v1/getsubgraphswaps?limit=101', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=101'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(100)
+  })
+})

--- a/apps/libs/utils/__tests__/tokenomics.test.ts
+++ b/apps/libs/utils/__tests__/tokenomics.test.ts
@@ -1,0 +1,128 @@
+import {
+  getUsdVolumesInTokens,
+  getVolumeD30InTokens,
+  getVolumeH24InTokens,
+  tokenPerUsd,
+  usdPerToken
+} from '../tokenomics'
+
+const EG_POOLPAIR = {
+  id: '4',
+  symbol: 'ETH-DFI',
+  displaySymbol: 'dETH-DFI',
+  name: 'Ether-Default Defi token',
+  status: true,
+  tokenA: {
+    symbol: 'ETH',
+    displaySymbol: 'dETH',
+    id: '1',
+    reserve: '12381.39595202',
+    blockCommission: '0'
+  },
+  tokenB: {
+    symbol: 'DFI',
+    displaySymbol: 'DFI',
+    id: '0',
+    reserve: '9515257.65041262',
+    blockCommission: '0'
+  },
+  priceRatio: {
+    ab: '0.00130121',
+    ba: '768.51250757'
+  },
+  commission: '0.002',
+  totalLiquidity: {
+    token: '342973.54270977',
+    usd: '64745242.17659580532292938112210697'
+  },
+  tradeEnabled: true,
+  ownerAddress: '8UAhRuUFCyFUHEPD7qvtj8Zy2HxF5HH5nb',
+  rewardPct: '0.14549',
+  creation: {
+    tx: '9827894c083b77938d13884f0404539daa054a818e0c5019afa1eeff0437a51b',
+    height: 466822
+  },
+  apr: {
+    reward: 0.5639641344943545,
+    commission: 0.015311352369549345,
+    total: 0.5792754868639037
+  },
+  volume: {
+    h24: 1357996.187969406,
+    d30: 48503079.01006337
+  }
+}
+
+describe('Convert volume USD amounts to token counts', () => {
+  it('getVolumesInTokens should return volumes in tokenA and tokenB', () => {
+    const result = getUsdVolumesInTokens(EG_POOLPAIR)
+
+    // ETH
+    expect([
+      result.volumeH24InTokenA.toFixed(8),
+      result.volumeD30InTokenA.toFixed(8)
+    ]).toStrictEqual([
+      '519.38607191', // ETH ~= 1357996.187969406 USD
+      '18550.73225235' // ETH ~= 48503079.01006337 USD
+    ])
+
+    // DFI
+    expect([
+      result.volumeH24InTokenB.toFixed(8),
+      result.volumeD30InTokenB.toFixed(8)
+    ]).toStrictEqual([
+      '399154.69252745', // DFI ~= 1357996.187969406 USD
+      '14256469.76067390' // DFI ~= 48503079.01006337 USD
+    ])
+  })
+
+  it('getVolumeH24InTokens() should convert volume.h24 (USD) to tokenA and tokenB counts', () => {
+    const result = getVolumeH24InTokens(EG_POOLPAIR)
+    expect([
+      result.volumeH24InTokenA.toFixed(8),
+      result.volumeH24InTokenB.toFixed(8)
+    ]).toStrictEqual([
+      '519.38607191',
+      '399154.69252745'
+    ])
+  })
+
+  it('getVolumeD30InTokens() should convert volume.d30 (USD) to tokenA and tokenB counts', () => {
+    const result = getVolumeD30InTokens(EG_POOLPAIR)
+    expect([
+      result.volumeD30InTokenA.toFixed(8),
+      result.volumeD30InTokenB.toFixed(8)
+    ]).toStrictEqual([
+      '18550.73225235',
+      '14256469.76067390'
+    ])
+  })
+})
+
+describe('USD-to-Token / Token-to-USD Conversion', () => {
+  it('usdPerToken() should derive USD price of tokens from poolpair data', () => {
+    const tokenAUsdPrice = usdPerToken(EG_POOLPAIR.tokenA.reserve, EG_POOLPAIR.totalLiquidity.usd)
+    const tokenBUsdPrice = usdPerToken(EG_POOLPAIR.tokenB.reserve, EG_POOLPAIR.totalLiquidity.usd)
+
+    expect([
+      tokenAUsdPrice.toFixed(8),
+      tokenBUsdPrice.toFixed(8)
+    ]).toStrictEqual([
+      '2614.61802964', // USD ~= 1 ETH
+      '3.40218019' // USD ~= 1 DFI
+    ])
+  })
+
+  it('tokenPerUsd() should convert 1 USD to token count from poolpair data', () => {
+    const tokenAUsdPrice = tokenPerUsd(EG_POOLPAIR.tokenA.reserve, EG_POOLPAIR.totalLiquidity.usd)
+    const tokenBUsdPrice = tokenPerUsd(EG_POOLPAIR.tokenB.reserve, EG_POOLPAIR.totalLiquidity.usd)
+
+    expect([
+      tokenAUsdPrice.toFixed(8),
+      tokenBUsdPrice.toFixed(8)
+    ]).toStrictEqual([
+      '0.00038247', // ETH ~= 1 USD
+      '0.29392917' // DFI ~= 1 USD
+    ])
+  })
+})

--- a/apps/libs/utils/tokenomics.ts
+++ b/apps/libs/utils/tokenomics.ts
@@ -1,0 +1,87 @@
+import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
+import BigNumber from 'bignumber.js'
+
+export function getUsdVolumesInTokens (
+  poolPair: PoolPairData
+): {
+    volumeD30InTokenA: BigNumber
+    volumeD30InTokenB: BigNumber
+    volumeH24InTokenB: BigNumber
+    volumeH24InTokenA: BigNumber
+  } {
+  return {
+    ...getVolumeD30InTokens(poolPair),
+    ...getVolumeH24InTokens(poolPair)
+  }
+}
+
+export function getVolumeH24InTokens (
+  poolPair: PoolPairData
+): { volumeH24InTokenB: BigNumber, volumeH24InTokenA: BigNumber } {
+  const volumeH24InUsd = new BigNumber(poolPair.volume?.h24 ?? 0)
+
+  // vol in token = vol in usd * (usd per 1 token)
+  const volumeH24InTokenA = volumeH24InUsd.times(
+    tokenPerUsd(
+      poolPair.tokenA.reserve,
+      poolPair.totalLiquidity.usd ?? 1
+    )
+  )
+  const volumeH24InTokenB = volumeH24InUsd.times(
+    tokenPerUsd(
+      poolPair.tokenB.reserve,
+      poolPair.totalLiquidity.usd ?? 1
+    )
+  )
+  // console.log(`${volumeH24InUsd} USD = ${volumeH24InTokenA} ${poolPair.tokenA.symbol}`)
+  // console.log(`${volumeH24InUsd} USD = ${volumeH24InTokenB} ${poolPair.tokenB.symbol}`)
+  return {
+    volumeH24InTokenA,
+    volumeH24InTokenB
+  }
+}
+
+export function getVolumeD30InTokens (
+  poolPair: PoolPairData
+): { volumeD30InTokenA: BigNumber, volumeD30InTokenB: BigNumber } {
+  const volumeD30InUsd = new BigNumber(poolPair.volume?.d30 ?? 0)
+
+  // vol in token = vol in usd * (usd per 1 token)
+  const volumeD30InTokenA = volumeD30InUsd.times(
+    tokenPerUsd(
+      poolPair.tokenA.reserve,
+      poolPair.totalLiquidity.usd ?? 1
+    )
+  )
+  const volumeD30InTokenB = volumeD30InUsd.times(
+    tokenPerUsd(
+      poolPair.tokenB.reserve,
+      poolPair.totalLiquidity.usd ?? 1
+    )
+  )
+  // console.log(`${volumeD30InUsd} USD = ${volumeD30InTokenA} ${poolPair.tokenA.symbol}`)
+  // console.log(`${volumeD30InUsd} USD = ${volumeD30InTokenB} ${poolPair.tokenB.symbol}`)
+  return {
+    volumeD30InTokenA,
+    volumeD30InTokenB
+  }
+}
+
+/**
+ * Derive from totalLiquidity in USD and token's reserve
+ * 1 BTC in USD = totalLiquidity.usd / 2(token.reserve)
+ */
+export function usdPerToken (
+  tokenReserve: string | number,
+  totalLiquidityInUsd: string | number
+): BigNumber {
+  return new BigNumber(totalLiquidityInUsd)
+    .div(new BigNumber(tokenReserve).times(2))
+}
+
+export function tokenPerUsd (
+  tokenReserve: string | number,
+  totalLiquidityInUsd: string | number
+): BigNumber {
+  return new BigNumber(1).div(usdPerToken(tokenReserve, totalLiquidityInUsd))
+}


### PR DESCRIPTION
What this PR does / why we need it:
Implementation of legacy-api to remap the legacy API (https://api.defichain.com/v1/getsubgraphswaps).

Which issue(s) does this PR fixes?:
Fixes part of https://github.com/DeFiCh/jellyfish/issues/1024

### Note
- `tokenomics` helper originates from #1115 - will deconflict if necessary, whichever PR is accepted first