### PR TITLE
fix(docker): don't need to specify ${APP} twice in RUN ln due to nest-apps mono repo design update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ RUN npx lerna run build
 
 ARG APP
 ENV APP ${APP}
-RUN ln -s apps/${APP}/dist/apps/${APP}/src ${APP}
+RUN ln -s apps/dist/apps/${APP}/src ${APP}
 
 CMD "node" ${APP}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

`Dockerfile` build was failing as `${APP}` is now redundant due to nestjs mono repo structural changes.

> #1073 will shift-left migrated invalid artifact in the future.
