### PR TITLE
chore(apps/legacy-api): set content-type header depending on stats type

### DIFF
--- a/apps/legacy-api/__tests__/controllers/StatsController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/StatsController.test.ts
@@ -94,6 +94,7 @@ describe('StatsController', () => {
 
     // Additional checks
     expect(actual.rewards.minter).toStrictEqual(actual.rewards.masternode)
+    expect(res.headers['content-type']).toStrictEqual('application/json; charset=utf-8')
   })
 
   it('/v1/stats?q=rewards - returns nested object', async () => {
@@ -119,6 +120,7 @@ describe('StatsController', () => {
       options: expect.any(Number),
       unallocated: expect.any(Number)
     })
+    expect(res.headers['content-type']).toStrictEqual('application/json; charset=utf-8')
   })
 
   it('/v1/stats?q=tokens.supply.total - returns text (leaf)', async () => {
@@ -128,6 +130,7 @@ describe('StatsController', () => {
     })
 
     expect(Number(res.body)).toStrictEqual(expect.any(Number))
+    expect(res.headers['content-type']).toStrictEqual('text; charset=utf-8')
   })
 })
 

--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -53,7 +53,7 @@ export class MainnetLegacyStatsProvider {
     this.api = clientProvider.getClient('mainnet')
   }
 
-  async getStats (jsonPath?: string): Promise<LegacyStats> {
+  async getStats (jsonPath?: string): Promise<LegacyStats | any> {
     const stats: StatsData = await this.api.stats.get()
 
     // Fire async requests at the same time and await results

--- a/apps/legacy-api/src/controllers/stats/StatsController.ts
+++ b/apps/legacy-api/src/controllers/stats/StatsController.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Query } from '@nestjs/common'
+import { Controller, Get, Query, Res } from '@nestjs/common'
 import { NetworkValidationPipe, SupportedNetwork } from '../../pipes/NetworkValidationPipe'
 import { LegacyStats, MainnetLegacyStatsProvider, TestnetLegacyStatsProvider } from './LegacyStatsProvider'
+import { FastifyReply } from 'fastify'
 
 @Controller('v1')
 export class StatsController {
@@ -11,14 +12,40 @@ export class StatsController {
 
   @Get('stats')
   async stats (
-    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
-    @Query('q') jsonPath?: string
-  ): Promise<LegacyStats> {
+    @Res() res: FastifyReply,
+      @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
+      @Query('q') jsonPath?: string
+  ): Promise<void> {
+    let stats
     switch (network) {
       case 'mainnet':
-        return await this.mainnetStatsProvider.getStats(jsonPath)
+        stats = await this.mainnetStatsProvider.getStats(jsonPath)
+        break
       case 'testnet':
-        return await this.testnetStatsProvider.getStats(jsonPath)
+        stats = await this.testnetStatsProvider.getStats(jsonPath)
+        break
+    }
+    await StatsController.replyWithContentType(res, stats)
+  }
+
+  private static async replyWithContentType (
+    res: FastifyReply,
+    stats: LegacyStats | any
+  ): Promise<void> {
+    switch (typeof stats) {
+      case 'number':
+      case 'string':
+        await res
+          .header('content-type', 'text; charset=utf-8')
+          .send(stats.toString())
+        break
+
+      case 'object':
+      default:
+        await res
+          .header('content-type', 'application/json; charset=utf-8')
+          .send(JSON.stringify(stats))
+        break
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
/stats endpoint can return either a JSON object or just text, depending on the `?q=json.path` query param