### PR TITLE
feat(apps/legacy-api): getsubgraphswaps

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -158,8 +158,7 @@ describe('getsubgraphswaps', () => {
   it('/v1/getsubgraphswaps', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
-      // TODO(eli-lim): temporary deployed TestNet for testing, to switch to mainnet
-      url: '/v1/getsubgraphswaps?network=testnet'
+      url: '/v1/getsubgraphswaps'
     })
 
     const response = res.json()

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -153,3 +153,67 @@ it('/v1/listyieldfarming', async () => {
     ]
   })
 })
+
+describe('getsubgraphswaps', () => {
+  it('/v1/getsubgraphswaps', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      // TODO(eli-lim): temporary deployed TestNet for testing, to switch to mainnet
+      url: '/v1/getsubgraphswaps?network=testnet'
+    })
+
+    const response = res.json()
+
+    console.log(response)
+
+    expect(response.data.swaps.length).toStrictEqual(100)
+
+    for (const swap of response.data.swaps) {
+      expect(swap).toStrictEqual({
+        id: expect.stringMatching(/[a-zA-Z0-9]{64}/),
+        pair: {
+          fromToken: {
+            decimals: 8,
+            symbol: expect.any(String),
+            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
+          },
+          toToken: {
+            decimals: 8,
+            symbol: expect.any(String),
+            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
+          }
+        },
+        timestamp: expect.stringMatching(/\d+/),
+        fromAmount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX),
+        toAmount: 'TODO' // TODO(eli-lim)
+      })
+    }
+  })
+
+  it('/v1/getsubgraphswaps?limit=3', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=3'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(3)
+  })
+
+  it('/v1/getsubgraphswaps?limit=-1', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=-1'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(0)
+  })
+
+  it('/v1/getsubgraphswaps?limit=101', async () => {
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=101'
+    })
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(100)
+  })
+})

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -155,15 +155,13 @@ it('/v1/listyieldfarming', async () => {
 })
 
 describe('getsubgraphswaps', () => {
-  it('/v1/getsubgraphswaps', async () => {
+  it.skip('/v1/getsubgraphswaps', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps'
     })
 
     const response = res.json()
-
-    console.log(response)
 
     expect(response.data.swaps.length).toStrictEqual(100)
 
@@ -207,12 +205,12 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(0)
   })
 
-  it('/v1/getsubgraphswaps?limit=101', async () => {
+  it.skip('/v1/getsubgraphswaps?limit=101 - limited to 30', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps?limit=101'
     })
     const response = res.json()
-    expect(response.data.swaps.length).toStrictEqual(100)
+    expect(response.data.swaps.length).toStrictEqual(30)
   })
 })

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -163,7 +163,7 @@ describe('getsubgraphswaps', () => {
 
     const response = res.json()
 
-    expect(response.data.swaps.length).toStrictEqual(100)
+    expect(response.data.swaps.length).toStrictEqual(30)
 
     for (const swap of response.data.swaps) {
       expect(swap).toStrictEqual({
@@ -199,12 +199,12 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(0)
   })
 
-  it('/v1/getsubgraphswaps?limit=101 - limited to 100', async () => {
+  it('/v1/getsubgraphswaps?limit=101 - limited to 30', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps?limit=101'
     })
     const response = res.json()
-    expect(response.data.swaps.length).toStrictEqual(100)
+    expect(response.data.swaps.length).toStrictEqual(30)
   })
 })

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -155,7 +155,7 @@ it('/v1/listyieldfarming', async () => {
 })
 
 describe('getsubgraphswaps', () => {
-  it.skip('/v1/getsubgraphswaps', async () => {
+  it('/v1/getsubgraphswaps', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps'
@@ -168,21 +168,15 @@ describe('getsubgraphswaps', () => {
     for (const swap of response.data.swaps) {
       expect(swap).toStrictEqual({
         id: expect.stringMatching(/[a-zA-Z0-9]{64}/),
-        pair: {
-          fromToken: {
-            decimals: 8,
-            symbol: expect.any(String),
-            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
-          },
-          toToken: {
-            decimals: 8,
-            symbol: expect.any(String),
-            tradeVolume: expect.stringMatching(/^[0-9]+(\.[0-9]{8})?$/)
-          }
-        },
         timestamp: expect.stringMatching(/\d+/),
-        fromAmount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX),
-        toAmount: 'TODO' // TODO(eli-lim)
+        from: {
+          symbol: expect.any(String),
+          amount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX)
+        },
+        to: {
+          symbol: expect.any(String),
+          amount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX)
+        }
       })
     }
   })
@@ -205,12 +199,12 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(0)
   })
 
-  it.skip('/v1/getsubgraphswaps?limit=101 - limited to 30', async () => {
+  it('/v1/getsubgraphswaps?limit=101 - limited to 100', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps?limit=101'
     })
     const response = res.json()
-    expect(response.data.swaps.length).toStrictEqual(30)
+    expect(response.data.swaps.length).toStrictEqual(100)
   })
 })

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -3,6 +3,18 @@ import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 import BigNumber from 'bignumber.js'
+import { Transaction, TransactionVout } from '@defichain/whale-api-client/dist/api/transactions'
+import {
+  CCompositeSwap,
+  CompositeSwap,
+  CPoolSwap,
+  OP_DEFI_TX,
+  PoolSwap,
+  toOPCodes
+} from '@defichain/jellyfish-transaction'
+import { SmartBuffer } from 'smart-buffer'
+import { AccountHistory } from '@defichain/jellyfish-api-core/src/category/account'
+import { fromScript } from '@defichain/jellyfish-address'
 
 @Controller('v1')
 export class PoolPairController {
@@ -67,6 +79,72 @@ export class PoolPairController {
     return result
   }
 
+  @Get('getsubgraphswaps')
+  async getSubgraphSwaps (
+    @Query('network', NetworkValidationPipe) network: SupportedNetwork = 'mainnet',
+    @Query('limit') limit: number = 30,
+    @Query('next') nextString?: string
+  ): Promise<LegacySubgraphSwapsResponse> {
+    limit = Math.min(30, limit)
+    // TODO(eli-lim): next string cursor should be = JSON string encoded base64-url-safe
+    const next: NextToken = JSON.parse(nextString ?? '{}')
+    return await this.getSwapsHistory(network, limit, next)
+    // TODO(eli-lim): next encoded as json string
+  }
+
+  async getSwapsHistory (network: SupportedNetwork, limit: number, next: NextToken): Promise<LegacySubgraphSwapsResponse> {
+    const api = this.whaleApiClientProvider.getClient(network)
+    const swaps: LegacySubgraphSwap[] = []
+
+    while (swaps.length <= limit) {
+      // injected height for this operation
+      for (const block of await api.blocks.list(200, next?.height ?? '892800')) {
+        for (const transaction of await api.blocks.getTransactions(block.hash, 100, next?.order)) {
+          const vouts = await api.transactions.getVouts(transaction.txid, 1)
+          const dftx = findPoolSwapDfTx(vouts)
+          if (dftx === undefined) {
+            continue
+          }
+
+          const swap = await this.findSwap(network, dftx, transaction)
+          if (swap === undefined) {
+            continue
+          }
+
+          swaps.push(swap)
+
+          next = {
+            height: block.height.toString(),
+            order: transaction.order.toString()
+          }
+
+          if (swaps.length === limit) {
+            return {
+              data: swaps,
+              page: {
+                next: JSON.stringify(next)
+              }
+            }
+          }
+        }
+      }
+
+      console.log(swaps.length)
+
+      if (swaps.length === 0) {
+        // TODO(eli-lim): exit early if no data? max 1000 loops?
+        break
+      }
+    }
+
+    return {
+      data: swaps,
+      page: {
+        next: JSON.stringify(next)
+      }
+    }
+  }
+
   getVolumes (poolPair: PoolPairData): [BigNumber, BigNumber] {
     const poolPairVolumeInUsd = new BigNumber(poolPair.volume?.h24 ?? 0)
 
@@ -98,6 +176,34 @@ export class PoolPairController {
   usdToTokenConversionRate (tokenReserve: string | number, totalLiquidityInUsd: string | number): BigNumber {
     return new BigNumber(tokenReserve).times(2)
       .div(new BigNumber(totalLiquidityInUsd))
+  }
+
+  async findSwap (network: SupportedNetwork, poolSwap: PoolSwap, transaction: Transaction): Promise<LegacySubgraphSwap | undefined> {
+    const api = this.whaleApiClientProvider.getClient(network)
+    const fromAddress = fromScript(poolSwap.fromScript, network)?.address
+    const toAddress = fromScript(poolSwap.toScript, network)?.address
+
+    const fromHistory: AccountHistory = await api.rpc.call<AccountHistory>('getaccounthistory', [fromAddress, transaction.block.height, transaction.order], 'number')
+    let toHistory: AccountHistory
+    if (toAddress === fromAddress) {
+      toHistory = fromHistory
+    } else {
+      toHistory = await api.rpc.call<AccountHistory>('getaccounthistory', [toAddress, transaction.block.height, transaction.order], 'number')
+    }
+
+    const from = findAmountSymbol(fromHistory, true)
+    const to = findAmountSymbol(toHistory, false)
+
+    if (from === undefined || to === undefined) {
+      return undefined
+    }
+
+    return {
+      id: transaction.txid,
+      timestamp: transaction.block.medianTime.toString(),
+      from: from,
+      to: to
+    }
   }
 
   @Get('listyieldfarming')
@@ -246,4 +352,76 @@ interface LegacyListYieldFarmingPool {
   poolRewards: string[]
   apr: number
   totalStaked: number
+}
+
+interface LegacySubgraphSwapsResponse {
+  data: LegacySubgraphSwap[]
+  page?: {
+    next: string
+  }
+}
+
+interface NextToken {
+  height?: string
+  order?: string
+}
+
+interface LegacySubgraphSwap {
+  id: string
+  timestamp: string
+  from: LegacySubgraphSwapFromTo
+  to: LegacySubgraphSwapFromTo
+}
+
+interface LegacySubgraphSwapFromTo {
+  amount: string
+  symbol: string
+}
+
+function findPoolSwapDfTx (vouts: TransactionVout[]): PoolSwap | undefined {
+  const hex = vouts[0].script.hex
+  const buffer = SmartBuffer.fromBuffer(Buffer.from(hex, 'hex'))
+  const stack = toOPCodes(buffer)
+  if (stack.length !== 2 || stack[1].type !== 'OP_DEFI_TX') {
+    return undefined
+  }
+
+  const dftx = (stack[1] as OP_DEFI_TX).tx
+  if (dftx === undefined) {
+    return undefined
+  }
+
+  switch (dftx.name) {
+    case CPoolSwap.OP_NAME:
+      return (dftx.data as PoolSwap)
+
+    case CCompositeSwap.OP_NAME:
+      return (dftx.data as CompositeSwap).poolSwap
+
+    default:
+      return undefined
+  }
+}
+
+function findAmountSymbol (history: AccountHistory, outgoing: boolean): LegacySubgraphSwapFromTo | undefined {
+  for (const amount of history.amounts) {
+    const [value, symbol] = amount.split('@')
+    const isNegative = value.startsWith('-')
+
+    if (isNegative && outgoing) {
+      return {
+        amount: new BigNumber(value).absoluteValue().toFixed(8),
+        symbol: symbol
+      }
+    }
+
+    if (!isNegative && !outgoing) {
+      return {
+        amount: new BigNumber(value).absoluteValue().toFixed(8),
+        symbol: symbol
+      }
+    }
+  }
+
+  return undefined
 }

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -85,7 +85,7 @@ export class PoolPairController {
     @Query('limit') limit: number = 30,
     @Query('next') nextString?: string
   ): Promise<LegacySubgraphSwapsResponse> {
-    limit = Math.min(30, limit)
+    limit = Math.min(100, limit)
     const next: NextToken = (nextString !== undefined)
       ? JSON.parse(Buffer.from(nextString, 'base64url').toString())
       : {}

--- a/apps/legacy-api/src/index.ts
+++ b/apps/legacy-api/src/index.ts
@@ -7,7 +7,7 @@ export class RootServer {
   app?: NestFastifyApplication
 
   async create (): Promise<NestFastifyApplication> {
-    const adapter = new FastifyAdapter()
+    const adapter = new FastifyAdapter({ logger: true })
     return await NestFactory.create<NestFastifyApplication>(RootModule, adapter)
   }
 

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -20,7 +20,7 @@ export class WhaleApiClientProvider {
 
   private createAndCacheClient (network: SupportedNetwork): WhaleApiClient {
     const client = new WhaleApiClient({
-      version: 'v0',
+      version: 'v0.26', // TODO(eli-lim): modified to use staging deployment
       network: network,
       url: 'https://ocean.defichain.com'
     })

--- a/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
+++ b/apps/legacy-api/src/providers/WhaleApiClientProvider.ts
@@ -20,7 +20,7 @@ export class WhaleApiClientProvider {
 
   private createAndCacheClient (network: SupportedNetwork): WhaleApiClient {
     const client = new WhaleApiClient({
-      version: 'v0.26', // TODO(eli-lim): modified to use staging deployment
+      version: 'v0',
       network: network,
       url: 'https://ocean.defichain.com'
     })


### PR DESCRIPTION
What this PR does / why we need it:
Implementation of https://api.defichain.com/v1/getsubgraphswaps in legacy-api

Which issue(s) does this PR fixes?:
Fixes part of https://github.com/DeFiCh/jellyfish/issues/1024

### Note
- query performance bottleneck is getaccounthistory