### PR TITLE
feat(workflow): skip container builds for dependabot PRs

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: github.actor != "dependabot[bot]"
+    if: github.actor != 'dependabot[bot]'
     name: Publish
     runs-on: ubuntu-latest
     strategy:
@@ -51,7 +51,7 @@ jobs:
           tags: ${{ steps.tags.outputs.result }}
 
   report:
-    if: github.event_name == 'pull_request' && github.actor != "dependabot[bot]"
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     name: Report
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.actor != "dependabot[bot]"
     name: Publish
     runs-on: ubuntu-latest
     strategy:
@@ -50,10 +51,10 @@ jobs:
           tags: ${{ steps.tags.outputs.result }}
 
   report:
+    if: github.event_name == 'pull_request' && github.actor != "dependabot[bot]"
     name: Report
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
       


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Dependabot does not have access to publish containers so we skip PR container builds in those circumstances:

 - https://github.com/DeFiCh/jellyfish/pull/1156#issuecomment-1058802501
