### PR TITLE
feat(legacy-api): update `whale-api-client` imports

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -1,5 +1,5 @@
 import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
-import { PoolPairData } from '@defichain/whale-api-client/src/api/PoolPairs'
+import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 
 const ONLY_DECIMAL_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/
 

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -1,5 +1,5 @@
 import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
-import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
+import { PoolPairData } from '@defichain/whale-api-client/src/api/PoolPairs'
 
 const ONLY_DECIMAL_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/
 

--- a/apps/legacy-api/__tests__/controllers/TokenController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/TokenController.test.ts
@@ -1,5 +1,5 @@
 import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
-import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
+import { TokenData } from '@defichain/whale-api-client/src/api/Tokens'
 
 const apiTesting = LegacyApiTesting.create()
 

--- a/apps/legacy-api/__tests__/controllers/TokenController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/TokenController.test.ts
@@ -1,5 +1,5 @@
 import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
-import { TokenData } from '@defichain/whale-api-client/src/api/Tokens'
+import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 
 const apiTesting = LegacyApiTesting.create()
 

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, NotFoundException, Query } from '@nestjs/common'
-import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
+import { StatsData } from '@defichain/whale-api-client/src/api/Stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 import { ValidateAddressResult } from '@defichain/jellyfish-api-core/src/category/wallet'

--- a/apps/legacy-api/src/controllers/MiscController.ts
+++ b/apps/legacy-api/src/controllers/MiscController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, NotFoundException, Query } from '@nestjs/common'
-import { StatsData } from '@defichain/whale-api-client/src/api/Stats'
+import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 import { ValidateAddressResult } from '@defichain/jellyfish-api-core/src/category/wallet'

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { PoolPairData } from '@defichain/whale-api-client/src/api/PoolPairs'
+import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 import BigNumber from 'bignumber.js'
-import { Transaction, TransactionVout } from '@defichain/whale-api-client/src/api/Transactions'
+import { Transaction, TransactionVout } from '@defichain/whale-api-client/dist/api/transactions'
 import {
   CCompositeSwap,
   CompositeSwap,

--- a/apps/legacy-api/src/controllers/PoolPairController.ts
+++ b/apps/legacy-api/src/controllers/PoolPairController.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { PoolPairData } from '@defichain/whale-api-client/dist/api/poolpairs'
+import { PoolPairData } from '@defichain/whale-api-client/src/api/PoolPairs'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 import BigNumber from 'bignumber.js'
-import { Transaction, TransactionVout } from '@defichain/whale-api-client/dist/api/transactions'
+import { Transaction, TransactionVout } from '@defichain/whale-api-client/src/api/Transactions'
 import {
   CCompositeSwap,
   CompositeSwap,

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
+import { TokenData } from '@defichain/whale-api-client/src/api/Tokens'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 

--- a/apps/legacy-api/src/controllers/TokenController.ts
+++ b/apps/legacy-api/src/controllers/TokenController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query } from '@nestjs/common'
-import { TokenData } from '@defichain/whale-api-client/src/api/Tokens'
+import { TokenData } from '@defichain/whale-api-client/dist/api/tokens'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { NetworkValidationPipe, SupportedNetwork } from '../pipes/NetworkValidationPipe'
 

--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -9,7 +9,7 @@ import {
 import { WhaleApiClientProvider } from '../../providers/WhaleApiClientProvider'
 import BigNumber from 'bignumber.js'
 import { WhaleApiClient } from '@defichain/whale-api-client'
-import { StatsData } from '@defichain/whale-api-client/src/api/Stats'
+import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
 import { get } from 'lodash'
 
 // region - Needs to be kept in sync with defi-stats-api-master

--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -9,7 +9,7 @@ import {
 import { WhaleApiClientProvider } from '../../providers/WhaleApiClientProvider'
 import BigNumber from 'bignumber.js'
 import { WhaleApiClient } from '@defichain/whale-api-client'
-import { StatsData } from '@defichain/whale-api-client/dist/api/stats'
+import { StatsData } from '@defichain/whale-api-client/src/api/Stats'
 import { get } from 'lodash'
 
 // region - Needs to be kept in sync with defi-stats-api-master

--- a/apps/package.json
+++ b/apps/package.json
@@ -21,7 +21,7 @@
     "@defichain/ocean-api-client": "^0.0.0",
     "@defichain/playground-api-client": "^0.0.0",
     "@defichain/playground": "^0.0.0",
-    "@defichain/whale-api-client": "^0.0.0",
+    "@defichain/whale-api-client": "0.27.0",
     "@nestjs/common": "^8.4.0",
     "@nestjs/config": "^1.2.0",
     "@nestjs/core": "^8.4.0",

--- a/apps/package.json
+++ b/apps/package.json
@@ -21,7 +21,7 @@
     "@defichain/ocean-api-client": "^0.0.0",
     "@defichain/playground-api-client": "^0.0.0",
     "@defichain/playground": "^0.0.0",
-    "@defichain/whale-api-client": "0.27.0",
+    "@defichain/whale-api-client": "^0.0.0",
     "@nestjs/common": "^8.4.0",
     "@nestjs/config": "^1.2.0",
     "@nestjs/core": "^8.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
         "@defichain/playground-api-client": "^0.0.0",
-        "@defichain/whale-api-client": "0.27.0",
+        "@defichain/whale-api-client": "^0.0.0",
         "@nestjs/common": "^8.4.0",
         "@nestjs/config": "^1.2.0",
         "@nestjs/core": "^8.4.0",
@@ -28052,7 +28052,7 @@
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
         "@defichain/playground-api-client": "^0.0.0",
-        "@defichain/whale-api-client": "0.27.0",
+        "@defichain/whale-api-client": "^0.0.0",
         "@nestjs/cli": "^8.2.2",
         "@nestjs/common": "^8.4.0",
         "@nestjs/config": "^1.2.0",
@@ -28099,8 +28099,7 @@
           }
         },
         "@defichain/whale-api-client": {
-          "version": "0.27.0",
-          "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
+          "version": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
           "integrity": "sha512-9hrXdiyv2481UOovDU/fCLIran3SuenBVGD9h1GLpacXvoHH1AXdEbBwWTArPCRzh/RmJEQslo+rIIjeNnKXtg==",
           "requires": {
             "@defichain/jellyfish-api-jsonrpc": "^2.28.0",
@@ -36442,7 +36441,7 @@
             "@defichain/ocean-api-client": "^0.0.0",
             "@defichain/playground": "^0.0.0",
             "@defichain/playground-api-client": "^0.0.0",
-            "@defichain/whale-api-client": "0.27.0",
+            "@defichain/whale-api-client": "^0.0.0",
             "@nestjs/cli": "^8.2.2",
             "@nestjs/common": "^8.4.0",
             "@nestjs/config": "^1.2.0",
@@ -36489,8 +36488,7 @@
               }
             },
             "@defichain/whale-api-client": {
-              "version": "0.27.0",
-              "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
+              "version": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
               "integrity": "sha512-9hrXdiyv2481UOovDU/fCLIran3SuenBVGD9h1GLpacXvoHH1AXdEbBwWTArPCRzh/RmJEQslo+rIIjeNnKXtg==",
               "requires": {
                 "@defichain/jellyfish-api-jsonrpc": "^2.28.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Since we are no longer targeting external package of `whale-api-client` we cannot use `/dist` targets. This PR removes the dependency on `/dist` and replaces it with `/src` as seen in other areas of apps in jellyfish. [Sample](https://github.com/DeFiCh/jellyfish/blob/main/apps/legacy-api/src/controllers/PoolPairController.ts#L16)

#### Additional comments?:

This PR depends on:

 - https://github.com/DeFiCh/jellyfish/pull/1166

This is part of whale migration efforts:

 - https://github.com/DeFiCh/jellyfish/pull/1168
