### PR TITLE
fix(workflows/release-apps): all platforms must be present for release builds otherwise it will conflict

### DIFF
--- a/.github/scripts/release-report.js
+++ b/.github/scripts/release-report.js
@@ -8,11 +8,11 @@ module.exports = ({ context }) => {
   const links = getContainerLinks(context)
   return `
 
-Build preview for jellyfish apps is ready!
+Docker build preview for jellyfish/apps is ready!
           
 Built with commit ${context.sha}
 
-${links.join('\n')}
+ - ${links.join('\n - ')}
 `
 }
 

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
 
+env:
+  APPS: 'legacy-api,ocean-api,playground-api'
+
 jobs:
   build:
     if: github.actor != 'dependabot[bot]'
@@ -41,13 +44,15 @@ jobs:
         with:
           script: return require('./.github/scripts/release-tags.js')({ context })
           result-encoding: string
-      
+
       - name: Build & Publish
         uses: docker/build-push-action@7f9d37fa544684fb73bfe4835ed7214c255ce02b
         with:
           push: true
           build-args: APP=${{ matrix.app }}
-          platforms: ${{ matrix.platform }}
+          platforms: |
+            linux/amd64
+            linux/arm64
           tags: ${{ steps.tags.outputs.result }}
 
   report:
@@ -57,12 +62,10 @@ jobs:
     needs: build
     steps:
       - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
-      
+
       - name: Create Report
         uses: actions/github-script@9ac08808f993958e9de277fe43a64532a609130e
         id: report
-        env:
-          APPS: 'legacy-api,ocean-api,playground-api'
         with:
           script: return require('./.github/scripts/release-report.js')({ context })
           result-encoding: string

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   APPS: 'legacy-api,ocean-api,playground-api'
 
@@ -19,7 +23,6 @@ jobs:
     strategy:
       matrix:
         app: [ legacy-api, ocean-api, playground-api ]
-        platform: [ linux/amd64, linux/arm64 ]
     steps:
       - uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

- All platforms must be present for release builds otherwise it will conflict due to platform OS label conflict.
- Also update release-report.js message add list indent
- Add `concurrency:` to cancel in progress workflow