### PR TITLE
chore(apps/legacy-api): LegacyStatsProvider.getBurnInfo to use `this.api.stats.getBurn` instead

### DIFF
--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common'
-import { BurnInfo, CommunityBalanceData } from '@defichain/jellyfish-api-core/src/category/account'
+import { CommunityBalanceData } from '@defichain/jellyfish-api-core/src/category/account'
 import {
   BlockRewardDistributionPercentage,
   BlockSubsidy,
@@ -133,7 +133,7 @@ export class MainnetLegacyStatsProvider {
   }
 
   async getBurnInfo (): Promise<LegacyBurnInfo> {
-    const burnInfo = await this.api.rpc.call<BurnInfo>('getburninfo', [], 'bignumber')
+    const burnInfo = await this.api.stats.getBurn()
     return {
       address: burnInfo.address,
       amount: burnInfo.amount.toFixed(DECIMAL_PLACES),

--- a/apps/package.json
+++ b/apps/package.json
@@ -21,7 +21,7 @@
     "@defichain/ocean-api-client": "^0.0.0",
     "@defichain/playground-api-client": "^0.0.0",
     "@defichain/playground": "^0.0.0",
-    "@defichain/whale-api-client": "0.26.3",
+    "@defichain/whale-api-client": "0.27.0",
     "@nestjs/common": "^8.4.0",
     "@nestjs/config": "^1.2.0",
     "@nestjs/core": "^8.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
         "@defichain/playground-api-client": "^0.0.0",
-        "@defichain/whale-api-client": "0.26.3",
+        "@defichain/whale-api-client": "0.27.0",
         "@nestjs/common": "^8.4.0",
         "@nestjs/config": "^1.2.0",
         "@nestjs/core": "^8.4.0",
@@ -98,54 +98,6 @@
         "@nestjs/cli": "^8.2.1",
         "@nestjs/schematics": "^8.0.6",
         "@nestjs/testing": "^8.3.1"
-      }
-    },
-    "apps/node_modules/@defichain/jellyfish-json": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.23.0.tgz",
-      "integrity": "sha512-yW1Wl8QKtozG7R7HqP8jH86VSKYSzP/E+ATCCv3ma2IehUicKxdAKOfvga0SzTwaiaXGCFecONMVV6SM6n1soQ==",
-      "dependencies": {
-        "@types/lossless-json": "^1.0.1",
-        "bignumber.js": "^9.0.2",
-        "lossless-json": "^1.0.5"
-      },
-      "peerDependencies": {
-        "defichain": "^2.23.0"
-      }
-    },
-    "apps/node_modules/@defichain/whale-api-client": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
-      "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
-      "dependencies": {
-        "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.5",
-        "url-search-params-polyfill": "8.1.1"
-      }
-    },
-    "apps/node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-core": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.23.0.tgz",
-      "integrity": "sha512-dg3vh0RDB4+PAao2bngb5jveF2EzHbVOC4Dlpzfc5InypkwzwYgHnruMpV5nnC+eWojc/g1JLFgw8Ze8C82qNw==",
-      "dependencies": {
-        "@defichain/jellyfish-json": "2.23.0"
-      },
-      "peerDependencies": {
-        "defichain": "^2.23.0"
-      }
-    },
-    "apps/node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-jsonrpc": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.23.0.tgz",
-      "integrity": "sha512-ASwxCkaho6CiopvF651RDIDdXL203ZmmfLDkrPMqXycrnxPC8F/53lSspW/v3bmWZXyfTOr4FqKOKymhIvTY+w==",
-      "dependencies": {
-        "@defichain/jellyfish-api-core": "2.23.0",
-        "abort-controller": "^3.0.0",
-        "cross-fetch": "^3.1.5"
-      },
-      "peerDependencies": {
-        "defichain": "^2.23.0"
       }
     },
     "apps/node_modules/@nestjs/common": {
@@ -579,15 +531,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "apps/node_modules/defichain": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.23.0.tgz",
-      "integrity": "sha512-Vd0tuyrMKIAJdsYDNLDXJmWbTWXRlaOOUti1yY39g0wM+w8UHQb9CSHPErMjM+SB2ytJKWB/gh+ufuYWelxpVg==",
-      "peer": true,
-      "engines": {
-        "node": ">=14.x"
       }
     },
     "apps/node_modules/eslint-visitor-keys": {
@@ -3092,6 +3035,63 @@
     "node_modules/@defichain/website": {
       "resolved": "website",
       "link": true
+    },
+    "node_modules/@defichain/whale-api-client": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
+      "integrity": "sha512-9hrXdiyv2481UOovDU/fCLIran3SuenBVGD9h1GLpacXvoHH1AXdEbBwWTArPCRzh/RmJEQslo+rIIjeNnKXtg==",
+      "dependencies": {
+        "@defichain/jellyfish-api-jsonrpc": "^2.28.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.5",
+        "url-search-params-polyfill": "8.1.1"
+      }
+    },
+    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-core": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.28.2.tgz",
+      "integrity": "sha512-kCKI4dpJlRF+1OYElEO1uXZbaeo80U7zqErCozDZDSQUOX2MP5J+2fZSMfyu1bp4ikwoYtkKGnr1ecuqrKaklg==",
+      "dependencies": {
+        "@defichain/jellyfish-json": "2.28.2"
+      },
+      "peerDependencies": {
+        "defichain": "^2.28.2"
+      }
+    },
+    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-api-jsonrpc": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.28.2.tgz",
+      "integrity": "sha512-Wevb57PyLrrJpmbOKLwCrAFRfVdNsHdRnc21chuJ2wtI14JwKSOr3uoQh3lX9HGsQ/sMcKjSzTYgWSNYt9FkIQ==",
+      "dependencies": {
+        "@defichain/jellyfish-api-core": "2.28.2",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "defichain": "^2.28.2"
+      }
+    },
+    "node_modules/@defichain/whale-api-client/node_modules/@defichain/jellyfish-json": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.28.2.tgz",
+      "integrity": "sha512-tPxKl6SEHd/UzrZbTqvKwYxXfyz7VSacfEwzOXllWKdsMIaXnWCLtsXa85KB15IcU2Io2ysW96/MjG43abAybw==",
+      "dependencies": {
+        "@types/lossless-json": "^1.0.1",
+        "bignumber.js": "^9.0.2",
+        "lossless-json": "^1.0.5"
+      },
+      "peerDependencies": {
+        "defichain": "^2.28.2"
+      }
+    },
+    "node_modules/@defichain/whale-api-client/node_modules/defichain": {
+      "version": "2.28.2",
+      "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.28.2.tgz",
+      "integrity": "sha512-gDZfwzaYSFL9iGtrI6fcdRDwC6GL7uEFaonv7ZHWRayTcL5GFg4N2+WmpbJ7/4IR2VkAfZ3VKbnHMNS7bnF+TQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=14.x"
+      }
     },
     "node_modules/@docsearch/css": {
       "version": "3.0.0",
@@ -28342,7 +28342,7 @@
         "@defichain/ocean-api-client": "^0.0.0",
         "@defichain/playground": "^0.0.0",
         "@defichain/playground-api-client": "^0.0.0",
-        "@defichain/whale-api-client": "0.26.3",
+        "@defichain/whale-api-client": "0.27.0",
         "@nestjs/cli": "^8.2.2",
         "@nestjs/common": "^8.4.0",
         "@nestjs/config": "^1.2.0",
@@ -28378,46 +28378,6 @@
         "typeorm": "^0.2.45"
       },
       "dependencies": {
-        "@defichain/jellyfish-json": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.23.0.tgz",
-          "integrity": "sha512-yW1Wl8QKtozG7R7HqP8jH86VSKYSzP/E+ATCCv3ma2IehUicKxdAKOfvga0SzTwaiaXGCFecONMVV6SM6n1soQ==",
-          "requires": {
-            "@types/lossless-json": "^1.0.1",
-            "bignumber.js": "^9.0.2",
-            "lossless-json": "^1.0.5"
-          }
-        },
-        "@defichain/whale-api-client": {
-          "version": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
-          "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
-          "requires": {
-            "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
-            "abort-controller": "^3.0.0",
-            "cross-fetch": "^3.1.5",
-            "url-search-params-polyfill": "8.1.1"
-          },
-          "dependencies": {
-            "@defichain/jellyfish-api-core": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.23.0.tgz",
-              "integrity": "sha512-dg3vh0RDB4+PAao2bngb5jveF2EzHbVOC4Dlpzfc5InypkwzwYgHnruMpV5nnC+eWojc/g1JLFgw8Ze8C82qNw==",
-              "requires": {
-                "@defichain/jellyfish-json": "2.23.0"
-              }
-            },
-            "@defichain/jellyfish-api-jsonrpc": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.23.0.tgz",
-              "integrity": "sha512-ASwxCkaho6CiopvF651RDIDdXL203ZmmfLDkrPMqXycrnxPC8F/53lSspW/v3bmWZXyfTOr4FqKOKymhIvTY+w==",
-              "requires": {
-                "@defichain/jellyfish-api-core": "2.23.0",
-                "abort-controller": "^3.0.0",
-                "cross-fetch": "^3.1.5"
-              }
-            }
-          }
-        },
         "@nestjs/common": {
           "version": "8.4.0",
           "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.0.tgz",
@@ -28649,12 +28609,6 @@
             "@typescript-eslint/types": "5.13.0",
             "eslint-visitor-keys": "^3.0.0"
           }
-        },
-        "defichain": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.23.0.tgz",
-          "integrity": "sha512-Vd0tuyrMKIAJdsYDNLDXJmWbTWXRlaOOUti1yY39g0wM+w8UHQb9CSHPErMjM+SB2ytJKWB/gh+ufuYWelxpVg==",
-          "peer": true
         },
         "eslint-visitor-keys": {
           "version": "3.3.0",
@@ -28923,6 +28877,53 @@
         "clsx": "^1.1.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
+      }
+    },
+    "@defichain/whale-api-client": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
+      "integrity": "sha512-9hrXdiyv2481UOovDU/fCLIran3SuenBVGD9h1GLpacXvoHH1AXdEbBwWTArPCRzh/RmJEQslo+rIIjeNnKXtg==",
+      "requires": {
+        "@defichain/jellyfish-api-jsonrpc": "^2.28.0",
+        "abort-controller": "^3.0.0",
+        "cross-fetch": "^3.1.5",
+        "url-search-params-polyfill": "8.1.1"
+      },
+      "dependencies": {
+        "@defichain/jellyfish-api-core": {
+          "version": "2.28.2",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.28.2.tgz",
+          "integrity": "sha512-kCKI4dpJlRF+1OYElEO1uXZbaeo80U7zqErCozDZDSQUOX2MP5J+2fZSMfyu1bp4ikwoYtkKGnr1ecuqrKaklg==",
+          "requires": {
+            "@defichain/jellyfish-json": "2.28.2"
+          }
+        },
+        "@defichain/jellyfish-api-jsonrpc": {
+          "version": "2.28.2",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.28.2.tgz",
+          "integrity": "sha512-Wevb57PyLrrJpmbOKLwCrAFRfVdNsHdRnc21chuJ2wtI14JwKSOr3uoQh3lX9HGsQ/sMcKjSzTYgWSNYt9FkIQ==",
+          "requires": {
+            "@defichain/jellyfish-api-core": "2.28.2",
+            "abort-controller": "^3.0.0",
+            "cross-fetch": "^3.1.5"
+          }
+        },
+        "@defichain/jellyfish-json": {
+          "version": "2.28.2",
+          "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.28.2.tgz",
+          "integrity": "sha512-tPxKl6SEHd/UzrZbTqvKwYxXfyz7VSacfEwzOXllWKdsMIaXnWCLtsXa85KB15IcU2Io2ysW96/MjG43abAybw==",
+          "requires": {
+            "@types/lossless-json": "^1.0.1",
+            "bignumber.js": "^9.0.2",
+            "lossless-json": "^1.0.5"
+          }
+        },
+        "defichain": {
+          "version": "2.28.2",
+          "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.28.2.tgz",
+          "integrity": "sha512-gDZfwzaYSFL9iGtrI6fcdRDwC6GL7uEFaonv7ZHWRayTcL5GFg4N2+WmpbJ7/4IR2VkAfZ3VKbnHMNS7bnF+TQ==",
+          "peer": true
+        }
       }
     },
     "@docsearch/css": {
@@ -37180,7 +37181,7 @@
             "@defichain/ocean-api-client": "^0.0.0",
             "@defichain/playground": "^0.0.0",
             "@defichain/playground-api-client": "^0.0.0",
-            "@defichain/whale-api-client": "0.26.3",
+            "@defichain/whale-api-client": "0.27.0",
             "@nestjs/cli": "^8.2.2",
             "@nestjs/common": "^8.4.0",
             "@nestjs/config": "^1.2.0",
@@ -37216,46 +37217,6 @@
             "typeorm": "^0.2.45"
           },
           "dependencies": {
-            "@defichain/jellyfish-json": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.23.0.tgz",
-              "integrity": "sha512-yW1Wl8QKtozG7R7HqP8jH86VSKYSzP/E+ATCCv3ma2IehUicKxdAKOfvga0SzTwaiaXGCFecONMVV6SM6n1soQ==",
-              "requires": {
-                "@types/lossless-json": "^1.0.1",
-                "bignumber.js": "^9.0.2",
-                "lossless-json": "^1.0.5"
-              }
-            },
-            "@defichain/whale-api-client": {
-              "version": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.26.2.tgz",
-              "integrity": "sha512-ETDD/N3sRdkE6gAvXr5XBe6dNYEPHAmZd7TYjmCC3eiPHskPjpXFrJuqKiZRJVf9u14mSNSglgxRwyn7WQ8mdQ==",
-              "requires": {
-                "@defichain/jellyfish-api-jsonrpc": "^2.21.0",
-                "abort-controller": "^3.0.0",
-                "cross-fetch": "^3.1.5",
-                "url-search-params-polyfill": "8.1.1"
-              },
-              "dependencies": {
-                "@defichain/jellyfish-api-core": {
-                  "version": "2.23.0",
-                  "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.23.0.tgz",
-                  "integrity": "sha512-dg3vh0RDB4+PAao2bngb5jveF2EzHbVOC4Dlpzfc5InypkwzwYgHnruMpV5nnC+eWojc/g1JLFgw8Ze8C82qNw==",
-                  "requires": {
-                    "@defichain/jellyfish-json": "2.23.0"
-                  }
-                },
-                "@defichain/jellyfish-api-jsonrpc": {
-                  "version": "2.23.0",
-                  "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.23.0.tgz",
-                  "integrity": "sha512-ASwxCkaho6CiopvF651RDIDdXL203ZmmfLDkrPMqXycrnxPC8F/53lSspW/v3bmWZXyfTOr4FqKOKymhIvTY+w==",
-                  "requires": {
-                    "@defichain/jellyfish-api-core": "2.23.0",
-                    "abort-controller": "^3.0.0",
-                    "cross-fetch": "^3.1.5"
-                  }
-                }
-              }
-            },
             "@nestjs/common": {
               "version": "8.4.0",
               "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-8.4.0.tgz",
@@ -37487,12 +37448,6 @@
                 "@typescript-eslint/types": "5.13.0",
                 "eslint-visitor-keys": "^3.0.0"
               }
-            },
-            "defichain": {
-              "version": "2.23.0",
-              "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.23.0.tgz",
-              "integrity": "sha512-Vd0tuyrMKIAJdsYDNLDXJmWbTWXRlaOOUti1yY39g0wM+w8UHQb9CSHPErMjM+SB2ytJKWB/gh+ufuYWelxpVg==",
-              "peer": true
             },
             "eslint-visitor-keys": {
               "version": "3.3.0",
@@ -37761,6 +37716,53 @@
             "clsx": "^1.1.1",
             "react": "^17.0.2",
             "react-dom": "^17.0.2"
+          }
+        },
+        "@defichain/whale-api-client": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/@defichain/whale-api-client/-/whale-api-client-0.27.0.tgz",
+          "integrity": "sha512-9hrXdiyv2481UOovDU/fCLIran3SuenBVGD9h1GLpacXvoHH1AXdEbBwWTArPCRzh/RmJEQslo+rIIjeNnKXtg==",
+          "requires": {
+            "@defichain/jellyfish-api-jsonrpc": "^2.28.0",
+            "abort-controller": "^3.0.0",
+            "cross-fetch": "^3.1.5",
+            "url-search-params-polyfill": "8.1.1"
+          },
+          "dependencies": {
+            "@defichain/jellyfish-api-core": {
+              "version": "2.28.2",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-core/-/jellyfish-api-core-2.28.2.tgz",
+              "integrity": "sha512-kCKI4dpJlRF+1OYElEO1uXZbaeo80U7zqErCozDZDSQUOX2MP5J+2fZSMfyu1bp4ikwoYtkKGnr1ecuqrKaklg==",
+              "requires": {
+                "@defichain/jellyfish-json": "2.28.2"
+              }
+            },
+            "@defichain/jellyfish-api-jsonrpc": {
+              "version": "2.28.2",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-api-jsonrpc/-/jellyfish-api-jsonrpc-2.28.2.tgz",
+              "integrity": "sha512-Wevb57PyLrrJpmbOKLwCrAFRfVdNsHdRnc21chuJ2wtI14JwKSOr3uoQh3lX9HGsQ/sMcKjSzTYgWSNYt9FkIQ==",
+              "requires": {
+                "@defichain/jellyfish-api-core": "2.28.2",
+                "abort-controller": "^3.0.0",
+                "cross-fetch": "^3.1.5"
+              }
+            },
+            "@defichain/jellyfish-json": {
+              "version": "2.28.2",
+              "resolved": "https://registry.npmjs.org/@defichain/jellyfish-json/-/jellyfish-json-2.28.2.tgz",
+              "integrity": "sha512-tPxKl6SEHd/UzrZbTqvKwYxXfyz7VSacfEwzOXllWKdsMIaXnWCLtsXa85KB15IcU2Io2ysW96/MjG43abAybw==",
+              "requires": {
+                "@types/lossless-json": "^1.0.1",
+                "bignumber.js": "^9.0.2",
+                "lossless-json": "^1.0.5"
+              }
+            },
+            "defichain": {
+              "version": "2.28.2",
+              "resolved": "https://registry.npmjs.org/defichain/-/defichain-2.28.2.tgz",
+              "integrity": "sha512-gDZfwzaYSFL9iGtrI6fcdRDwC6GL7uEFaonv7ZHWRayTcL5GFg4N2+WmpbJ7/4IR2VkAfZ3VKbnHMNS7bnF+TQ==",
+              "peer": true
+            }
           }
         },
         "@docsearch/css": {


### PR DESCRIPTION
#### What this PR does / why we need it:

In DeFiCh/whale [v0.27.0](https://github.com/DeFiCh/whale/releases/tag/v0.27.0) deprecate `getburninfo` RPC on ocean immediately.