### PR TITLE
chore(tsconfig): add `lib: ["dom"]` globally in tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [
-      "es2020"
+      "es2020", "dom"
     ],
     "target": "es6",
     "module": "commonjs",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Due to the use of `cross-fetch` on `jellyfish-api-core`, we might need to add `lib: ["dom"]` so that is can build without error.

@kodemon this might be related to you.