### PR TITLE
fix(legacy-api): burn info after RPC migration

### DIFF
--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -55,7 +55,7 @@ jobs:
           build-args: APP=${{ matrix.app }}
           platforms: |
             linux/amd64
-            linux/arm64
+#            linux/arm64
           tags: ${{ steps.tags.outputs.result }}
 
   report:

--- a/.github/workflows/release-apps.yml
+++ b/.github/workflows/release-apps.yml
@@ -55,7 +55,7 @@ jobs:
           build-args: APP=${{ matrix.app }}
           platforms: |
             linux/amd64
-#            linux/arm64
+            linux/arm64
           tags: ${{ steps.tags.outputs.result }}
 
   report:

--- a/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
+++ b/apps/legacy-api/src/controllers/stats/LegacyStatsProvider.ts
@@ -133,18 +133,18 @@ export class MainnetLegacyStatsProvider {
   }
 
   async getBurnInfo (): Promise<LegacyBurnInfo> {
-    const burnInfo = await this.api.stats.getBurn()
+    const burnInfo: any = await this.api.stats.getBurn()
     return {
       address: burnInfo.address,
-      amount: burnInfo.amount.toFixed(DECIMAL_PLACES),
+      amount: new BigNumber(burnInfo.amount).toFixed(DECIMAL_PLACES),
       tokens: burnInfo.tokens,
-      feeburn: burnInfo.feeburn.toNumber(),
-      auctionburn: burnInfo.auctionburn.toNumber(),
-      paybackburn: burnInfo.paybackburn.toFixed(8),
+      feeburn: burnInfo.feeburn,
+      auctionburn: burnInfo.auctionburn,
+      paybackburn: new BigNumber(burnInfo.paybackburn).toFixed(8),
       dexfeetokens: burnInfo.dexfeetokens,
-      dfipaybackfee: burnInfo.dfipaybackfee.toNumber(),
+      dfipaybackfee: burnInfo.dfipaybackfee,
       dfipaybacktokens: burnInfo.dfipaybacktokens,
-      emissionburn: burnInfo.emissionburn.toFixed(8)
+      emissionburn: new BigNumber(burnInfo.emissionburn).toFixed(8)
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

#1192 broke `burnInfo`