### PR TITLE
chore(dependencies): remove eslint in `apps/package.json`

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,8 +49,6 @@
     "@types/lodash": "^4.14.179",
     "@types/node": "^16.11.26",
     "@types/supertest": "^2.0.11",
-    "@typescript-eslint/eslint-plugin": "^5.13.0",
-    "@typescript-eslint/parser": "^5.14.0",
     "source-map-support": "^0.5.21",
     "supertest": "^6.2.2",
     "testcontainers": "^8.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,8 +72,6 @@
         "@types/lodash": "^4.14.179",
         "@types/node": "^16.11.26",
         "@types/supertest": "^2.0.11",
-        "@typescript-eslint/eslint-plugin": "^5.13.0",
-        "@typescript-eslint/parser": "^5.14.0",
         "source-map-support": "^0.5.21",
         "supertest": "^6.2.2",
         "testcontainers": "^8.4.0",
@@ -144,66 +142,6 @@
       },
       "peerDependencies": {
         "typescript": "^3.4.5 || ^4.3.5"
-      }
-    },
-    "apps/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-      "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "5.14.0",
-        "@typescript-eslint/type-utils": "5.14.0",
-        "@typescript-eslint/utils": "5.14.0",
-        "debug": "^4.3.2",
-        "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
-        "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/node_modules/@typescript-eslint/parser": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "5.14.0",
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/typescript-estree": "5.14.0",
-        "debug": "^4.3.2"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "apps/node_modules/defichain": {
@@ -2497,6 +2435,10 @@
     },
     "node_modules/@defichain/whale-api-client": {
       "resolved": "packages/whale-api-client",
+      "link": true
+    },
+    "node_modules/@defichain/whale-api-wallet": {
+      "resolved": "packages/whale-api-wallet",
       "link": true
     },
     "node_modules/@docsearch/css": {
@@ -7146,130 +7088,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/visitor-keys": "5.14.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "5.14.0",
-        "debug": "^4.3.2",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "*"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/visitor-keys": "5.14.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-      "dev": true,
-      "dependencies": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.14.0",
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/typescript-estree": "5.14.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/types": "5.14.0",
-        "eslint-visitor-keys": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -12009,6 +11827,7 @@
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -12027,17 +11846,9 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/ajv": {
@@ -26464,6 +26275,18 @@
         "defichain": "^0.0.0"
       }
     },
+    "packages/whale-api-wallet": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@defichain/jellyfish-transaction-builder": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
+        "@defichain/whale-api-client": "^0.0.0"
+      },
+      "peerDependencies": {
+        "defichain": "^0.0.0"
+      }
+    },
     "website": {
       "name": "@defichain/website",
       "version": "0.0.0",
@@ -28069,8 +27892,6 @@
         "@types/lodash": "^4.14.179",
         "@types/node": "^16.11.26",
         "@types/supertest": "^2.0.11",
-        "@typescript-eslint/eslint-plugin": "^5.13.0",
-        "@typescript-eslint/parser": "^5.14.0",
         "cache-manager": "^3.6.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
@@ -28140,35 +27961,6 @@
             "fs-extra": "10.0.1",
             "jsonc-parser": "3.0.0",
             "pluralize": "8.0.0"
-          }
-        },
-        "@typescript-eslint/eslint-plugin": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-          "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "5.14.0",
-            "@typescript-eslint/type-utils": "5.14.0",
-            "@typescript-eslint/utils": "5.14.0",
-            "debug": "^4.3.2",
-            "functional-red-black-tree": "^1.0.1",
-            "ignore": "^5.1.8",
-            "regexpp": "^3.2.0",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/parser": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-          "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "5.14.0",
-            "@typescript-eslint/types": "5.14.0",
-            "@typescript-eslint/typescript-estree": "5.14.0",
-            "debug": "^4.3.2"
           }
         },
         "defichain": {
@@ -28393,6 +28185,14 @@
         "abort-controller": "^3.0.0",
         "cross-fetch": "^3.1.5",
         "url-search-params-polyfill": "8.1.1"
+      }
+    },
+    "@defichain/whale-api-wallet": {
+      "version": "file:packages/whale-api-wallet",
+      "requires": {
+        "@defichain/jellyfish-transaction-builder": "^0.0.0",
+        "@defichain/jellyfish-wallet": "^0.0.0",
+        "@defichain/whale-api-client": "^0.0.0"
       }
     },
     "@docsearch/css": {
@@ -32075,72 +31875,6 @@
         }
       }
     },
-    "@typescript-eslint/scope-manager": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/visitor-keys": "5.14.0"
-      }
-    },
-    "@typescript-eslint/type-utils": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/utils": "5.14.0",
-        "debug": "^4.3.2",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-      "dev": true
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/visitor-keys": "5.14.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
-        "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
-    },
-    "@typescript-eslint/utils": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.14.0",
-        "@typescript-eslint/types": "5.14.0",
-        "@typescript-eslint/typescript-estree": "5.14.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
-      }
-    },
-    "@typescript-eslint/visitor-keys": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-      "dev": true,
-      "requires": {
-        "@typescript-eslint/types": "5.14.0",
-        "eslint-visitor-keys": "^3.0.0"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -34860,6 +34594,7 @@
         "@defichain/testing": "file:packages/testing",
         "@defichain/website": "file:website",
         "@defichain/whale-api-client": "file:packages/whale-api-client",
+        "@defichain/whale-api-wallet": "file:packages/whale-api-wallet",
         "@types/jest": "^27.4.1",
         "defichain": "file:",
         "eslint": "^7.32.0",
@@ -36459,8 +36194,6 @@
             "@types/lodash": "^4.14.179",
             "@types/node": "^16.11.26",
             "@types/supertest": "^2.0.11",
-            "@typescript-eslint/eslint-plugin": "^5.13.0",
-            "@typescript-eslint/parser": "^5.14.0",
             "cache-manager": "^3.6.0",
             "class-transformer": "^0.5.1",
             "class-validator": "^0.13.2",
@@ -36530,35 +36263,6 @@
                 "fs-extra": "10.0.1",
                 "jsonc-parser": "3.0.0",
                 "pluralize": "8.0.0"
-              }
-            },
-            "@typescript-eslint/eslint-plugin": {
-              "version": "5.14.0",
-              "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-              "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
-              "dev": true,
-              "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
-                "debug": "^4.3.2",
-                "functional-red-black-tree": "^1.0.1",
-                "ignore": "^5.1.8",
-                "regexpp": "^3.2.0",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-              }
-            },
-            "@typescript-eslint/parser": {
-              "version": "5.14.0",
-              "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-              "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
-              "dev": true,
-              "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
-                "debug": "^4.3.2"
               }
             },
             "defichain": {
@@ -36783,6 +36487,14 @@
             "abort-controller": "^3.0.0",
             "cross-fetch": "^3.1.5",
             "url-search-params-polyfill": "8.1.1"
+          }
+        },
+        "@defichain/whale-api-wallet": {
+          "version": "file:packages/whale-api-wallet",
+          "requires": {
+            "@defichain/jellyfish-transaction-builder": "^0.0.0",
+            "@defichain/jellyfish-wallet": "^0.0.0",
+            "@defichain/whale-api-client": "^0.0.0"
           }
         },
         "@docsearch/css": {
@@ -40463,72 +40175,6 @@
               "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
               "dev": true
             }
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-          "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.14.0",
-            "@typescript-eslint/visitor-keys": "5.14.0"
-          }
-        },
-        "@typescript-eslint/type-utils": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-          "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/utils": "5.14.0",
-            "debug": "^4.3.2",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-          "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-          "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.14.0",
-            "@typescript-eslint/visitor-keys": "5.14.0",
-            "debug": "^4.3.2",
-            "globby": "^11.0.4",
-            "is-glob": "^4.0.3",
-            "semver": "^7.3.5",
-            "tsutils": "^3.21.0"
-          }
-        },
-        "@typescript-eslint/utils": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-          "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
-          "dev": true,
-          "requires": {
-            "@types/json-schema": "^7.0.9",
-            "@typescript-eslint/scope-manager": "5.14.0",
-            "@typescript-eslint/types": "5.14.0",
-            "@typescript-eslint/typescript-estree": "5.14.0",
-            "eslint-scope": "^5.1.1",
-            "eslint-utils": "^3.0.0"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "5.14.0",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-          "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "5.14.0",
-            "eslint-visitor-keys": "^3.0.0"
           }
         },
         "@webassemblyjs/ast": {
@@ -44243,6 +43889,7 @@
           "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
           "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
           },
@@ -44251,15 +43898,10 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
               "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-              "dev": true
+              "dev": true,
+              "peer": true
             }
           }
-        },
-        "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-          "dev": true
         },
         "espree": {
           "version": "7.3.1",
@@ -55769,6 +55411,7 @@
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "eslint-visitor-keys": "^2.0.0"
       },
@@ -55777,15 +55420,10 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
           "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
+          "dev": true,
+          "peer": true
         }
       }
-    },
-    "eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true
     },
     "espree": {
       "version": "7.3.1",


### PR DESCRIPTION
#### What this PR does / why we need it:

Remove `eslint` in `apps/package.json` as it's added globally in the mono repo, not used in apps.