### PR TITLE
feat(packages/jellyfish-wallet): expose deriveNode and derivePath to allow better abstraction of Wallet

### DIFF
--- a/packages/jellyfish-wallet/__tests__/wallet.test.ts
+++ b/packages/jellyfish-wallet/__tests__/wallet.test.ts
@@ -193,3 +193,35 @@ describe('get accounts on MASTERNODE', () => {
     expect(address).toStrictEqual('bcrt1qfyygclxhcwh97hyylhkn3asucae29x6qhnnh47')
   })
 })
+
+describe('deriveNode', () => {
+  const accountProvider = new TestAccountProvider([])
+  const wallet = new JellyfishWallet(nodeProvider, accountProvider)
+
+  it('should get account 0 (default address)', async () => {
+    const node = wallet.deriveNode(0)
+    const pubKey = await node.publicKey()
+    expect(pubKey.toString('hex')).toStrictEqual('03880a9552c2881b126d6d11d5639f3578d9fdf9c50207c5f220eb795ac5691148')
+  })
+
+  it('should get account 1', async () => {
+    const node = wallet.deriveNode(1)
+    const pubKey = await node.publicKey()
+    expect(pubKey.toString('hex')).toStrictEqual('0385f1e9d6d3a2a2c6ba2855f44c258564bc1951039f29bb32b029b565c59b2de4')
+  })
+})
+
+describe('derivePath', () => {
+  const accountProvider = new TestAccountProvider([])
+  const wallet = new JellyfishWallet(nodeProvider, accountProvider)
+
+  it('should get account 0 (default address)', async () => {
+    const path = wallet.derivePath(0)
+    expect(path).toStrictEqual('1129/0/0/0')
+  })
+
+  it('should get account 1', async () => {
+    const path = wallet.derivePath(1)
+    expect(path).toStrictEqual('1129/0/0/1')
+  })
+})

--- a/packages/jellyfish-wallet/src/wallet.ts
+++ b/packages/jellyfish-wallet/src/wallet.ts
@@ -31,21 +31,37 @@ export class JellyfishWallet<Account extends WalletAccount, HdNode extends Walle
    * @param {number} [purpose=0] PURPOSE_LIGHT_WALLET
    */
   constructor (
-    private readonly nodeProvider: WalletHdNodeProvider<HdNode>,
-    private readonly accountProvider: WalletAccountProvider<Account>,
-    private readonly coinType: number = JellyfishWallet.COIN_TYPE_DFI,
-    private readonly purpose: number = JellyfishWallet.PURPOSE_LIGHT_WALLET
+    protected readonly nodeProvider: WalletHdNodeProvider<HdNode>,
+    protected readonly accountProvider: WalletAccountProvider<Account>,
+    protected readonly coinType: number = JellyfishWallet.COIN_TYPE_DFI,
+    protected readonly purpose: number = JellyfishWallet.PURPOSE_LIGHT_WALLET
   ) {
   }
 
   /**
    * @param {number} account number to get
-   * @return Promise<WalletAccount>
+   * @return {WalletAccount}
    */
   get (account: number): Account {
-    const path = `${this.coinType}/${this.purpose}/0/${account}`
-    const node = this.nodeProvider.derive(path)
+    const node = this.deriveNode(account)
     return this.accountProvider.provide(node)
+  }
+
+  /**
+   * @param {number} account number to get
+   * @return {WalletHdNode}
+   */
+  deriveNode (account: number): HdNode {
+    const path = this.derivePath(account)
+    return this.nodeProvider.derive(path)
+  }
+
+  /**
+   * @param {number} account number to get
+   * @return {string} HD path
+   */
+  derivePath (account: number): string {
+    return `${this.coinType}/${this.purpose}/0/${account}`
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Node and path derivation were previously embedded within `wallet.get()` routine. This makes it difficult for downstream implementation to use Wallet as an Abstraction to build custom patterns. This PR exposes those two functions as separate methods.

This PR also updates all wallet class parameters from `private readonly` to `protected readonly` for the same effect.