### PR TITLE
feat(packages/jellyfish-wallet-mnemonic): validate 24 words optionally

### DIFF
--- a/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
+++ b/packages/jellyfish-wallet-mnemonic/__tests__/bip32.test.ts
@@ -43,6 +43,37 @@ const prevout: Vout = {
   tokenId: 0x00
 }
 
+describe('validation', () => {
+  it('should validate mnemonic sentence and succeed 1000 times', () => {
+    for (let i = 0; i < 1000; i++) {
+      const words = MnemonicHdNodeProvider.generateWords(24)
+      MnemonicHdNodeProvider.fromWords(words, regTestBip32Options, true)
+    }
+  })
+
+  it('should validate mnemonic sentence and fail 1000 times', () => {
+    for (let i = 0; i < 1000; i++) {
+      const words = MnemonicHdNodeProvider.generateWords(24)
+      words[0] = 'mnemonic'
+
+      expect(() => {
+        MnemonicHdNodeProvider.fromWords(words, regTestBip32Options, true)
+      }).toThrow('mnemonic sentence checksum invalid')
+    }
+  })
+
+  it('should not validate mnemonic sentence and not fail 1000 times', () => {
+    for (let i = 0; i < 1000; i++) {
+      const words = MnemonicHdNodeProvider.generateWords(24)
+      words[0] = 'mnemonic'
+
+      expect(() => {
+        MnemonicHdNodeProvider.fromWords(words, regTestBip32Options, false)
+      }).not.toThrow('mnemonic sentence checksum invalid')
+    }
+  })
+})
+
 describe('24 words: random', () => {
   let provider: MnemonicHdNodeProvider
 
@@ -51,11 +82,11 @@ describe('24 words: random', () => {
     provider = MnemonicHdNodeProvider.fromWords(words, regTestBip32Options)
   })
 
-  describe("44'/1129'/0'/0/0", () => {
+  describe('44\'/1129\'/0\'/0/0', () => {
     let node: MnemonicHdNode
 
     beforeEach(() => {
-      node = provider.derive("44'/1129'/0'/0/0")
+      node = provider.derive('44\'/1129\'/0\'/0/0')
     })
 
     it('should derive pub key', async () => {
@@ -156,12 +187,12 @@ describe('24 words: abandon x23 art', () => {
     provider = MnemonicHdNodeProvider.fromWords(words, regTestBip32Options)
   })
 
-  describe("44'/1129'/0'/0/0", () => {
+  describe('44\'/1129\'/0\'/0/0', () => {
     let node: MnemonicHdNode
     const pubKey = '034849fafd49b531a2b8a101993c34ea5c70bdc094fd4fc45d2fca2068d2143553'
 
     beforeEach(() => {
-      node = provider.derive("44'/1129'/0'/0/0")
+      node = provider.derive('44\'/1129\'/0\'/0/0')
     })
 
     it('should derive pub key', async () => {
@@ -203,12 +234,12 @@ describe('24 words: abandon x23 art', () => {
     })
   })
 
-  describe("44'/1129'/1'/0/0", () => {
+  describe('44\'/1129\'/1\'/0/0', () => {
     let node: MnemonicHdNode
     const pubKey = '032a530c06df4a2b4e50863da169733d57ec07c598f8188e5a0341952fa2580075'
 
     beforeEach(() => {
-      node = provider.derive("44'/1129'/1'/0/0")
+      node = provider.derive('44\'/1129\'/1\'/0/0')
     })
 
     it('should derive pub key', async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

While BIP39 standard doesn't enforce validation of words to generate the HD seed, this implementation optionally allows you to validate the BIP39 word list before generating the MnemonicProviderData.

```ts
/**
 * @param {boolean} [validate=false] optionally validate mnemonic words. While BIP39 standard doesn't enforce
 * validation of words to generate the HD seed, this implementation optionally allow you to validate the BIP39 
 * word list before generating the MnemonicProviderData.
 *
 * @throws {Error} if mnemonic sentence checksum invalid, if validate=true
 */
static wordsToData (words: string[], options: Bip32Options, validate: boolean = false): MnemonicProviderData {
  if (validate && !validateMnemonicSentence(words)) {
    throw new Error('mnemonic sentence checksum invalid')
  }
  // ...
}
```
