### PR TITLE
chore(website): fix docusaurus failed build due to deprecation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -16,10 +16,6 @@ module.exports = {
     },
     colorMode: {
       defaultMode: 'light',
-      switchConfig: {
-        darkIcon: '🌙',
-        lightIcon: '💡'
-      },
       respectPrefersColorScheme: true
     },
     navbar: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Release version v2.0.0-beta.17 deprecated `switchConfig` from the theme, causing build to fail.

https://github.com/facebook/docusaurus/releases/tag/v2.0.0-beta.17

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1223

#### Additional comments?:
Looks like they have plans for quite some breaking changes in their 2.0.0 release milestone.
https://github.com/facebook/docusaurus/milestone/15