### PR TITLE
docs(apps/legacy-api): 02-dex.mdx add corrected `/v2/listswaps` note

### DIFF
--- a/.idea/dictionaries/fuxing.xml
+++ b/.idea/dictionaries/fuxing.xml
@@ -150,6 +150,7 @@
       <w>listmasternodes</w>
       <w>listpoolpairs</w>
       <w>listpoolshares</w>
+      <w>listswaps</w>
       <w>listunspent</w>
       <w>listvaults</w>
       <w>liveness</w>

--- a/docs/legacy/02-dex.mdx
+++ b/docs/legacy/02-dex.mdx
@@ -14,7 +14,7 @@ Endpoint: https://api.defichain.com/v2/listswaps
 :::caution DEPRECATED `/v1/listswaps`
 
 On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted.
-**`/v2/listswaps` is the corrected version.** `/v1/listswaps` has been deprecated but still be supported.
+**`/v2/listswaps` is the corrected version.** `/v1/listswaps` has been deprecated but will still be supported.
 
 :::
 

--- a/docs/legacy/02-dex.mdx
+++ b/docs/legacy/02-dex.mdx
@@ -11,8 +11,12 @@ slug: /dex
 
 Endpoint: https://api.defichain.com/v2/listswaps
 
-> On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted. `/v2/listswaps` is the corrected
-> version. `/v1/listswaps` is deprecated but still be supported.
+:::caution DEPRECATED `/v1/listswaps`
+
+On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted.
+**`/v2/listswaps` is the corrected version.** `/v1/listswaps` is deprecated but still be supported.
+
+:::
 
 Query params:
 

--- a/docs/legacy/02-dex.mdx
+++ b/docs/legacy/02-dex.mdx
@@ -14,7 +14,7 @@ Endpoint: https://api.defichain.com/v2/listswaps
 :::caution DEPRECATED `/v1/listswaps`
 
 On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted.
-**`/v2/listswaps` is the corrected version.** `/v1/listswaps` is deprecated but still be supported.
+**`/v2/listswaps` is the corrected version.** `/v1/listswaps` has been deprecated but still be supported.
 
 :::
 

--- a/docs/legacy/02-dex.mdx
+++ b/docs/legacy/02-dex.mdx
@@ -9,7 +9,10 @@ slug: /dex
 
 ## C1: Uniswap Sample
 
-Endpoint: https://api.defichain.com/v1/listswaps
+Endpoint: https://api.defichain.com/v2/listswaps
+
+> On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted. `/v2/listswaps` is the corrected
+> version. `/v1/listswaps` is deprecated but still be supported.
 
 Query params:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Endpoint: https://api.defichain.com/v2/listswaps

> On the previous version of `/v1/listswaps`; `last_price` was mistakenly inverted. `/v2/listswaps` is the corrected
> version. `/v1/listswaps` is deprecated but still be supported.
