### PR TITLE
chore(apps/legacy-api): use rootserver for DRYness

### DIFF
--- a/apps/legacy-api/src/index.ts
+++ b/apps/legacy-api/src/index.ts
@@ -1,40 +1,11 @@
-import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify'
-import { NestFactory } from '@nestjs/core'
-import { ConfigService } from '@nestjs/config'
 import { RootModule } from './modules/RootModule'
+import { NestFastifyApplication } from '@nestjs/platform-fastify'
+import { NestFactory } from '@nestjs/core'
+import { RootServer } from '@defichain-apps/libs/rootserver'
 
-export class RootServer {
-  app?: NestFastifyApplication
-
+export class LegacyApiServer extends RootServer {
   async create (): Promise<NestFastifyApplication> {
-    const adapter = new FastifyAdapter({ logger: true })
-    return await NestFactory.create<NestFastifyApplication>(RootModule, adapter)
-  }
-
-  async configure (app: NestFastifyApplication): Promise<void> {
-    app.enableCors({
-      origin: '*',
-      methods: ['GET'],
-      allowedHeaders: ['Content-Type'],
-      maxAge: 60 * 24 * 7
-    })
-  }
-
-  async init (app: NestFastifyApplication, config: ConfigService): Promise<void> {
-    const port = config.get<number>('PORT', 3000)
-    await app.listen(port, '0.0.0.0')
-  }
-
-  async start (): Promise<void> {
-    this.app = await this.create()
-    const config = this.app.get(ConfigService)
-
-    await this.configure(this.app)
-    await this.init(this.app, config)
-  }
-
-  async stop (): Promise<void> {
-    await this.app?.close()
+    return await NestFactory.create<NestFastifyApplication>(RootModule, this.adapter)
   }
 }
 
@@ -42,5 +13,5 @@ export class RootServer {
  * Bootstrap RootModule and start server
  */
 if (require.main === module) {
-  void new RootServer().start()
+  void new LegacyApiServer().start()
 }

--- a/apps/legacy-api/testing/LegacyStubServer.ts
+++ b/apps/legacy-api/testing/LegacyStubServer.ts
@@ -1,13 +1,13 @@
 import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import { RootModule } from '../src/modules/RootModule'
-import { RootServer } from '../src'
+import { LegacyApiServer } from '../src'
 import { ConfigModule, ConfigService } from '@nestjs/config'
 
 /**
  * Service stubs are simulations of a real service, which are used for functional testing.
  */
-export class LegacyStubServer extends RootServer {
+export class LegacyStubServer extends LegacyApiServer {
   private readonly allRoutes: RegisteredRoute[] = []
 
   async create (): Promise<NestFastifyApplication> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Change legacy-api to use RootServer to reduce code duplication
