### PR TITLE
chore(apps/whale): exclude tests from build and change 'whale-api' references to just 'whale'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@
 /apps/playground-api/                           @fuxingloh @canonbrother
 /packages/playground-api-client/                @fuxingloh @canonbrother
 
-/apps/whale-api/                                @fuxingloh @canonbrother @ivan-zynesis @jingyi2811 @kodemon
+/apps/whale/                                    @fuxingloh @canonbrother @ivan-zynesis @jingyi2811 @kodemon
 /packages/whale-api-client/                     @fuxingloh @canonbrother @ivan-zynesis @jingyi2811 @kodemon
 /packages/whale-api-wallet/                     @fuxingloh @canonbrother @ivan-zynesis @jingyi2811 @kodemon
 

--- a/apps/nest-cli.json
+++ b/apps/nest-cli.json
@@ -29,7 +29,7 @@
       "entryFile": "apps/rich-list-api/src/index",
       "sourceRoot": "rich-list-api/src"
     },
-    "whale-api": {
+    "whale": {
       "type": "application",
       "root": "whale",
       "entryFile": "apps/whale/src/main",

--- a/apps/package.json
+++ b/apps/package.json
@@ -12,7 +12,7 @@
     "start:ocean-api": "nest start ocean-api",
     "start:playground-api": "nest start playground-api",
     "start:rich-list-api": "nest start rich-list-api",
-    "start:whale-api": "nest start whale-api",
+    "start:whale": "nest start whale",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/apps/tsconfig.json
+++ b/apps/tsconfig.json
@@ -4,6 +4,10 @@
     "./*/src",
     "./libs/*/src"
   ],
+  "exclude": [
+    "**/*spec.ts",
+    "**/*e2e.ts"
+  ],
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
- exclude tests from tsbuild
- some references to `whale-api` still exist, but should be `whale` as it was changed: https://github.com/DeFiCh/jellyfish/pull/1248#pullrequestreview-918283735

#### Which issue(s) does this PR fixes?:
Part of #977
