### PR TITLE
feat(rich-list-core): remove use of droppedFrom db for invalidation

### DIFF
--- a/packages/rich-list-core/__tests__/RichListCore.test.ts
+++ b/packages/rich-list-core/__tests__/RichListCore.test.ts
@@ -1,6 +1,6 @@
-import { BigNumber } from '@defichain/jellyfish-api-core'
 import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import waitForExpect from 'wait-for-expect'
 import { RichListCore } from '../src/RichListCore'
 import { RichListCoreTest, waitForCatchingUp } from '../test/RichListCoreTest'
 
@@ -76,35 +76,50 @@ describe('RichListCore', () => {
     })
   })
 
-  describe('setRichListLength()', () => {
-    it('should control rich list query output length', async () => {
+  describe('invalidate', () => {
+    async function rpcInvalidate (container: MasterNodeRegTestContainer, invalidateHeight: number): Promise<void> {
+      const invalidateBlockHash = await container.call('getblockhash', [invalidateHeight])
+      await container.call('invalidateblock', [invalidateBlockHash])
+      await container.call('clearmempool')
+    }
+
+    it('should invalidate if is not best chain', async () => {
+      const newAddr = await container.getNewAddress()
+      await apiClient.wallet.sendToAddress(newAddr, 100)
+      await container.generate(1)
+      await apiClient.wallet.sendToAddress(newAddr, 100)
+      await container.generate(1)
       richListCore.start()
       await waitForCatchingUp(richListCore)
-
-      richListCore.setRichListLength(3)
       await richListCore.calculateNext()
 
       const richList = await richListCore.get('-1')
-      expect(richList.length).toStrictEqual(3)
-
+      expect(richList).toContainEqual({ address: newAddr, amount: 200 })
       for (let i = 0; i < richList.length - 1; i++) {
         const current = richList[i]
         const next = richList[i + 1]
-        expect(EXPECTED_RICH_LIST_ADDRESSES).toContain(current.address)
-        expect(EXPECTED_RICH_LIST_ADDRESSES).toContain(next.address)
         expect(current.amount).toBeGreaterThanOrEqual(next.amount)
       }
 
-      const excludedFromTopThree = await richListCore.addressBalances.list({
-        partition: '-1', // token id for utxo
-        order: 'DESC',
-        limit: Number.MAX_SAFE_INTEGER,
-        lt: new BigNumber(richList[2].amount).times('1e8').dividedToIntegerBy(1).toNumber()
-      })
-      expect(excludedFromTopThree.length).toStrictEqual(EXPECTED_RICH_LIST_ADDRESSES.length - 3)
+      const curHeight = await apiClient.blockchain.getBlockCount()
+      await rpcInvalidate(container, curHeight)
+      await waitForExpect(async () => {
+        const newHeight = await apiClient.blockchain.getBlockCount()
+        expect(newHeight).toBeLessThan(curHeight)
+      }, 30000)
+      await container.generate(2)
 
-      for (let i = 0; i < excludedFromTopThree.length; i++) {
-        expect(excludedFromTopThree[i].data.amount).toBeLessThanOrEqual(richList[2].amount)
+      richListCore.start()
+      await waitForCatchingUp(richListCore)
+      await richListCore.calculateNext()
+
+      const newRichList = await richListCore.get('-1')
+      expect(newRichList).toContainEqual({ address: newAddr, amount: 100 })
+      // Should still keep the order.
+      for (let i = 0; i < newRichList.length - 1; i++) {
+        const current = newRichList[i]
+        const next = newRichList[i + 1]
+        expect(current.amount).toBeGreaterThanOrEqual(next.amount)
       }
     })
   })

--- a/packages/rich-list-core/test/RichListCoreTest.ts
+++ b/packages/rich-list-core/test/RichListCoreTest.ts
@@ -11,7 +11,6 @@ export function RichListCoreTest (apiClient: JsonRpcClient): RichListCore {
     new StubbedWhaleApiClient(),
     new InMemoryDatabase<AddressBalance>(),
     new InMemoryDatabase<CrawledBlock>(),
-    new InMemoryDatabase<string>(),
     new InMemoryQueueClient()
   )
 }

--- a/packages/rich-list-core/test/RichListCoreTest.ts
+++ b/packages/rich-list-core/test/RichListCoreTest.ts
@@ -8,9 +8,10 @@ export function RichListCoreTest (apiClient: JsonRpcClient): RichListCore {
   return new RichListCore(
     'regtest',
     apiClient, // using defid rpc directly for test instead of exposed via whale
-    new StubbedWhaleApiClient(),
+    new StubbedWhaleApiClient(apiClient),
     new InMemoryDatabase<AddressBalance>(),
     new InMemoryDatabase<CrawledBlock>(),
+    new InMemoryDatabase<string>(),
     new InMemoryQueueClient()
   )
 }

--- a/packages/rich-list-core/test/StubbedWhaleClient.ts
+++ b/packages/rich-list-core/test/StubbedWhaleClient.ts
@@ -1,3 +1,5 @@
+import { BigNumber } from '@defichain/jellyfish-api-core'
+import { JsonRpcClient } from '@defichain/jellyfish-api-jsonrpc'
 import { ApiMethod, ResponseAsString, WhaleApiClient } from '@defichain/whale-api-client'
 
 /**
@@ -6,7 +8,7 @@ import { ApiMethod, ResponseAsString, WhaleApiClient } from '@defichain/whale-ap
  * stub each required method one by one as usage is minimal
  */
 export class StubbedWhaleApiClient extends WhaleApiClient {
-  constructor () {
+  constructor (private readonly rpcClient: JsonRpcClient) {
     super({ url: 'stubbed' })
     this.stubMethods()
   }
@@ -18,9 +20,18 @@ export class StubbedWhaleApiClient extends WhaleApiClient {
 
   private stubMethods (): void {
     this.address.getBalance = async (address: string): Promise<string> => {
-      const power = Math.round(Math.random() * 4)
-      const coef = Math.random()
-      return `${coef * Math.pow(10, power)}`
+      // const power = Math.round(Math.random() * 4)
+      // const coef = Math.random()
+      const utxoBals = (await this.rpcClient.wallet.listUnspent()).filter(val => val.address === address)
+      let totalUtxoBal = new BigNumber(0)
+      utxoBals.forEach(utxo => {
+        totalUtxoBal = totalUtxoBal.plus(utxo.amount)
+      })
+      // So this is done specifically this way
+      // As there is some conflict with the previous test cases
+      // TODO: Determine if we should use rpcClient for stubbing, or
+      // keep to using random values, as its not compatible with each other.
+      return totalUtxoBal.toString()
     }
   }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

This is a patch for `rich-list-core` which removes the use of `droppedFromRichList` single index db in the invalidation process.

This is due to the change in design decisions, from only storing the top 1000 richest, to keeping balance for every address instead.

#### Additional comments?:
This is a patch for #1084.