### PR TITLE
feat(apps/legacy-api): perf improvement with caching

### DIFF
--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -289,7 +289,7 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(0)
   })
 
-  it('/v1/getsubgraphswaps?limit=101 - limited to 30', async () => {
+  it('/v1/getsubgraphswaps?limit=101 - limited to 100', async () => {
     const res = await apiTesting.app.inject({
       method: 'GET',
       url: '/v1/getsubgraphswaps?limit=101'
@@ -298,7 +298,7 @@ describe('getsubgraphswaps', () => {
     expect(response.data.swaps.length).toStrictEqual(100)
   })
 
-  it('should paginate', async () => {
+  it('/v1/getsubgraphswaps?limit=X&next=Y - should paginate', async () => {
     const [swap1And2, swap1]: any = await Promise.all([
       apiTesting.app.inject({
         method: 'GET',
@@ -326,7 +326,7 @@ describe('getsubgraphswaps - relying on caching', () => {
     // Given caching enabled and cache is filled sufficiently
     await waitForCondition(
       async () => apiTesting.app.get(SwapCacheFiller).isReady,
-      60_000 // 60s
+      30_000 // 30s
     )
   })
 

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -326,7 +326,7 @@ describe('getsubgraphswaps - relying on caching', () => {
     // Given caching enabled and cache is filled sufficiently
     await waitForCondition(
       async () => apiTesting.app.get(SwapCacheFiller).isReady,
-      30_000 // 30s
+      60_000 // 60s
     )
   })
 

--- a/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
+++ b/apps/legacy-api/__tests__/controllers/PoolPairController.test.ts
@@ -1,5 +1,8 @@
 import { LegacyApiTesting } from '../../testing/LegacyApiTesting'
 import { PoolPairData } from '@defichain/whale-api-client/src/api/PoolPairs'
+import { SupportedNetwork } from 'apps/legacy-api/src/pipes/NetworkValidationPipe'
+import { encodeBase64, SwapCacheFiller } from '../../src/controllers/PoolPairController'
+import { waitForCondition } from '@defichain/testcontainers'
 
 const ONLY_DECIMAL_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/
 
@@ -205,14 +208,38 @@ it('/v1/listyieldfarming', async () => {
     provider_logo: 'https://defichain.com/downloads/symbol-defi-blockchain.svg',
     provider_URL: 'https://defichain.com',
     links: [
-      { title: 'Twitter', link: 'https://twitter.com/defichain' },
-      { title: 'YouTube', link: 'https://www.youtube.com/DeFiChain' },
-      { title: 'Reddit', link: 'https://reddit.com/r/defiblockchain' },
-      { title: 'Telegram', link: 'https://t.me/defiblockchain' },
-      { title: 'LinkedIn', link: 'https://www.linkedin.com/company/defichain' },
-      { title: 'Facebook', link: 'https://www.facebook.com/defichain.official' },
-      { title: 'GitHub', link: 'https://github.com/DeFiCh' },
-      { title: 'Discord', link: 'https://discord.com/invite/py55egyaGy' }
+      {
+        title: 'Twitter',
+        link: 'https://twitter.com/defichain'
+      },
+      {
+        title: 'YouTube',
+        link: 'https://www.youtube.com/DeFiChain'
+      },
+      {
+        title: 'Reddit',
+        link: 'https://reddit.com/r/defiblockchain'
+      },
+      {
+        title: 'Telegram',
+        link: 'https://t.me/defiblockchain'
+      },
+      {
+        title: 'LinkedIn',
+        link: 'https://www.linkedin.com/company/defichain'
+      },
+      {
+        title: 'Facebook',
+        link: 'https://www.facebook.com/defichain.official'
+      },
+      {
+        title: 'GitHub',
+        link: 'https://github.com/DeFiCh'
+      },
+      {
+        title: 'Discord',
+        link: 'https://discord.com/invite/py55egyaGy'
+      }
     ]
   })
 })
@@ -268,6 +295,181 @@ describe('getsubgraphswaps', () => {
       url: '/v1/getsubgraphswaps?limit=101'
     })
     const response = res.json()
-    expect(response.data.swaps.length).toStrictEqual(30)
+    expect(response.data.swaps.length).toStrictEqual(100)
+  })
+
+  it('should paginate correctly', async () => {
+    const swap1 = {
+      id: '034cbe632cd15bd186d1977f6bb2cf122e61020d5527870ce6d6c80526fb6c5a',
+      timestamp: '1648795499',
+      from: { amount: '417.15100000', symbol: 'USDT' },
+      to: { amount: '417.34346336', symbol: 'DUSD' }
+    }
+    const swap2 = {
+      id: '83f1b597cdb9777d7a98c51e945453b706fbd2e24a7be8cd36f56d7e83a69664',
+      timestamp: '1648795390',
+      from: { amount: '11.56907797', symbol: 'DFI' },
+      to: { amount: '0.25767674', symbol: 'AAPL' }
+    }
+    const swap3 = {
+      id: 'd2122646688c01dc03814dc8ae46cf05d3d07df6acadeb153c32d317aedc6000',
+      timestamp: '1648795366',
+      from: { amount: '6225.00000000', symbol: 'DUSD' },
+      to: { amount: '14.91801818', symbol: 'NFLX' }
+    }
+
+    // When endpoint is queried with pagination token starting from block 1757725 tx 0
+    const swapsResponseAll = (await apiTesting.app.inject({
+      method: 'GET',
+      url: `/v1/getsubgraphswaps?limit=3&next=${encodeBase64({ height: '1757725', order: '0' })}`
+    })).json()
+
+    // Then swaps are returned from the correct page, starting from BEFORE swap1
+    expect(swapsResponseAll).toStrictEqual({
+      data: {
+        swaps: [swap1, swap2, swap3]
+      },
+      page: {
+        next: encodeBase64({
+          height: '1757722',
+          order: '5',
+          index: '1'
+        })
+      }
+    })
+
+    // When endpoint is queried with pagination token starting BEFORE swap1
+    const swapsResponse1 = (await apiTesting.app.inject({
+      method: 'GET',
+      url: `/v1/getsubgraphswaps?limit=1&next=${encodeBase64({ height: '1757725', order: '0' })}`
+    })).json()
+    // Then swap1 is returned
+    expect(swapsResponse1).toStrictEqual({
+      data: {
+        swaps: [swap1]
+      },
+      page: {
+        next: encodeBase64({
+          height: '1757724',
+          order: '0',
+          index: '0'
+        })
+      }
+    })
+
+    // When endpoint is queried with pagination token from previous response (start from swap1)
+    const swapsResponse2 = (await apiTesting.app.inject({
+      method: 'GET',
+      url: `/v1/getsubgraphswaps?limit=1&next=${swapsResponse1.page.next as string}`
+    })).json()
+
+    // Then swap2 is returned
+    expect(swapsResponse2).toStrictEqual({
+      data: {
+        swaps: [swap2]
+      },
+      page: {
+        next: encodeBase64({
+          height: '1757722',
+          order: '0',
+          index: '0'
+        })
+      }
+    })
+
+    // When endpoint is queried with pagination token from previous response (start from swap2)
+    const swapsResponse3 = (await apiTesting.app.inject({
+      method: 'GET',
+      url: `/v1/getsubgraphswaps?limit=1&next=${swapsResponse2.page.next as string}`
+    })).json()
+
+    // Then swap3 is returned
+    expect(swapsResponse3.data.swaps[0]).toStrictEqual(swap3)
   })
 })
+
+describe('getsubgraphswaps - relying on caching', () => {
+  beforeAll(async () => {
+    // Given caching enabled and cache is filled sufficiently
+    await waitForCondition(
+      async () => apiTesting.app.get(SwapCacheFiller).isReady,
+      30_000 // 30s
+    )
+  })
+
+  it('/v1/getsubgraphswaps - should return 100 relatively quickly', async () => {
+    // When getsubgraphswaps query is made
+    const msStart = Date.now()
+    const res = await apiTesting.app.inject({
+      method: 'GET',
+      url: '/v1/getsubgraphswaps?limit=100'
+    })
+    // Then response is returned relatively quickly: less than 500ms
+    // As this test relies on production, avoid test flakiness due to network latency / ocean unavailable
+    // Emit warning instead of failing
+    const msElapsed = Date.now() - msStart
+    expect(msElapsed).toBeLessThanOrEqual(3_000)
+    if (msElapsed > 500) {
+      console.warn(
+        'legacy-api/getsubgraphswaps?limit=100: ' +
+        `took ${msElapsed}ms (> 500ms) to get a response`
+      )
+    }
+
+    // And number of swaps returned is correct
+    const response = res.json()
+    expect(response.data.swaps.length).toStrictEqual(100)
+
+    // And all swaps have correct shape
+    verifySwapsShape(response.data.swaps)
+
+    // And swaps are ordered by timestamp
+    verifySwapsOrdering(response.data.swaps, 'mainnet', 'desc')
+  })
+})
+
+export function verifySwapsShape (swaps: any[]): void {
+  const ONLY_DECIMAL_NUMBER_REGEX = /^[0-9]+(\.[0-9]+)?$/
+  for (const swap of swaps) {
+    expect(swap).toStrictEqual({
+      id: expect.stringMatching(/[a-zA-Z0-9]{64}/),
+      timestamp: expect.stringMatching(/\d+/),
+      from: {
+        symbol: expect.any(String),
+        amount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX)
+      },
+      to: {
+        symbol: expect.any(String),
+        amount: expect.stringMatching(ONLY_DECIMAL_NUMBER_REGEX)
+      }
+    })
+  }
+}
+
+export function verifySwapsOrdering (
+  swaps: any[],
+  network: SupportedNetwork,
+  order: 'asc' | 'desc' = 'asc'
+): void {
+// Since testsuite relies on mainnet / testnet, skip if fewer than 2 swaps
+  if (swaps.length < 2) {
+    console.warn(`No ${network} swaps found for this test run`)
+    return
+  }
+
+  // Verify swaps are ordered by timestamp in ascending order
+
+  if (order === 'asc') {
+    for (let i = 1; i < swaps.length; i++) {
+      const swap1 = swaps[i - 1]
+      const swap2 = swaps[i]
+      expect(Number(swap1.timestamp)).toBeLessThanOrEqual(Number(swap2.timestamp))
+    }
+  } else {
+    for (let i = 1; i < swaps.length; i++) {
+      const swap1 = swaps[i - 1]
+      const swap2 = swaps[i]
+      expect(Number(swap1.timestamp)).toBeGreaterThanOrEqual(Number(swap2.timestamp))
+    }
+  }
+}

--- a/apps/legacy-api/src/cache/SimpleCache.ts
+++ b/apps/legacy-api/src/cache/SimpleCache.ts
@@ -16,10 +16,10 @@ export class SimpleCache {
    * Get from cache, providing a fetch interface if cache miss.
    *
    * @param {string} key to get from cache
-   * @param {(id: string) => Promise<T | NO_VALUE>} fetch if miss cache
+   * @param {(id: string) => Promise<T | null>} fetch if miss cache
    * @param {GlobalCache} options
    * @param {number} [options.ttl=600] cache ttl, 600 seconds
-   * @return {Promise<T | NO_VALUE>}
+   * @return {Promise<T | null>}
    */
   async get<T> (
     key: string,
@@ -38,9 +38,3 @@ export class SimpleCache {
     return fetched
   }
 }
-
-/**
- * Allows null values to be cached, to indicate that the given look-up key has no value
- * This is different from `undefined` which indicates a cache miss
- */
-export const NO_VALUE = null

--- a/apps/legacy-api/src/cache/SimpleCache.ts
+++ b/apps/legacy-api/src/cache/SimpleCache.ts
@@ -1,0 +1,46 @@
+import { CACHE_MANAGER, Inject, Injectable } from '@nestjs/common'
+import { Cache } from 'cache-manager'
+
+export interface CacheOption {
+  ttl?: number
+}
+
+@Injectable()
+export class SimpleCache {
+  constructor (
+    @Inject(CACHE_MANAGER) protected readonly cacheManager: Cache
+  ) {
+  }
+
+  /**
+   * Get from cache, providing a fetch interface if cache miss.
+   *
+   * @param {string} key to get from cache
+   * @param {(id: string) => Promise<T | NO_VALUE>} fetch if miss cache
+   * @param {GlobalCache} options
+   * @param {number} [options.ttl=600] cache ttl, 600 seconds
+   * @return {Promise<T | NO_VALUE>}
+   */
+  async get<T> (
+    key: string,
+    fetch: (id: string) => Promise<T>,
+    options: CacheOption = {}
+  ): Promise<T> {
+    const cached = await this.cacheManager.get<T>(key)
+    if (cached !== undefined) {
+      return cached
+    }
+
+    const fetched = await fetch(key)
+    await this.cacheManager.set(key, fetched, {
+      ttl: options.ttl ?? 600
+    })
+    return fetched
+  }
+}
+
+/**
+ * Allows null values to be cached, to indicate that the given look-up key has no value
+ * This is different from `undefined` which indicates a cache miss
+ */
+export const NO_VALUE = null

--- a/apps/legacy-api/src/modules/ControllerModule.ts
+++ b/apps/legacy-api/src/modules/ControllerModule.ts
@@ -1,18 +1,24 @@
 import { CacheModule, Module } from '@nestjs/common'
 import { TokenController } from '../controllers/TokenController'
-import { PoolPairController, PoolPairControllerV2 } from '../controllers/PoolPairController'
+import { SwapCacheFiller, PoolPairController, PoolPairControllerV2 } from '../controllers/PoolPairController'
 import { MiscController } from '../controllers/MiscController'
 import { WhaleApiClientProvider } from '../providers/WhaleApiClientProvider'
 import { StatsController } from '../controllers/stats/StatsController'
 import { MainnetLegacyStatsProvider, TestnetLegacyStatsProvider } from '../controllers/stats/LegacyStatsProvider'
 import { ActuatorController } from '@defichain-apps/libs/actuator'
+import { ScheduleModule } from '@nestjs/schedule'
+import { SimpleCache } from '../cache/SimpleCache'
+import { ConfigService } from '@nestjs/config'
 
 /**
  * Exposed ApiModule for public interfacing
  */
 @Module({
   imports: [
-    CacheModule.register()
+    ScheduleModule.forRoot(),
+    CacheModule.register({
+      max: 1_000_000
+    })
   ],
   controllers: [
     TokenController,
@@ -25,7 +31,22 @@ import { ActuatorController } from '@defichain-apps/libs/actuator'
   providers: [
     WhaleApiClientProvider,
     MainnetLegacyStatsProvider,
-    TestnetLegacyStatsProvider
+    TestnetLegacyStatsProvider,
+    PoolPairController,
+    SimpleCache,
+    SwapCacheFiller,
+
+    {
+      provide: 'SWAP_CACHE_COUNT',
+      useFactory: (cfg: ConfigService): number => {
+        const swapCacheCount = cfg.get<string>('SWAP_CACHE_COUNT')
+        if (swapCacheCount === undefined) {
+          throw new Error('cfg:SWAP_CACHE_COUNT was not provided')
+        }
+        return Number(swapCacheCount)
+      },
+      inject: [ConfigService]
+    }
   ]
 })
 export class ControllerModule {

--- a/apps/legacy-api/src/modules/RootModule.ts
+++ b/apps/legacy-api/src/modules/RootModule.ts
@@ -5,11 +5,18 @@ import { WhaleApiModule } from './WhaleApiModule'
 import { ActuatorModule } from '@defichain-apps/libs/actuator'
 import { LoggingModule } from './LoggingModule'
 
+function AppConfiguration (): Record<string, any> {
+  return {
+    SWAP_CACHE_COUNT: process.env.SWAP_CACHE_COUNT ?? 1_000
+  }
+}
+
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      cache: true
+      cache: true,
+      load: [AppConfiguration]
     }),
     ActuatorModule,
     WhaleApiModule,

--- a/apps/legacy-api/testing/LegacyStubServer.ts
+++ b/apps/legacy-api/testing/LegacyStubServer.ts
@@ -51,7 +51,7 @@ export class LegacyStubServer extends LegacyApiServer {
 class TestConfigService extends ConfigService {
   constructor () {
     super({
-      SWAP_CACHE_COUNT: 150
+      SWAP_CACHE_COUNT: 50
     })
   }
 }

--- a/apps/legacy-api/testing/LegacyStubServer.ts
+++ b/apps/legacy-api/testing/LegacyStubServer.ts
@@ -2,7 +2,7 @@ import { FastifyAdapter, NestFastifyApplication } from '@nestjs/platform-fastify
 import { Test } from '@nestjs/testing'
 import { RootModule } from '../src/modules/RootModule'
 import { LegacyApiServer } from '../src'
-import { ConfigModule, ConfigService } from '@nestjs/config'
+import { ConfigService } from '@nestjs/config'
 
 /**
  * Service stubs are simulations of a real service, which are used for functional testing.
@@ -13,12 +13,12 @@ export class LegacyStubServer extends LegacyApiServer {
   async create (): Promise<NestFastifyApplication> {
     const module = await Test.createTestingModule({
       imports: [
-        RootModule,
-        ConfigModule.forFeature(() => {
-          return {}
-        })
+        RootModule
       ]
-    }).compile()
+    })
+      .overrideProvider(ConfigService)
+      .useValue(new TestConfigService())
+      .compile()
 
     const adapter = new FastifyAdapter({
       logger: false
@@ -45,6 +45,14 @@ export class LegacyStubServer extends LegacyApiServer {
       .addHook('onRoute', (opts: RegisteredRoute) => {
         this.allRoutes.push(opts)
       })
+  }
+}
+
+class TestConfigService extends ConfigService {
+  constructor () {
+    super({
+      SWAP_CACHE_COUNT: 150
+    })
   }
 }
 


### PR DESCRIPTION
What this PR does / why we need it:
- Introduces block-level + transaction-level swap caching for getsubgraphswaps query path
- Recent blocks (within chain height - 2) are not cached as they could be invalidated. However, transaction-level swap cache enables us to call AccountHistory rpc at most once for any given txn, hence largely side-stepping the performance bottleneck.

### Caveats
#### 1. Block-level caching of pool swaps needed to get response time in the milliseconds range
- Unfortunately, it's not enough to just cache by txid of the pool swap. Although the bottleneck of accounthistory rpc is side-stepped with this, the times from traversing blocks and their transactions add up.
- Hence, I tried caching the swaps by block hash instead, although we probably shouldn't cache recent blocks since they could be invalidated / more swaps could be added to them. 
- This was great for performance!

#### 2. Fixing pagination and making it work with this caching approach
- Pagination is currently wrongly implemented. Every returned `next` token when used to hit the endpoint again will **skip the block** even if there are pool swaps remaining in the block.
  ```
  blockchain = [ 
    block 2 [{ swap D }, ..., { swap C }, ..., { swap B }]
    block 1 [{ swap A }, ...]
  ]

  /getsubgraphswaps?limit=2 
    - gives: { swaps: [{ swap D }, { swap C }], page: XXX }

  /getsubgraphswaps?limit=2&next=XXX
    - should give:  [{ swap B }, { swap A }]
    - but gives:  [{ swap A }]
  ```
- This is due to the `next.height` value being returned to the client as the current block's height, say 2. So in the next pagination call, the provided `next.height` of 2 is passed to the node rpc call, thereby skipping block 2 (this is expected behaviour).
- We therefore should +1 to `next.height` if the swap **isn't the last swap in the block's swaps**.

Which issue(s) does this PR fixes?:
- Part of https://github.com/DeFiCh/jellyfish/issues/1024

# Sanity checks
- [x] Responses are the same as https://api.defichain.com/v1/getsubgraphswaps
- [x] Pagination is correct