### PR TITLE
feat(jellyfish-api-core): implement refundHtlcAll

### DIFF
--- a/docs/node/CATEGORIES/14-spv.md
+++ b/docs/node/CATEGORIES/14-spv.md
@@ -158,6 +158,20 @@ interface SendMessageResult {
 }
 ```
 
+## refundHtlcAll
+
+Gets all HTLC contracts stored in wallet and creates refunds transactions for all that have expired
+
+```ts title="client.spv.refundHtlcAll()"
+interface spv {
+  refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string>
+}
+
+interface SpvDefaultOptions {
+  feeRate?: BigNumber
+}
+```
+
 ## listHtlcOutputs
 
 List all outputs related to HTLC addresses in the wallet.

--- a/docs/node/CATEGORIES/14-spv.md
+++ b/docs/node/CATEGORIES/14-spv.md
@@ -164,7 +164,7 @@ Gets all HTLC contracts stored in wallet and creates refunds transactions for al
 
 ```ts title="client.spv.refundHtlcAll()"
 interface spv {
-  refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string>
+  refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string[]>
 }
 
 interface SpvDefaultOptions {

--- a/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
@@ -1,0 +1,210 @@
+import { MasterNodeRegTestContainer } from '@defichain/testcontainers'
+import { BigNumber, RpcApiError } from '@defichain/jellyfish-api-core'
+import { Testing } from '@defichain/jellyfish-testing'
+
+describe('Spv', () => {
+  let testing: Testing
+  let container: MasterNodeRegTestContainer
+
+  beforeEach(async () => {
+    testing = Testing.create(new MasterNodeRegTestContainer())
+    container = testing.container
+    await container.start()
+    await container.spv.fundAddress(await container.call('spv_getnewaddress')) // Funds 1 BTC
+  })
+
+  afterEach(async () => {
+    await container.stop()
+  })
+
+  it('should refundHtlcAll', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const htlc1 = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+    const htlc2 = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+
+    const fund1 = await container.call('spv_sendtoaddress', [htlc1.address, 0.1]) // Funds HTLC address
+    const fund2 = await container.call('spv_sendtoaddress', [htlc2.address, 0.2])
+    await container.spv.increaseSpvHeight(10)
+
+    const destinationAddress = await container.call('spv_getnewaddress')
+    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(typeof result).toStrictEqual('string')
+    expect(result.length).toStrictEqual(64)
+
+    /**
+     * Assert that refund happened
+     * confirms at 11 as it `increaseSpvHeight` increased height by 10,
+     * and refund action adds 1.
+     */
+    const outputList: any[] = await container.call('spv_listhtlcoutputs')
+    expect(outputList.length).toStrictEqual(2)
+    const output1 = outputList.find(({ txid }: { txid: string }) => txid === fund1.txid)
+    const output2 = outputList.find(({ txid }: { txid: string }) => txid === fund2.txid)
+    expect(output1).toStrictEqual({
+      txid: fund1.txid,
+      vout: expect.any(Number),
+      amount: new BigNumber(0.1).toNumber(),
+      address: htlc1.address,
+      confirms: 11,
+      spent: {
+        txid: result,
+        confirms: 1
+      }
+    })
+    expect(output2).toStrictEqual({
+      txid: fund2.txid,
+      vout: expect.any(Number),
+      amount: new BigNumber(0.2).toNumber(),
+      address: htlc2.address,
+      confirms: 11,
+      spent: {
+        txid: result,
+        confirms: 1
+      }
+    })
+
+    /**
+     * Assert that the destination address received the refund
+     */
+    const listReceivingAddresses: any[] = await container.call('spv_listreceivedbyaddress')
+    const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
+    expect(receivingAddress.address).toStrictEqual(destinationAddress)
+    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+  })
+
+  it('should refundHtlcAll for expired only', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const htlc1 = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+    const htlc2 = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '50'])
+
+    const fund1 = await container.call('spv_sendtoaddress', [htlc1.address, 0.1]) // Funds HTLC address
+    const fund2 = await container.call('spv_sendtoaddress', [htlc2.address, 0.2])
+    await container.spv.increaseSpvHeight(10)
+
+    const destinationAddress = await container.call('spv_getnewaddress')
+    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(typeof result).toStrictEqual('string')
+    expect(result.length).toStrictEqual(64)
+
+    /**
+     * Assert that refund happened
+     * confirms at 11 as it `increaseSpvHeight` increased height by 10,
+     * and refund action adds 1.
+     */
+    const outputList: any[] = await container.call('spv_listhtlcoutputs')
+    expect(outputList.length).toStrictEqual(2)
+    const output1 = outputList.find(({ txid }: { txid: string }) => txid === fund1.txid)
+    const output2 = outputList.find(({ txid }: { txid: string }) => txid === fund2.txid)
+    expect(output1).toStrictEqual({
+      txid: fund1.txid,
+      vout: expect.any(Number),
+      amount: new BigNumber(0.1).toNumber(),
+      address: htlc1.address,
+      confirms: 11,
+      spent: {
+        txid: result,
+        confirms: 1
+      }
+    })
+    expect(output2).toStrictEqual({
+      txid: fund2.txid,
+      vout: expect.any(Number),
+      amount: new BigNumber(0.2).toNumber(),
+      address: htlc2.address,
+      confirms: 11
+    })
+
+    /**
+     * Assert that the destination address received the refund
+     */
+    const listReceivingAddresses: any[] = await container.call('spv_listreceivedbyaddress')
+    const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
+    expect(receivingAddress.address).toStrictEqual(destinationAddress)
+    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+  })
+
+  it('should refundHtlcAll with custom feeRate', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const htlc = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+
+    const fund = await container.call('spv_sendtoaddress', [htlc.address, 0.1]) // Funds HTLC address
+    await container.spv.increaseSpvHeight()
+
+    const destinationAddress = await container.call('spv_getnewaddress')
+    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress, { feeRate: new BigNumber('20000') }) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(typeof result).toStrictEqual('string')
+    expect(result.length).toStrictEqual(64)
+
+    /**
+     * Assert that refund happened
+     * confirms at 11 as it `increaseSpvHeight` increased height by 10,
+     * and refund action adds 1.
+     */
+    const outputList: any[] = await container.call('spv_listhtlcoutputs')
+    expect(outputList.length).toStrictEqual(1)
+    const output = outputList.find(({ txid }: { txid: string }) => txid === fund.txid)
+    expect(output).toStrictEqual({
+      txid: fund.txid,
+      vout: expect.any(Number),
+      amount: new BigNumber(0.1).toNumber(),
+      address: htlc.address,
+      confirms: 11,
+      spent: {
+        txid: result,
+        confirms: 1
+      }
+    })
+
+    /**
+     * Assert that the destination address received the refund
+     */
+    const listReceivingAddresses = await container.call('spv_listreceivedbyaddress')
+    const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
+    expect(receivingAddress.address).toStrictEqual(destinationAddress)
+    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+  })
+
+  it('should not refundHtlcAll when no unspent HTLC outputs found', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+
+    const promise = testing.rpc.spv.refundHtlcAll(await container.call('spv_getnewaddress'))
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('No unspent HTLC outputs found')
+  })
+
+  it('should not refundHtlcAll with invalid destination address', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const htlc = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+
+    await container.call('spv_sendtoaddress', [htlc.address, 0.1]) // Funds HTLC address
+    await container.spv.increaseSpvHeight(10)
+
+    const promise = testing.rpc.spv.refundHtlcAll('XXXX')
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('Invalid destination address')
+  })
+
+  it('should not refundHtlcAll with not enough funds to cover fee', async () => {
+    const pubKeyA = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const pubKeyB = await container.call('spv_getaddresspubkey', [await container.call('spv_getnewaddress')])
+    const htlc = await container.call('spv_createhtlc', [pubKeyA, pubKeyB, '10'])
+
+    await testing.container.call('spv_sendtoaddress', [htlc.address, 0.00000546]) // Funds HTLC address with dust
+
+    const promise = testing.rpc.spv.refundHtlcAll(await container.call('spv_getnewaddress'))
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('No unspent HTLC outputs found')
+  })
+
+  it('should not refundHtlcAll when not htlc is created for wallet', async () => {
+    const promise = testing.rpc.spv.refundHtlcAll(await container.call('spv_getnewaddress'))
+    await expect(promise).rejects.toThrow(RpcApiError)
+    await expect(promise).rejects.toThrow('Redeem script details not found.')
+  })
+})

--- a/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
@@ -211,7 +211,7 @@ describe('Spv', () => {
     await expect(promise).rejects.toThrow('No unspent HTLC outputs found')
   })
 
-  it('should not refundHtlcAll when not htlc is created for wallet', async () => {
+  it('should not refundHtlcAll when no htlc is created for wallet', async () => {
     const promise = testing.rpc.spv.refundHtlcAll(await container.call('spv_getnewaddress'))
     await expect(promise).rejects.toThrow(RpcApiError)
     await expect(promise).rejects.toThrow('Redeem script details not found.')

--- a/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
+++ b/packages/jellyfish-api-core/__tests__/category/spv/refundHtlcAll.test.ts
@@ -28,9 +28,12 @@ describe('Spv', () => {
     await container.spv.increaseSpvHeight(10)
 
     const destinationAddress = await container.call('spv_getnewaddress')
-    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
-    expect(typeof result).toStrictEqual('string')
-    expect(result.length).toStrictEqual(64)
+    const results = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(results.length).toStrictEqual(1)
+    for (const txid of results) {
+      expect(typeof txid).toStrictEqual('string')
+      expect(txid.length).toStrictEqual(64)
+    }
 
     /**
      * Assert that refund happened
@@ -48,7 +51,7 @@ describe('Spv', () => {
       address: htlc1.address,
       confirms: 11,
       spent: {
-        txid: result,
+        txid: results[0],
         confirms: 1
       }
     })
@@ -59,7 +62,7 @@ describe('Spv', () => {
       address: htlc2.address,
       confirms: 11,
       spent: {
-        txid: result,
+        txid: results[0],
         confirms: 1
       }
     })
@@ -70,7 +73,7 @@ describe('Spv', () => {
     const listReceivingAddresses: any[] = await container.call('spv_listreceivedbyaddress')
     const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
     expect(receivingAddress.address).toStrictEqual(destinationAddress)
-    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+    expect(receivingAddress.txids.some((txid: string) => txid === results[0])).toStrictEqual(true)
   })
 
   it('should refundHtlcAll for expired only', async () => {
@@ -84,9 +87,12 @@ describe('Spv', () => {
     await container.spv.increaseSpvHeight(10)
 
     const destinationAddress = await container.call('spv_getnewaddress')
-    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
-    expect(typeof result).toStrictEqual('string')
-    expect(result.length).toStrictEqual(64)
+    const results = await testing.rpc.spv.refundHtlcAll(destinationAddress) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(results.length).toStrictEqual(1)
+    for (const txid of results) {
+      expect(typeof txid).toStrictEqual('string')
+      expect(txid.length).toStrictEqual(64)
+    }
 
     /**
      * Assert that refund happened
@@ -104,7 +110,7 @@ describe('Spv', () => {
       address: htlc1.address,
       confirms: 11,
       spent: {
-        txid: result,
+        txid: results[0],
         confirms: 1
       }
     })
@@ -122,7 +128,7 @@ describe('Spv', () => {
     const listReceivingAddresses: any[] = await container.call('spv_listreceivedbyaddress')
     const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
     expect(receivingAddress.address).toStrictEqual(destinationAddress)
-    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+    expect(receivingAddress.txids.some((txid: string) => txid === results[0])).toStrictEqual(true)
   })
 
   it('should refundHtlcAll with custom feeRate', async () => {
@@ -134,9 +140,12 @@ describe('Spv', () => {
     await container.spv.increaseSpvHeight()
 
     const destinationAddress = await container.call('spv_getnewaddress')
-    const result = await testing.rpc.spv.refundHtlcAll(destinationAddress, { feeRate: new BigNumber('20000') }) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
-    expect(typeof result).toStrictEqual('string')
-    expect(result.length).toStrictEqual(64)
+    const results = await testing.rpc.spv.refundHtlcAll(destinationAddress, { feeRate: new BigNumber('20000') }) // This refund should only happen after timeout threshold set in createHtlc. See https://en.bitcoin.it/wiki/BIP_0199
+    expect(results.length).toStrictEqual(1)
+    for (const txid of results) {
+      expect(typeof txid).toStrictEqual('string')
+      expect(txid.length).toStrictEqual(64)
+    }
 
     /**
      * Assert that refund happened
@@ -153,7 +162,7 @@ describe('Spv', () => {
       address: htlc.address,
       confirms: 11,
       spent: {
-        txid: result,
+        txid: results[0],
         confirms: 1
       }
     })
@@ -164,7 +173,7 @@ describe('Spv', () => {
     const listReceivingAddresses = await container.call('spv_listreceivedbyaddress')
     const receivingAddress = listReceivingAddresses.find(({ address }: { address: string }) => address === destinationAddress)
     expect(receivingAddress.address).toStrictEqual(destinationAddress)
-    expect(receivingAddress.txids.some((txid: string) => txid === result)).toStrictEqual(true)
+    expect(receivingAddress.txids.some((txid: string) => txid === results[0])).toStrictEqual(true)
   })
 
   it('should not refundHtlcAll when no unspent HTLC outputs found', async () => {

--- a/packages/jellyfish-api-core/src/category/spv.ts
+++ b/packages/jellyfish-api-core/src/category/spv.ts
@@ -126,16 +126,15 @@ export class Spv {
    * @param {string} destinationAddress Destination for funds in the HTLC
    * @param {SpvDefaultOptions} [options]
    * @param {BigNumber} [options.feeRate=10000] Fee rate in satoshis per KB. Minimum is 1000.
-   * @return {Promise<string>} txid
+   * @return {Promise<string[]>} array of txid
    */
-  async refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string> {
+  async refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string[]> {
     /**
      * Looking at ain, its returning an array of txid containing only 1 txid.
-     * https://github.com/DeFiCh/ain/blob/86f554f2454edc8c16684cac6f7332b437a991e0/src/spv/spv_wrapper.cpp#L1354-L1379
-     * For now, extract the txid from the array according to docs from rpc.
+     * Considering some factors, this implementation is different from the rpc docs
+     * on ain side. Refer to PR https://github.com/DeFiCh/jellyfish/pull/1324
      */
-    const result = await this.client.call<string[]>('spv_refundhtlcall', [destinationAddress, options.feeRate], 'number')
-    return result[0]
+    return await this.client.call<string[]>('spv_refundhtlcall', [destinationAddress, options.feeRate], 'number')
   }
 
   /**

--- a/packages/jellyfish-api-core/src/category/spv.ts
+++ b/packages/jellyfish-api-core/src/category/spv.ts
@@ -121,6 +121,24 @@ export class Spv {
   }
 
   /**
+   * Gets all HTLC contracts stored in wallet and creates refunds transactions for all that have expired
+   *
+   * @param {string} destinationAddress Destination for funds in the HTLC
+   * @param {SpvDefaultOptions} [options]
+   * @param {BigNumber} [options.feeRate=10000] Fee rate in satoshis per KB. Minimum is 1000.
+   * @return {Promise<string>} txid
+   */
+  async refundHtlcAll (destinationAddress: string, options: SpvDefaultOptions = { feeRate: new BigNumber('10000') }): Promise<string> {
+    /**
+     * Looking at ain, its returning an array of txid containing only 1 txid.
+     * https://github.com/DeFiCh/ain/blob/86f554f2454edc8c16684cac6f7332b437a991e0/src/spv/spv_wrapper.cpp#L1354-L1379
+     * For now, extract the txid from the array according to docs from rpc.
+     */
+    const result = await this.client.call<string[]>('spv_refundhtlcall', [destinationAddress, options.feeRate], 'number')
+    return result[0]
+  }
+
+  /**
    * List all outputs related to HTLC addresses in the wallet.
    *
    * @param {string | undefined} [scriptAddress] HTLC address to filter result


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Implements spv `spv_refundhtlcall` rpc call.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes part of #202 

#### Additional comments?:
Need some confirmation with how the `ain` implementation of this rpc is. Right now `ain`'s implementation returns an array of strings, containing only one string, shown [here](https://github.com/DeFiCh/ain/blob/86f554f2454edc8c16684cac6f7332b437a991e0/src/spv/spv_wrapper.cpp#L1354-L1379).

The [rpc documentation from `ain`](https://github.com/DeFiCh/ain/blob/86f554f2454edc8c16684cac6f7332b437a991e0/src/spv/spv_rpc.cpp#L1126) however shows that it returns a string txid, which is not the case.

This current implementation for jellyfish deals with this by simply taking the first element of the returned array.

Edit: This rpc now returns a string array, faithful to its `ain` implementation.