### PR TITLE
feat(packages/network): add getNetworkBitcoinJsLib to support bitcoinjs-lib

### DIFF
--- a/packages/jellyfish-network/__tests__/BitcoinJsLib.test.ts
+++ b/packages/jellyfish-network/__tests__/BitcoinJsLib.test.ts
@@ -1,0 +1,37 @@
+import { getNetworkBitcoinJsLib } from '@defichain/jellyfish-network'
+
+it('should match MainNet network', () => {
+  const network = getNetworkBitcoinJsLib('mainnet')
+
+  expect(network.bech32).toStrictEqual('df')
+  expect(network.bip32.public).toStrictEqual(0x0488b21e)
+  expect(network.bip32.private).toStrictEqual(0x0488ade4)
+  expect(network.wif).toStrictEqual(0x80)
+  expect(network.pubKeyHash).toStrictEqual(0x12)
+  expect(network.scriptHash).toStrictEqual(0x5a)
+  expect(network.messagePrefix).toStrictEqual('\x15Defi Signed Message:\n')
+})
+
+it('should match TestNet network', () => {
+  const network = getNetworkBitcoinJsLib('testnet')
+
+  expect(network.bech32).toStrictEqual('tf')
+  expect(network.bip32.public).toStrictEqual(0x043587cf)
+  expect(network.bip32.private).toStrictEqual(0x04358394)
+  expect(network.wif).toStrictEqual(0xef)
+  expect(network.pubKeyHash).toStrictEqual(0xf)
+  expect(network.scriptHash).toStrictEqual(0x80)
+  expect(network.messagePrefix).toStrictEqual('\x15Defi Signed Message:\n')
+})
+
+it('should match RegTest network', () => {
+  const network = getNetworkBitcoinJsLib('regtest')
+
+  expect(network.bech32).toStrictEqual('bcrt')
+  expect(network.bip32.public).toStrictEqual(0x043587cf)
+  expect(network.bip32.private).toStrictEqual(0x04358394)
+  expect(network.wif).toStrictEqual(0xef)
+  expect(network.pubKeyHash).toStrictEqual(0x6f)
+  expect(network.scriptHash).toStrictEqual(0xc4)
+  expect(network.messagePrefix).toStrictEqual('\x15Defi Signed Message:\n')
+})

--- a/packages/jellyfish-network/src/BitcoinJsLib.ts
+++ b/packages/jellyfish-network/src/BitcoinJsLib.ts
@@ -18,7 +18,7 @@ export namespace BitcoinJsLib {
 }
 
 /**
- * https://github.com/bitcoinjs/bitcoinjs-lib
+ * https://github.com/bitcoinjs/bip32/blob/ccc8fa7eedd7ff072f2f5c2d1ef89f0222391235/src/bip32.js#L18-L28
  *
  * @param network name
  * @return Network specific DeFi configuration in BitcoinJsLib.Network interface

--- a/packages/jellyfish-network/src/BitcoinJsLib.ts
+++ b/packages/jellyfish-network/src/BitcoinJsLib.ts
@@ -1,0 +1,40 @@
+import { getNetwork, NetworkName } from './Network'
+
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace BitcoinJsLib {
+  export interface Network {
+    messagePrefix: string
+    bech32: string
+    bip32: Bip32
+    pubKeyHash: number
+    scriptHash: number
+    wif: number
+  }
+
+  interface Bip32 {
+    public: number
+    private: number
+  }
+}
+
+/**
+ * https://github.com/bitcoinjs/bitcoinjs-lib
+ *
+ * @param network name
+ * @return Network specific DeFi configuration in BitcoinJsLib.Network interface
+ */
+export function getNetworkBitcoinJsLib (network: NetworkName): BitcoinJsLib.Network {
+  const jellyfish = getNetwork(network)
+
+  return {
+    messagePrefix: jellyfish.messagePrefix,
+    bech32: jellyfish.bech32.hrp,
+    bip32: {
+      public: jellyfish.bip32.publicPrefix,
+      private: jellyfish.bip32.privatePrefix
+    },
+    pubKeyHash: jellyfish.pubKeyHashPrefix,
+    scriptHash: jellyfish.scriptHashPrefix,
+    wif: jellyfish.wifPrefix
+  }
+}

--- a/packages/jellyfish-network/src/index.ts
+++ b/packages/jellyfish-network/src/index.ts
@@ -1,3 +1,4 @@
+export * from './BitcoinJsLib'
 export * from './BlockRewardDistribution'
 export * from './BlockSubsidy'
 export * from './Network'


### PR DESCRIPTION
#### What this PR does / why we need it:

Add `getNetworkBitcoinJsLib` to support `bitcoinjs-lib` Network interface easily.

> https://github.com/bitcoinjs/bitcoinjs-lib